### PR TITLE
Add lint, format, and typecheck gates to CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -156,6 +156,10 @@ jobs:
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
         if: always()  # Upload even if previous step fails
+        # Reporting only, like the scanner's own exit-code: 0. Code scanning
+        # ingestion needs Advanced Security, which this private repo lacks, and a
+        # rejected upload must not fail an otherwise healthy build.
+        continue-on-error: true
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'docker-image'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,51 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  quality:
+    name: Lint, Format, Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Check formatting (ruff format)
+        run: ruff format --check --diff .
+
+      - name: Lint (ruff check)
+        run: ruff check --output-format=github .
+
+      - name: Typecheck (mypy)
+        run: mypy
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.7'
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: Lint frontend (eslint)
+        working-directory: frontend
+        run: bun run lint
+
+      - name: Typecheck frontend (tsc)
+        working-directory: frontend
+        run: bun run typecheck
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest
@@ -50,7 +95,7 @@ jobs:
   build:
     name: Build and Test Docker Image
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, quality]
     permissions:
       contents: read
       packages: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-**Commit:** b9c2336
+**Commit:** a9fadd7
 **Branch:** main
 
 ## OVERVIEW
@@ -8,32 +8,37 @@
 `kiro-lb` is a FastAPI reverse-engineered proxy that exposes Kiro (Amazon Q
 Developer / CodeWhisperer) through OpenAI- and Anthropic-compatible APIs, load
 balances across a pool of Kiro accounts, and ships a private React operations
-dashboard. Python 3.10+, httpx, loguru, tiktoken. AGPL-3.0, partly derived from
-Kiro Gateway (`jwadow/kiro-gateway`) — keep the per-file license headers.
+dashboard. Python 3.10 (`Dockerfile`, CI), httpx, loguru, tiktoken. AGPL-3.0,
+partly derived from Kiro Gateway (`jwadow/kiro-gateway`) — keep the per-file
+license headers.
 
 ## STRUCTURE
 
 ```
 kiro-lb-python/
-├── main.py                  # App factory, lifespan, CLI, static mounts (873 lines)
-├── kiro/                    # Gateway package: 39 modules, ~17.1k lines
+├── main.py                  # App factory, lifespan, CLI, static mounts (855 lines)
+├── kiro/                    # Gateway package: 39 modules, ~16.5k lines
 │   └── static/              # BUILD OUTPUT of frontend/ — never hand-edit
 ├── frontend/                # Bun + Vite + React 19 dashboard source
 ├── tests/                   # pytest, 1694 tests; network-blocked by conftest
-├── docs/                    # ADRs, router design, translated READMEs
 ├── data/                    # Runtime credentials/state/sqlite (gitignored)
 ├── debug_logs/              # Capture output when DEBUG_MODE is on (gitignored)
-├── docker-compose.yml       # Upstream-style deployment
+├── docker-compose.yml       # Upstream-style deployment (service kiro-gateway)
 ├── docker-compose.homelab.yml  # This operator's live deployment (bound to 10.10.10.10)
 └── manual_api_test.py       # Manual live-API script, excluded from pytest
 ```
+
+No `docs/`, root `README.md`, or license/community docs exist any more: `48e728d`
+removed the root docs, `a9fadd7` removed the whole `docs/` tree (ADR 0001,
+router design, ARCHITECTURE, 8 translated READMEs). The invariants they held are
+folded into this file; do not link to them.
 
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
 |---|---|---|
 | Add/modify a client endpoint | `kiro/routes_openai.py`, `kiro/routes_anthropic.py` | Only 4 + 2 public routes exist |
-| Request -> Kiro payload | `kiro/converters_core.py` | 1397 lines; both adapters delegate here |
+| Request -> Kiro payload | `kiro/converters_core.py` | 1379 lines; both adapters delegate here |
 | Kiro -> client stream | `kiro/streaming_openai.py`, `kiro/streaming_anthropic.py` | Shared event model in `kiro/streaming_core.py` |
 | AWS event-stream framing | `kiro/parsers.py` | Frame reassembly + bracket tool-call recovery |
 | Stream order invariants | `kiro/sse_validation.py` | Raises mid-stream instead of shipping bad order |
@@ -43,41 +48,49 @@ kiro-lb-python/
 | Dashboard API / SQLite store | `kiro/dashboard.py` | 17 routes under `/api/dashboard`, plus `/` |
 | Per-key token accounting | `kiro/usage_tracking.py` | ContextVar identity, batched flush |
 | Model name handling | `kiro/model_resolver.py` | Never raises; unknown names pass through |
-| Failure capture/replay | `kiro/debug_capture.py`, `kiro/debug_replay.py` | Redacted by default |
-| Payload size repair | `kiro/payload_guards.py` | Kiro rejects ~615KB+ (`payload_guards.py:23`) |
+| Request/response schemas | `kiro/models_openai.py`, `kiro/models_anthropic.py` | Extra-open models preserve unknown fields |
+| Extended thinking budgets | `kiro/native_thinking.py` | Budget must be >= 1024; unknown fields rejected upstream |
+| Failure capture/replay | `kiro/debug_capture.py`, `kiro/debug_replay.py`, `kiro/debug_sanitize.py` | Redacted by default |
+| Payload size repair | `kiro/payload_guards.py` | Kiro rejects ~615KB+ (`payload_guards.py:5`) |
 
 ## CODE MAP
 
 | Symbol | Type | Location | Role |
 |---|---|---|---|
-| `build_kiro_payload` | function | `kiro/converters_core.py:1224` | Single funnel for every upstream request |
-| `parse_kiro_stream` | async gen | `kiro/streaming_core.py:130` | Only place raw frames become `KiroEvent` |
-| `KiroEvent` | dataclass | `kiro/streaming_core.py:66` | Protocol-neutral event both adapters consume |
-| `AccountManager` | class | `kiro/account_manager.py:276` | Pool state, failover, rate series, persistence |
-| `AccountManager.get_next_account` | method | `kiro/account_manager.py:749` | Rotation; excludes quota-exhausted accounts outright |
-| `AccountManager.report_failure` | method | `kiro/account_manager.py:936` | Classifies 429 / 402 / INVALID_MODEL_ID separately |
-| `KiroAuthManager` | class | `kiro/auth.py:85` | Token lifecycle, region + host resolution |
-| `ModelResolver` | class | `kiro/model_resolver.py:259` | normalize -> cache -> hidden -> passthrough |
+| `build_kiro_payload` | function | `kiro/converters_core.py:1206` | Single funnel for every upstream request |
+| `parse_kiro_stream` | async gen | `kiro/streaming_core.py:112` | Only place raw frames become `KiroEvent` |
+| `KiroEvent` | dataclass | `kiro/streaming_core.py:48` | Protocol-neutral event both adapters consume |
+| `AccountManager` | class | `kiro/account_manager.py:258` | Pool state, failover, rate series, persistence |
+| `AccountManager.get_next_account` | method | `kiro/account_manager.py:731` | Rotation from the global index; skips quota-exhausted accounts |
+| `AccountManager.report_failure` | method | `kiro/account_manager.py:918` | Classifies 429 / 402 / INVALID_MODEL_ID separately |
+| `KiroAuthManager` | class | `kiro/auth.py:67` | Token lifecycle, region + host resolution |
+| `ModelResolver` | class | `kiro/model_resolver.py:241` | normalize -> cache -> hidden -> passthrough |
 | `validate_live_openai_payload` | function | `kiro/sse_validation.py:204` | Fails the stream instead of shipping bad order |
-| `identify_data_api_key` | function | `kiro/dashboard.py:309` | Legacy env key -> `ROOT_KEY_ID`, else hashed `klb_` key |
-| `record_token_usage` | function | `kiro/usage_tracking.py:48` | Attributes tokens to the calling key |
-| `start_device_login` | function | `kiro/device_login.py:317` | Social vs Builder ID flows, deliberately unshared |
+| `identify_data_api_key` | function | `kiro/dashboard.py:288` | Legacy env key -> `ROOT_KEY_ID`, else hashed `klb_` key |
+| `record_token_usage` | function | `kiro/usage_tracking.py:30` | Attributes tokens to the calling key |
+| `start_device_login` | function | `kiro/device_login.py:299` | Social vs Builder ID flows, deliberately unshared |
+| `get_kiro_api_host` / `get_kiro_q_host` | function | `kiro/config.py:578`, `:584` | Builder ID flag picks the host template |
+
+Line numbers drift on every edit to these files. Grep the symbol name before
+trusting a pin here.
 
 ## CONVENTIONS
 
 - Reasoning is forwarded only from native upstream frames. Never synthesize it
-  from response text or prompt tags (`docs/adr/0001-real-upstream-reasoning-only.md`).
-- OpenAI reasoning is emitted as `reasoning` (`streaming_openai.py:205`), not the
+  from response text or prompt tags.
+- OpenAI reasoning is emitted as `reasoning` (`streaming_openai.py:187`), not the
   legacy `reasoning_content`; requests accept both on input.
 - Streaming uses a per-request `httpx.AsyncClient`; non-streaming uses the shared
   pooled client from `lifespan`. Reusing the shared client for streams leaks CLOSE_WAIT.
 - Any new client-visible behavior must land on OpenAI **and** Anthropic, in both
   streaming and non-streaming paths.
 - Control and data planes stay separate: dashboard cookie sessions cannot call
-  `/v1`, and `/v1` API keys cannot call `/api/dashboard` (`docs/router-design.md`).
+  `/v1`, and `/v1` API keys cannot call `/api/dashboard`.
 - Dashboard SQLite stores metadata only — no prompts, completions, raw keys, or
-  refresh tokens. New columns arrive via additive `ALTER TABLE` migration
-  (`dashboard.py:150`), never a destructive rewrite.
+  refresh tokens. New columns arrive via additive `PRAGMA table_info` +
+  `ALTER TABLE` migration (`dashboard.py:148`), never a destructive rewrite.
+- Proxy env vars are set before any httpx client exists (`main.py:180`); creating
+  a client earlier silently ignores the VPN/proxy config.
 - `pytest.ini`, `kiro/__init__.py`, and some legacy comments are Russian; new
   code, comments, and docstrings are English only.
 
@@ -86,20 +99,31 @@ kiro-lb-python/
 - Editing `kiro/static/**` by hand — it is `frontend/` build output
   (`frontend/vite.config.ts` sets `outDir: "../kiro/static"`).
 - Putting images into `userInputMessageContext`; they belong directly in
-  `userInputMessage.images` (`kiro/converters_core.py:1177`).
+  `userInputMessage.images` (`kiro/converters_core.py:463` states the rule, the
+  assembly is at `:1343`).
+- Emitting `toolResults` without the preceding assistant `toolUses` message.
+  Cline/Roo/Cursor send histories that need repair (`converters_core.py:814`).
+- Normalizing roles after `ensure_alternating_roles()`; the order is fixed
+  (`converters_core.py:1024`).
 - Client-specific stream mutilation in the gateway. The removed
   `OPENAI_SINGLE_BLOCK_TOOL_COMPAT` mode dropped reasoning, pre-tool text, and
   parallel tool calls; the real defect is in the client adapter.
 - Applying the Claude token-correction coefficient to `prompt_tokens`
-  (`kiro/streaming_openai.py:352`).
-- Rejecting unknown model names. Kiro is the arbiter, not this gateway.
+  (`kiro/streaming_openai.py:334`).
+- Rejecting unknown model names. Kiro is the arbiter, not this gateway. The
+  resolver also never suggests a model from another family
+  (`model_resolver.py:411`).
 - Building the upstream host from region alone. A Builder ID account (SSO OIDC
   with no profile ARN) must go to `q.{region}.amazonaws.com`; everything else
-  stays on `runtime.kiro.dev` (`kiro/config.py:596`). Absence of a profile alone
-  is not the test.
+  stays on the Kiro host (`kiro/config.py:578`). Absence of a profile alone is
+  not the test, and Builder ID accounts must never receive the global fallback
+  profile ARN (`routes_openai.py:268`, `routes_anthropic.py:273`).
+- Moving `_current_account_index` on failure. It advances only on success —
+  that is the global sticky behavior (`account_manager.py:1009`).
 - Letting a burst escalate into a long exclusion. `USER_REQUEST_RATE_EXCEEDED`
-  parks an account for `ACCOUNT_RATE_LIMIT_COOLDOWN` (10s) and leaves the circuit
-  breaker untouched; only `MONTHLY_REQUEST_COUNT` quarantines it (6h).
+  parks an account for `ACCOUNT_RATE_LIMIT_COOLDOWN` (10s, `config.py:507`) and
+  leaves the circuit breaker untouched; only `MONTHLY_REQUEST_COUNT`
+  quarantines it (6h).
 - Assuming cache metadata exists. Kiro emits only `contextUsagePercentage` and a
   credit `meteringEvent`, so `cache_read_input_tokens` stays absent.
 
@@ -108,27 +132,30 @@ kiro-lb-python/
 ```bash
 python main.py --host 127.0.0.1 --port 8000    # run gateway
 pytest -q                                      # full suite (1694 tests, <10s, no network)
-pytest tests/unit/test_streaming_openai.py -v   # focused protocol suite
-pytest --cov=kiro --cov-report=term             # what CI measures (.github/workflows/docker.yml)
-cd frontend && bun run build                    # rebuild dashboard into kiro/static
+pytest -v --tb=short                            # exactly what CI runs
+pytest --cov=kiro --cov-report=term             # CI coverage gate (.github/workflows/docker.yml)
+cd frontend && bun run build                    # tsc -b + vite build into kiro/static
 docker compose -f docker-compose.homelab.yml up -d --build
 ```
+
+CI (`.github/workflows/docker.yml`) runs the `test` job on Python 3.10 and gates
+`build` on it; the build job also Trivy-scans and pushes multi-arch images on
+non-PR runs only.
 
 ## NOTES
 
 - `main.py` refuses to start when `credentials.json` has no usable account, even
   with `ACCOUNT_SYSTEM=false`; set `KIRO_CLI_DB_FILE` for a standalone run.
-  `validate_configuration` (`main.py:223`) skips legacy `.env` checks entirely
-  once `credentials.json` exists.
+  `validate_configuration` (`main.py:205`) skips legacy `.env` checks entirely
+  once `credentials.json` exists. Legacy mode always recreates
+  `credentials.json` from `.env` (`main.py:417`).
 - The OpenAI `developer` role must be folded into the system prompt
-  (`converters_openai.py:161`); dropping it makes Kiro answer `REQUEST_BODY_INVALID`.
+  (`converters_openai.py:143`); dropping it makes Kiro answer `REQUEST_BODY_INVALID`.
 - "Improperly formed request" is Kiro's catch-all validation error. Treat it as
   a signal to diff the emitted payload, not as a specific cause.
+- Truncated upstream turns must not be reported as clean finishes
+  (`kiro/stop_reasons.py`).
 - The homelab compose mounts the host `kiro-cli` store read-only at
   `/host/kiro-cli` with `SQLITE_READONLY=true`. The gateway must never write it.
-- 39 Python files exceed 500 lines (14 outside `tests/`);
-  `kiro/converters_core.py` and `kiro/streaming_anthropic.py` are the
-  highest-risk edit sites.
-- Root `AGENTS.md`, `README.md`, and the license files are currently deleted in
-  the working tree but present at HEAD. Check `git status` before assuming a
-  root doc is missing.
+- 14 files outside `tests/` exceed 500 lines; `kiro/converters_core.py` (1379)
+  and `kiro/streaming_anthropic.py` (1007) are the highest-risk edit sites.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,17 +1,20 @@
 # frontend/ — operations dashboard
 
-Bun + Vite + React 19 + Tailwind 4 SPA, ~2.3k lines across 29 source files.
+Bun + Vite 7 + React 19 + Tailwind 4 SPA, ~2.6k lines across 31 source files.
 Built output is committed into `../kiro/static` and served by FastAPI; there is
-no separate dashboard server.
+no separate dashboard server. `README.md` in this directory still says
+`../app/static` and lists a `/backend-api` proxy — both are wrong; trust
+`vite.config.ts`.
 
 ## WHERE TO LOOK
 
 | Task | Location |
 |---|---|
-| Page composition | `src/features/dashboard/components/` (11 panels/cards) |
+| Page composition | `src/features/dashboard/components/` (10 panels/cards) |
 | Data fetching + polling | `src/features/dashboard/use-dashboard.ts`, `api.ts` |
+| Auth state | `use-dashboard.ts`; `AUTH_REQUIRED` from `api.ts` means show `LoginCard` |
 | Response shapes | `src/features/dashboard/types.ts` (mirror of `dashboard.py` JSON) |
-| Shared primitives | `src/components/ui/` (radix-based) |
+| Shared primitives | `src/components/ui/` (radix-based, 10 files) |
 | Build/output wiring | `vite.config.ts` (`outDir: "../kiro/static"`) |
 | Backend API contract | `../kiro/dashboard.py` (`/api/dashboard/*`) |
 
@@ -21,12 +24,21 @@ no separate dashboard server.
   introduce npm or pnpm lockfiles.
 - `bun run build` runs `tsc -b` first; type errors block the build by design.
 - Fonts are vendored under `public/fonts` and mounted by the backend at `/fonts`
-  (`../main.py:653`).
+  (`../main.py:635`).
 - `vite dev` proxies `/api`, `/v1`, and `/health` to `API_PROXY_TARGET`
   (default `http://localhost:8000`); the gateway must be running for dev mode.
+- No auth token lives in the client. Session is a server-side cookie; every call
+  is a same-origin `fetch`, and any non-2xx becomes `DashboardApiError`.
+- All dashboard state lives in the single `useDashboard()` hook. Live polling runs
+  once a second only while authenticated and live; request-log pages are guarded
+  by a request-id so a slow page cannot overwrite a newer one.
+- Device-login registration is single-shot, guarded by a ref against overlapping
+  polls.
 
 ## ANTI-PATTERNS
 
 - Editing `../kiro/static/**` directly instead of rebuilding here.
 - Adding a dev-only proxy assumption; the SPA is served same-origin in production.
 - Committing a build without running `bun run typecheck`.
+- Ad hoc tab buttons; extend the `Tabs` primitive and `useTabHash()` instead
+  (an unknown hash falls back to `overview`).

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,67 +5,35 @@
     "": {
       "name": "frontend",
       "dependencies": {
-        "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.1.18",
-        "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "date-fns": "^4.1.0",
         "geist": "^1.7.0",
-        "input-otp": "^1.4.2",
         "lucide-react": "^0.563.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
-        "react-day-picker": "^9.13.2",
         "react-dom": "^19.2.4",
-        "react-hook-form": "^7.71.1",
-        "react-router-dom": "^7.13.0",
-        "recharts": "^3.7.0",
-        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.11",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "^1.52.0",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/react": "^16.3.2",
-        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.2.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.2.3",
-        "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.0",
         "globals": "^17.3.0",
-        "jsdom": "^28.0.0",
-        "msw": "^2.12.10",
-        "shadcn": "^3.8.4",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.55.0",
         "vite": "^7.3.1",
-        "vitest": "^4.0.18",
       },
     },
   },
   "packages": {
-    "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
-
-    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
-
-    "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "nci": "bin/nci.mjs", "ni": "bin/ni.mjs", "nlx": "bin/nlx.mjs", "nr": "bin/nr.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
-
-    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@4.1.2", "", { "dependencies": { "@csstools/css-calc": "^3.0.0", "@csstools/css-color-parser": "^4.0.1", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.5" } }, "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg=="],
-
-    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.7.8", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.5" } }, "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ=="],
-
-    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
-
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -74,27 +42,13 @@
 
     "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
 
-    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
-
     "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
 
-    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/helper-replace-supers": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/traverse": "^7.28.6", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow=="],
-
     "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
-
-    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.28.5", "", { "dependencies": { "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5" } }, "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg=="],
 
     "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
 
     "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
-
-    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.27.1", "", { "dependencies": { "@babel/types": "^7.27.1" } }, "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw=="],
-
-    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
-
-    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.28.6", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg=="],
-
-    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -106,43 +60,11 @@
 
     "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
-    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
-
-    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
-
-    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.28.6", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA=="],
-
-    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw=="],
-
-    "@babel/preset-typescript": ["@babel/preset-typescript@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g=="],
-
-    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
-
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
-
-    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.1", "", {}, "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ=="],
-
-    "@csstools/css-calc": ["@csstools/css-calc@3.0.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bsDKIP6f4ta2DO9t+rAbSSwv4EMESXy5ZIvzQl1afmD6Z1XHkVu9ijcG9QR/qSgQS1dVa+RaQ/MfQ7FIB/Dn1Q=="],
-
-    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.0.1", "", { "dependencies": { "@csstools/color-helpers": "^6.0.1", "@csstools/css-calc": "^3.0.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw=="],
-
-    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
-
-    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.0.27", "", {}, "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow=="],
-
-    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
-
-    "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
-
-    "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
-
-    "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
@@ -214,8 +136,6 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.0", "", { "dependencies": { "@eslint/core": "^1.1.0", "levn": "^0.4.1" } }, "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ=="],
 
-    "@exodus/bytes": ["@exodus/bytes@1.14.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" } }, "sha512-YiY1OmY6Qhkvmly8vZiD8wZRpW/npGZNg+0Sk8mstxirRHCg6lolHt5tSODCfuNPE/fBsAqRwDJE417x7jDDHA=="],
-
     "@floating-ui/core": ["@floating-ui/core@1.7.4", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
@@ -223,10 +143,6 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.7", "", { "dependencies": { "@floating-ui/dom": "^1.7.5" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
-
-    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
-
-    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -286,16 +202,6 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
-
-    "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
-
-    "@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
-
-    "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
-
-    "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" } }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
-
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
@@ -309,10 +215,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
-
-    "@mswjs/interceptors": ["@mswjs/interceptors@0.41.2", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw=="],
 
     "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
 
@@ -331,24 +233,6 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A=="],
-
-    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
-    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
-    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
-
-    "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
-
-    "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
@@ -472,8 +356,6 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
-    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
-
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.2", "", {}, "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
@@ -525,14 +407,6 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
-
-    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
-
-    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@swc/core": ["@swc/core@1.15.11", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.11", "@swc/core-darwin-x64": "1.15.11", "@swc/core-linux-arm-gnueabihf": "1.15.11", "@swc/core-linux-arm64-gnu": "1.15.11", "@swc/core-linux-arm64-musl": "1.15.11", "@swc/core-linux-x64-gnu": "1.15.11", "@swc/core-linux-x64-musl": "1.15.11", "@swc/core-win32-arm64-msvc": "1.15.11", "@swc/core-win32-ia32-msvc": "1.15.11", "@swc/core-win32-x64-msvc": "1.15.11" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w=="],
 
@@ -592,44 +466,6 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
-
-    "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
-
-    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
-
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
-
-    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
-
-    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
-
-    "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
-
-    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
-
-    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
-
-    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
-
-    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
-
-    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
-
-    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
-
-    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
-
-    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
-
-    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
-
-    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
-
-    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
-
-    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
-
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -641,12 +477,6 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
-
-    "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
-
-    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
-
-    "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.55.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.55.0", "@typescript-eslint/type-utils": "8.55.0", "@typescript-eslint/utils": "8.55.0", "@typescript-eslint/visitor-keys": "8.55.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.55.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ=="],
 
@@ -670,227 +500,51 @@
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.2.3", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.2", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7" } }, "sha512-QIluDil2prhY1gdA3GGwxZzTAmLdi8cQ2CcuMW4PB/Wu4e/1pzqrwhYWVd09LInCRlDUidQjd0B70QWbjWtLxA=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.0.18", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.0.18", "ast-v8-to-istanbul": "^0.3.10", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.1", "obug": "^2.1.1", "std-env": "^3.10.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "@vitest/browser": "4.0.18", "vitest": "4.0.18" }, "optionalPeers": ["@vitest/browser"] }, "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg=="],
-
-    "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
-
-    "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" } }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
-
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.0.18", "", { "dependencies": { "tinyrainbow": "^3.0.3" } }, "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw=="],
-
-    "@vitest/runner": ["@vitest/runner@4.0.18", "", { "dependencies": { "@vitest/utils": "4.0.18", "pathe": "^2.0.3" } }, "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw=="],
-
-    "@vitest/snapshot": ["@vitest/snapshot@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA=="],
-
-    "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
-
-    "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
-
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" }, "peerDependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
-
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
-
-    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
-
-    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
-
-    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
-
-    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
-
-    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.11", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": "dist/cli.js" }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
-    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
-
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": "cli.js" }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
-
-    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
     "caniuse-lite": ["caniuse-lite@1.0.30001769", "", {}, "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg=="],
-
-    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
-    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
-    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
-
-    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
-
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
-
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
-
-    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
-
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
-
-    "cosmiconfig": ["cosmiconfig@9.0.0", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "css-tree": ["css-tree@3.1.0", "", { "dependencies": { "mdn-data": "2.12.2", "source-map-js": "^1.0.1" } }, "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w=="],
-
-    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
-
-    "cssesc": ["cssesc@3.0.0", "", { "bin": "bin/cssesc" }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
-
-    "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
-
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
-
-    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
-
-    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
-
-    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
-
-    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
-
-    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
-
-    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
-
-    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
-
-    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
-
-    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
-
-    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
-
-    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
-
-    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
-
-    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
-
-    "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
-
-    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
-
-    "dedent": ["dedent@1.7.1", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg=="],
-
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
-
-    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
-
-    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
-
-    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
-
-    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
-
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
-    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
-
-    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
-
-    "dotenv": ["dotenv@17.2.4", "", {}, "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw=="],
-
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "eciesjs": ["eciesjs@0.4.17", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w=="],
-
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
     "electron-to-chromium": ["electron-to-chromium@1.5.286", "", {}, "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
-
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
-
-    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
-
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
-
-    "es-toolkit": ["es-toolkit@1.44.0", "", {}, "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -906,57 +560,23 @@
 
     "espree": ["espree@11.1.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw=="],
 
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
-
-    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
-
-    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
-
-    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
-
-    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
-
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
-
-    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
-
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
-
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -964,171 +584,49 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
-    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
-
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
-
-    "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
-
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
-
-    "fzf": ["fzf@0.5.2", "", {}, "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="],
 
     "geist": ["geist@1.7.0", "", { "peerDependencies": { "next": ">=13.2.0" } }, "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
-    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
-
-    "get-own-enumerable-keys": ["get-own-enumerable-keys@1.0.0", "", {}, "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@17.3.0", "", {}, "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw=="],
 
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
-    "graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
-
-    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
-
-    "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
-    "hono": ["hono@4.11.9", "", {}, "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ=="],
-
-    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
-
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
-
-    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
-
-    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
-
-    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
-
-    "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
-    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
-
-    "is-docker": ["is-docker@3.0.0", "", { "bin": "cli.js" }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
-    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
-
-    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": "cli.js" }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
-
-    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
-
-    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
-
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "is-obj": ["is-obj@3.0.0", "", {}, "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ=="],
-
-    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
-
-    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
-
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
-    "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
-
-    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
-
-    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
-
-    "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
-
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
-
-    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
-
-    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": "lib/jiti-cli.mjs" }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
-
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
-
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
-
-    "jsdom": ["jsdom@28.0.0", "", { "dependencies": { "@acemir/cssom": "^0.9.31", "@asamuzakjp/dom-selector": "^6.7.6", "@exodus/bytes": "^1.11.0", "cssstyle": "^5.3.7", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "undici": "^7.20.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA=="],
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
-    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
-
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
-
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -1156,127 +654,39 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
-    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
-
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
-
-    "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
-    "lz-string": ["lz-string@1.5.0", "", { "bin": "bin/bin.js" }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
-    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
-
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
-
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
-
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
-
-    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
-
-    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
-
-    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
-
-    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
 
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "msw": ["msw@2.12.10", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.10.1", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "bin": "cli/index.js" }, "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw=="],
-
-    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
-
-    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
-
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
-
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
-
-    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
-
-    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
-
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
-
-    "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
-
-    "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
-    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
-
-    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
-
-    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
-
-    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
-
-    "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
-    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
-
-    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
-
-    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
@@ -1284,103 +694,27 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
-    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
-
-    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
-
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
-
-    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
-
-    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
-
-    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
-
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qs": ["qs@6.14.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
-
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
-    "react-day-picker": ["react-day-picker@9.13.2", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "date-fns": "^4.1.0", "date-fns-jalali": "^4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-IMPiXfXVIAuR5Yk58DDPBC8QKClrhdXV+Tr/alBrwrHUw0qDDYB1m5zPNuTnnPIr/gmJ4ChMxmtqPdxm8+R4Eg=="],
-
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
-
-    "react-hook-form": ["react-hook-form@7.71.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w=="],
-
-    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
-
-    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
-
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
-
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
-
-    "recharts": ["recharts@3.7.0", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew=="],
-
-    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
-
-    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
-
-    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
-
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
-
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
-
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
-    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
-
-    "rettime": ["rettime@0.10.1", "", {}, "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw=="],
-
-    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
-
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
-    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
-
-    "shadcn": ["shadcn@3.8.4", "", { "dependencies": { "@antfu/ni": "^25.0.0", "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": "dist/index.js" }, "sha512-pSad/m1+PGzB0aLsRBV0EkyGg9al1nJqYUuucg6d8v8xZspPZ5/ehGNEp5M4b1KQYqdO5/gGPbkhVbgmXqG9Pw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1388,55 +722,9 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
-
-    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
-
-    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
-
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
-
-    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
-
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
-
-    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
-
-    "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
-
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "stringify-object": ["stringify-object@5.0.0", "", { "dependencies": { "get-own-enumerable-keys": "^1.0.0", "is-obj": "^3.0.0", "is-regexp": "^3.1.0" } }, "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg=="],
-
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
-
-    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
-
-    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
-
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
-
-    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
-
-    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
@@ -1444,33 +732,9 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
-    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
-
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
-
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
-
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "tinyrainbow": ["tinyrainbow@3.0.3", "", {}, "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q=="],
-
-    "tldts": ["tldts@7.0.23", "", { "dependencies": { "tldts-core": "^7.0.23" }, "bin": "bin/cli.js" }, "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw=="],
-
-    "tldts-core": ["tldts-core@7.0.23", "", {}, "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ=="],
-
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
-    "tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
-
-    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
-
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
-
-    "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
-
-    "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1478,25 +742,11 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
-
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
-
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.55.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.55.0", "@typescript-eslint/parser": "8.55.0", "@typescript-eslint/typescript-estree": "8.55.0", "@typescript-eslint/utils": "8.55.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HE4wj+r5lmDVS9gdaN0/+iqNvPZwGfnJ5lZuz7s5vLlg9ODw0bIiiETaios9LvFI1U94/VBXGm3CB2Y5cNFMpw=="],
 
-    "undici": ["undici@7.21.0", "", {}, "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg=="],
-
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
-
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
-
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "until-async": ["until-async@3.0.2", "", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -1508,83 +758,21 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
-
-    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
-
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
-
-    "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom"], "bin": "vitest.mjs" }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
-
-    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
-
-    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
-
-    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
-
-    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
-
-    "whatwg-url": ["whatwg-url@16.0.0", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
-
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
-
-    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
-
-    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
-
-    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
-
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
-
-    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
-    "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["immer"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
-
-    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
-    "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
-
-    "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
-
-    "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
-
-    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1594,68 +782,10 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
-    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
-
-    "make-dir/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
-    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
-
-    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
-
-    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
-    "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
-
-    "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "sharp/semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
-
-    "@dotenvx/dotenvx/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "@dotenvx/dotenvx/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
-    "@dotenvx/dotenvx/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
-
-    "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
-
-    "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
-
-    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
   }
 }

--- a/kiro/AGENTS.md
+++ b/kiro/AGENTS.md
@@ -1,7 +1,7 @@
 # kiro/ — gateway package
 
 Protocol translation between client APIs and the Kiro upstream, plus the
-operations control plane. 39 modules, ~17.1k lines. Layered:
+operations control plane. 39 modules, ~16.5k lines. Layered:
 routes -> converters -> http_client -> streaming.
 
 ## STRUCTURE
@@ -14,13 +14,17 @@ kiro/
 ├── usage_tracking.py / usage.py                            # per-key tokens; upstream quota lookup
 ├── converters_core.py                                      # shared payload builder
 ├── converters_openai.py / converters_anthropic.py          # thin adapters
+├── models_openai.py / models_anthropic.py                  # pydantic request/response schemas
+├── native_thinking.py                                      # extended-thinking budget validation
+├── mcp_tools.py                                            # web_search bridge + SSE emulation
 ├── streaming_core.py                                       # KiroEvent + parse_kiro_stream
 ├── streaming_openai.py / streaming_anthropic.py            # per-protocol serializers
 ├── parsers.py                                              # AWS event-stream frames
 ├── sse_validation.py                                       # live order invariants
 ├── auth.py / account_manager.py / account_errors.py        # credentials + pool
 ├── http_client.py / network_errors.py / kiro_errors.py     # transport + error mapping
-├── debug_logger.py / debug_capture.py / debug_replay.py    # failure forensics
+├── debug_logger.py / debug_middleware.py                   # request logging
+├── debug_capture.py / debug_replay.py / debug_sanitize.py  # failure forensics + redaction
 ├── payload_guards.py                                       # oversize payload repair
 └── static/                                                 # frontend build output
 ```
@@ -35,7 +39,9 @@ kiro/
 | Adjust finish/stop mapping | `stop_reasons.py` |
 | Token accounting | `tokenizer.py`, `streaming_core.py:calculate_tokens_from_context_usage` |
 | Per-key/model usage rows | `usage_tracking.py` -> `dashboard.py:flush_key_model_usage` |
-| Web search emulation | `mcp_tools.py` |
+| Web search emulation | `mcp_tools.py` (transport shim, not a tool framework) |
+| Extended thinking budget rules | `native_thinking.py` (min 1024; unknown fields rejected) |
+| Request/response schema change | `models_openai.py` / `models_anthropic.py` |
 | Rate estimate + chart data | `account_manager.py:estimate_rate_limit`, `:request_rate_series` |
 | New login provider | `device_login.py`, then `dashboard.py` device-login routes |
 
@@ -45,14 +51,17 @@ kiro/
   belongs in `streaming_*.py`, never in `parsers.py`.
 - `ModelResolver` never raises; it degrades to pass-through.
 - `AccountManager` returns 429 to the caller immediately so failover happens
-  before backoff (`docs/router-design.md`).
+  before backoff.
+- Account selection always starts from the global index
+  (`account_manager.py:791`) and that index moves only on success
+  (`account_manager.py:1009`).
 - Every emitted chunk goes through `sse_validation`; a protocol violation fails
   the stream loudly rather than reaching the client.
 - Debug capture redacts content unless `DEBUG_CAPTURE_CONTENT=true`; credential
   patterns stay redacted regardless.
 - Accounting and dashboard store writes never break the data plane: they catch
-  their own exceptions and return a neutral value (`usage_tracking.py:57`,
-  `dashboard.py:233`).
+  their own exceptions and return a neutral value (`usage_tracking.py:41`,
+  `dashboard.py:261`).
 - The calling key's identity travels in a `ContextVar`, not through converter and
   serializer signatures (`usage_tracking.py`).
 - Social and Builder ID login polling are deliberately not shared; their pending
@@ -68,5 +77,9 @@ kiro/
   further without splitting; all three already exceed 1000 lines.
 - Editing `static/` — regenerate from `frontend/`.
 - Recreating a dashboard SQLite table to add a column. Follow the additive
-  `PRAGMA table_info` + `ALTER TABLE` pattern in `dashboard.py:150`.
+  `PRAGMA table_info` + `ALTER TABLE` pattern in `dashboard.py:148`.
+- Exposing the device code or token in a device-flow response; `DeviceFlow.view`
+  is the only client-facing shape (`device_login.py:83`).
+- Giving a Builder ID account the global fallback profile ARN
+  (`routes_openai.py:268`, `routes_anthropic.py:273`).
 - Storing anything sensitive in the dashboard store; it holds metadata only.

--- a/kiro/__init__.py
+++ b/kiro/__init__.py
@@ -28,31 +28,36 @@ __author__ = "Jwadow"
 # Main components for convenient import
 from kiro.auth import KiroAuthManager
 from kiro.cache import ModelInfoCache
-from kiro.http_client import KiroHttpClient
-from kiro.routes_openai import router
-from kiro.model_resolver import ModelResolver, normalize_model_name, get_model_id_for_kiro
 
 # Configuration
 from kiro.config import (
+    APP_VERSION,
+    HIDDEN_MODELS,
     PROXY_API_KEY,
     REGION,
-    HIDDEN_MODELS,
-    APP_VERSION,
 )
+from kiro.converters_core import (
+    extract_text_content,
+    merge_adjacent_messages,
+)
+
+# Converters
+from kiro.converters_openai import build_kiro_payload
+
+# Exceptions
+from kiro.exceptions import (
+    sanitize_validation_errors,
+    validation_exception_handler,
+)
+from kiro.http_client import KiroHttpClient
+from kiro.model_resolver import ModelResolver, get_model_id_for_kiro, normalize_model_name
 
 # Models
 from kiro.models_openai import (
     ChatCompletionRequest,
     ChatMessage,
-    OpenAIModel,
     ModelList,
-)
-
-# Converters
-from kiro.converters_openai import build_kiro_payload
-from kiro.converters_core import (
-    extract_text_content,
-    merge_adjacent_messages,
+    OpenAIModel,
 )
 
 # Parsers
@@ -60,59 +65,46 @@ from kiro.parsers import (
     AwsEventStreamParser,
     parse_bracket_tool_calls,
 )
+from kiro.routes_openai import router
 
 # Streaming
 from kiro.streaming_openai import (
-    stream_kiro_to_openai,
     collect_stream_response,
-)
-
-# Exceptions
-from kiro.exceptions import (
-    validation_exception_handler,
-    sanitize_validation_errors,
+    stream_kiro_to_openai,
 )
 
 __all__ = [
     # Version
     "__version__",
-    
     # Main classes
     "KiroAuthManager",
     "ModelInfoCache",
     "KiroHttpClient",
     "ModelResolver",
     "router",
-    
     # Configuration
     "PROXY_API_KEY",
     "REGION",
     "HIDDEN_MODELS",
     "APP_VERSION",
-    
     # Model resolution
     "normalize_model_name",
     "get_model_id_for_kiro",
-    
     # Models
     "ChatCompletionRequest",
     "ChatMessage",
     "OpenAIModel",
     "ModelList",
-    
     # Converters
     "build_kiro_payload",
     "extract_text_content",
     "merge_adjacent_messages",
-    
     # Parsers
     "AwsEventStreamParser",
     "parse_bracket_tool_calls",
-    
     # Streaming
     "stream_kiro_to_openai",
     "collect_stream_response",
-    
     # Exceptions
     "validation_exception_handler",
     "sanitize_validation_errors",

--- a/kiro/account_errors.py
+++ b/kiro/account_errors.py
@@ -17,13 +17,14 @@ from typing import Optional
 class ErrorType(Enum):
     """
     Type of error for failover decision.
-    
+
     FATAL: Error in the request itself (bad payload, context overflow, etc.)
            Should be returned to client immediately without trying other accounts.
-    
+
     RECOVERABLE: Error with the account (expired token, rate limit, quota exceeded)
                 Should try next available account.
     """
+
     FATAL = "fatal"
     RECOVERABLE = "recoverable"
 
@@ -31,30 +32,30 @@ class ErrorType(Enum):
 def classify_error(status_code: int, reason: Optional[str]) -> ErrorType:
     """
     Classify Kiro API error for failover decision.
-    
+
     Determines whether an error is account-specific (RECOVERABLE) or
     request-specific (FATAL) based on HTTP status code and error reason.
-    
+
     RECOVERABLE errors (try next account):
     - 400 + INVALID_MODEL_ID: Could be invalid model or insufficient subscription
     - 402: Payment required (monthly quota exceeded, billing issues)
     - 403: Token expired/invalid
     - 429: Rate limit exceeded
-    
+
     FATAL errors (return to client immediately):
     - 400 + CONTENT_LENGTH_EXCEEDS_THRESHOLD: Context overflow
     - 400 + other/null reason: Malformed request
     - 422: Validation error
     - 5xx: Kiro API server error
-    
+
     Args:
         status_code: HTTP status code from Kiro API
         reason: Error reason from Kiro API response (may be None)
-    
+
     Returns:
         ErrorType.RECOVERABLE if should try next account
         ErrorType.FATAL if should return error to client
-    
+
     Examples:
         >>> classify_error(400, "INVALID_MODEL_ID")
         ErrorType.RECOVERABLE
@@ -77,40 +78,39 @@ def classify_error(status_code: int, reason: Optional[str]) -> ErrorType:
     # Kiro API returns 402 for MONTHLY_REQUEST_COUNT
     if status_code == 402:
         return ErrorType.RECOVERABLE
-    
+
     # RECOVERABLE: Token expired/invalid
     if status_code == 403:
         return ErrorType.RECOVERABLE
-    
+
     # RECOVERABLE: Rate limit exceeded
     if status_code == 429:
         return ErrorType.RECOVERABLE
-    
+
     # 400 errors - depends on reason
     if status_code == 400:
-        
         # RECOVERABLE: Model not available on this account (subscription level)
         # Different accounts may have different model access based on their subscription
         if reason == "INVALID_MODEL_ID":
             return ErrorType.RECOVERABLE
-        
+
         # FATAL: Context overflow - will fail on all accounts
         if reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD":
             return ErrorType.FATAL
-        
+
         # FATAL: Generic bad request (malformed payload, validation error)
         # This includes "Improperly formed request" with null/missing reason
         return ErrorType.FATAL
-    
+
     # FATAL: Validation error (malformed request)
     if status_code == 422:
         return ErrorType.FATAL
-    
+
     # FATAL: Server errors (5xx)
     # Note: 503 could be temporary, but we classify as FATAL for simplicity
     # Retrying on different accounts won't help if Kiro API is down
     if 500 <= status_code < 600:
         return ErrorType.FATAL
-    
+
     # Default: treat unknown errors as FATAL to avoid wasting retries
     return ErrorType.FATAL

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -354,6 +354,7 @@ class AccountManager:
                 continue  # Skip path processing for refresh_token
 
             # Handle folder scanning for json/sqlite types
+            assert path is not None
             expanded_path = Path(path).expanduser()
             if expanded_path.is_dir():
                 logger.info(f"Scanning folder for credentials: {path}")
@@ -667,6 +668,10 @@ class AccountManager:
         account = self._accounts.get(account_id)
         if not account or not account.auth_manager:
             return
+
+        # These dependencies are initialized atomically with the auth manager.
+        assert account.model_cache is not None
+        assert account.model_resolver is not None
 
         # Check if using runtime endpoint (no dynamic model list available)
         if _is_runtime_endpoint(account.auth_manager):

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -24,47 +24,45 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-import httpx
 from loguru import logger
 
-from kiro.auth import KiroAuthManager, AuthType
+from kiro.account_errors import ErrorType
+from kiro.auth import AuthType, KiroAuthManager
 from kiro.cache import ModelInfoCache
-from kiro.model_resolver import ModelResolver, normalize_model_name
 from kiro.config import (
-    HIDDEN_MODELS,
-    MODEL_ALIASES,
-    HIDDEN_FROM_LIST,
-    ACCOUNT_RECOVERY_TIMEOUT,
+    ACCOUNT_CACHE_TTL,
     ACCOUNT_MAX_BACKOFF_MULTIPLIER,
     ACCOUNT_PROBABILISTIC_RETRY_CHANCE,
-    ACCOUNT_RATE_LIMIT_COOLDOWN,
     ACCOUNT_QUOTA_QUARANTINE,
-    RATE_WINDOW_SECONDS,
-    RATE_ESTIMATE_WINDOW_SECONDS,
-    ACCOUNT_CACHE_TTL,
-    STATE_SAVE_INTERVAL_SECONDS,
+    ACCOUNT_RATE_LIMIT_COOLDOWN,
+    ACCOUNT_RECOVERY_TIMEOUT,
     FALLBACK_MODELS,
+    HIDDEN_FROM_LIST,
+    HIDDEN_MODELS,
+    MODEL_ALIASES,
+    RATE_ESTIMATE_WINDOW_SECONDS,
+    RATE_WINDOW_SECONDS,
+    STATE_SAVE_INTERVAL_SECONDS,
 )
-from kiro.utils import get_kiro_headers
-from kiro.account_errors import ErrorType
 from kiro.http_client import KiroHttpClient
+from kiro.model_resolver import ModelResolver, normalize_model_name
 
 
 def _is_runtime_endpoint(auth_manager: KiroAuthManager) -> bool:
     """
     Check if auth manager uses runtime endpoint that doesn't provide /ListAvailableModels.
-    
+
     Runtime endpoint pattern: https://runtime.{region}.kiro.dev
     Old endpoint pattern: https://q.{region}.amazonaws.com
-    
+
     Runtime endpoint does not provide /ListAvailableModels API (AWS limitation).
-    
+
     Args:
         auth_manager: KiroAuthManager instance
-    
+
     Returns:
         True if using runtime endpoint, False otherwise
-    
+
     Examples:
         >>> auth_manager.api_host = "https://runtime.us-east-1.kiro.dev"
         >>> _is_runtime_endpoint(auth_manager)
@@ -140,13 +138,13 @@ def account_routing_state(account: "Account", now: Optional[float] = None) -> Tu
 def _format_duration(seconds: float) -> str:
     """
     Format duration in human-readable format.
-    
+
     Args:
         seconds: Duration in seconds
-    
+
     Returns:
         Formatted string (e.g., "30s", "5m", "2h", "1d")
-    
+
     Examples:
         >>> _format_duration(30)
         '30s'
@@ -171,9 +169,10 @@ def _format_duration(seconds: float) -> str:
 class AccountStats:
     """
     Statistics for account usage.
-    
+
     Tracks request counts for monitoring and future web UI.
     """
+
     total_requests: int = 0
     successful_requests: int = 0
     failed_requests: int = 0
@@ -183,10 +182,10 @@ class AccountStats:
 class Account:
     """
     Complete account entity with all dependencies.
-    
+
     Represents a single Kiro account with its authentication,
     model cache, resolver, and runtime state.
-    
+
     Attributes:
         id: Unique identifier (path to credentials file)
         auth_manager: Authentication manager (lazy initialized)
@@ -207,6 +206,7 @@ class Account:
         models_cached_at: Timestamp of last model cache update
         stats: Usage statistics
     """
+
     id: str
     auth_manager: Optional[KiroAuthManager] = None
     model_cache: Optional[ModelInfoCache] = None
@@ -235,6 +235,7 @@ class RateObservation:
         rpm: Requests in the trailing RATE_WINDOW_SECONDS at that instant
         rejected: True when the upstream answered with a rate rejection
     """
+
     at: float
     account_id: str
     rpm: int
@@ -246,26 +247,27 @@ class RateObservation:
 class ModelAccountList:
     """
     List of accounts for a specific model.
-    
+
     Attributes:
         accounts: List of account IDs that have this model
-    
+
     Note: next_index removed - now using global _current_account_index
     """
+
     accounts: List[str] = field(default_factory=list)
 
 
 class AccountManager:
     """
     Manages multiple Kiro accounts with intelligent failover.
-    
+
     Responsibilities:
     - Load credentials from credentials.json
     - Lazy initialization of accounts
     - Select next available account (Circuit Breaker + Sticky)
     - Track statistics and failures
     - Persist state to state.json
-    
+
     Example:
         >>> manager = AccountManager("credentials.json", "state.json")
         >>> await manager.load_credentials()
@@ -273,11 +275,11 @@ class AccountManager:
         >>> account = await manager.get_next_account("claude-opus-4.5")
         >>> await manager.report_success(account.id, "claude-opus-4.5")
     """
-    
+
     def __init__(self, credentials_file: str, state_file: str):
         """
         Initialize AccountManager.
-        
+
         Args:
             credentials_file: Path to credentials.json
             state_file: Path to state.json
@@ -295,62 +297,62 @@ class AccountManager:
         # Routing history outlives the process; see RateObservation.
         self._rate_observations: List[RateObservation] = []
         self._unsaved_rate_observations: List[RateObservation] = []
-    
+
     async def load_credentials(self) -> None:
         """
         Load credentials from credentials.json.
-        
+
         Validates each entry and creates Account objects.
         Invalid entries are skipped with warnings.
         Folders are scanned for credential files.
         """
         creds_path = Path(self._credentials_file).expanduser()
-        
+
         if not creds_path.exists():
             logger.warning(f"Credentials file not found: {self._credentials_file}")
             return
-        
+
         try:
-            with open(creds_path, 'r', encoding='utf-8') as f:
+            with open(creds_path, "r", encoding="utf-8") as f:
                 self._credentials_config = json.load(f)
         except Exception as e:
             logger.error(f"Failed to load credentials: {e}")
             return
-        
+
         # Process each credential entry
         for entry in self._credentials_config:
             cred_type = entry.get("type")
             path = entry.get("path")
             enabled = entry.get("enabled", True)
-            
+
             if not enabled:
                 continue
-            
+
             # Validate required fields based on type
             if not cred_type:
                 logger.warning(f"Invalid credential entry (missing type): {entry}")
                 continue
-            
+
             # For json/sqlite types, path is required
             if cred_type in ("json", "sqlite") and not path:
                 logger.warning(f"Invalid credential entry (type={cred_type} requires path): {entry}")
                 continue
-            
+
             # For refresh_token type, refresh_token field is required
             if cred_type == "refresh_token" and not entry.get("refresh_token"):
                 logger.warning(f"Invalid credential entry (type=refresh_token requires refresh_token field): {entry}")
                 continue
-            
+
             # Handle refresh_token type (no path processing needed)
             if cred_type == "refresh_token":
                 # Use deterministic hash for refresh_token (hash() is not deterministic between process restarts)
-                token = entry.get('refresh_token', '')
+                token = entry.get("refresh_token", "")
                 token_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
                 account_id = f"refresh_token_{token_hash}"
                 self._accounts[account_id] = Account(id=account_id)
                 logger.debug(f"Added account: {account_id}")
                 continue  # Skip path processing for refresh_token
-            
+
             # Handle folder scanning for json/sqlite types
             expanded_path = Path(path).expanduser()
             if expanded_path.is_dir():
@@ -358,26 +360,27 @@ class AccountManager:
                 for file_path in expanded_path.iterdir():
                     if not file_path.is_file():
                         continue
-                    
+
                     # Validate file before adding as account
                     account_id = str(file_path.resolve())
                     is_valid = False
-                    
+
                     # Try JSON validation
                     if cred_type == "json":
                         try:
-                            with open(file_path, 'r', encoding='utf-8') as f:
+                            with open(file_path, "r", encoding="utf-8") as f:
                                 data = json.load(f)
                                 # Valid if has refreshToken or clientId
-                                if 'refreshToken' in data or 'clientId' in data:
+                                if "refreshToken" in data or "clientId" in data:
                                     is_valid = True
                         except Exception as e:
                             logger.warning(f"Invalid JSON credentials file {file_path.name}: {e}")
-                    
+
                     # Try SQLite validation
                     elif cred_type == "sqlite":
                         try:
                             import sqlite3
+
                             conn = sqlite3.connect(str(file_path))
                             cursor = conn.cursor()
                             # Check if auth_kv table exists
@@ -387,7 +390,7 @@ class AccountManager:
                             conn.close()
                         except Exception as e:
                             logger.warning(f"Invalid SQLite database file {file_path.name}: {e}")
-                    
+
                     if is_valid:
                         self._accounts[account_id] = Account(id=account_id)
                         logger.debug(f"Added account from folder: {account_id}")
@@ -397,7 +400,7 @@ class AccountManager:
                 # Single file or refresh_token type
                 if cred_type == "refresh_token":
                     # Use deterministic hash for refresh_token (hash() is not deterministic between process restarts)
-                    token = entry.get('refresh_token', '')
+                    token = entry.get("refresh_token", "")
                     token_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
                     account_id = f"refresh_token_{token_hash}"
                 else:
@@ -406,34 +409,32 @@ class AccountManager:
                 logger.debug(f"Added account: {account_id}")
             else:
                 logger.warning(f"Credential path not found: {path}")
-        
+
         logger.info(f"Loaded {len(self._accounts)} account(s) from credentials")
-    
+
     async def load_state(self) -> None:
         """
         Load runtime state from state.json.
-        
+
         Restores model_to_accounts mapping and account runtime state.
         Creates empty state if file doesn't exist.
         """
         state_path = Path(self._state_file)
-        
+
         if not state_path.exists():
             logger.debug("State file not found, starting with empty state")
             return
-        
+
         try:
-            with open(state_path, 'r', encoding='utf-8') as f:
+            with open(state_path, "r", encoding="utf-8") as f:
                 state_data = json.load(f)
             # Restore global current_account_index
             self._current_account_index = state_data.get("current_account_index", 0)
-            
+
             # Restore model_to_accounts mapping (without next_index)
             for model, data in state_data.get("model_to_accounts", {}).items():
-                self._model_to_accounts[model] = ModelAccountList(
-                    accounts=data.get("accounts", [])
-                )
-            
+                self._model_to_accounts[model] = ModelAccountList(accounts=data.get("accounts", []))
+
             # Restore account runtime state
             for account_id, data in state_data.get("accounts", {}).items():
                 if account_id in self._accounts:
@@ -442,23 +443,23 @@ class AccountManager:
                     account.last_failure_time = data.get("last_failure_time", 0.0)
                     account.quota_exhausted_until = data.get("quota_exhausted_until", 0.0)
                     account.models_cached_at = data.get("models_cached_at", 0.0)
-                    
+
                     stats_data = data.get("stats", {})
                     account.stats = AccountStats(
                         total_requests=stats_data.get("total_requests", 0),
                         successful_requests=stats_data.get("successful_requests", 0),
-                        failed_requests=stats_data.get("failed_requests", 0)
+                        failed_requests=stats_data.get("failed_requests", 0),
                     )
-            
+
             logger.info(f"Loaded state: {len(self._model_to_accounts)} model mappings, {len(self._accounts)} accounts")
-        
+
         except Exception as e:
             logger.error(f"Failed to load state: {e}")
-    
+
     async def _save_state(self) -> None:
         """
         Save runtime state to state.json atomically.
-        
+
         Uses tmp file + rename for atomic write.
         """
         state_data = {
@@ -472,87 +473,84 @@ class AccountManager:
                     "stats": {
                         "total_requests": account.stats.total_requests,
                         "successful_requests": account.stats.successful_requests,
-                        "failed_requests": account.stats.failed_requests
-                    }
+                        "failed_requests": account.stats.failed_requests,
+                    },
                 }
                 for account_id, account in self._accounts.items()
             },
-            "model_to_accounts": {
-                model: {
-                    "accounts": mal.accounts
-                }
-                for model, mal in self._model_to_accounts.items()
-            }
+            "model_to_accounts": {model: {"accounts": mal.accounts} for model, mal in self._model_to_accounts.items()},
         }
-        
+
         state_path = Path(self._state_file)
-        tmp_path = state_path.with_suffix('.json.tmp')
-        
+        tmp_path = state_path.with_suffix(".json.tmp")
+
         try:
-            with open(tmp_path, 'w', encoding='utf-8') as f:
+            with open(tmp_path, "w", encoding="utf-8") as f:
                 json.dump(state_data, f, indent=2, ensure_ascii=False)
-            
+
             # Atomic rename
             tmp_path.replace(state_path)
             logger.debug("State saved successfully")
-        
+
         except Exception as e:
             logger.error(f"Failed to save state: {e}")
             if tmp_path.exists():
                 tmp_path.unlink()
-    
+
     async def save_state_periodically(self) -> None:
         """
         Background task for periodic state saving.
-        
+
         Saves state every STATE_SAVE_INTERVAL_SECONDS if dirty flag is set.
         """
         while True:
             await asyncio.sleep(STATE_SAVE_INTERVAL_SECONDS)
-            
+
             if self._dirty:
                 async with self._lock:
                     await self._save_state()
                     self._dirty = False
-    
+
     async def _initialize_account(self, account_id: str) -> bool:
         """
         Initialize account (lazy initialization).
-        
+
         Creates auth_manager, fetches models, creates cache and resolver.
-        
+
         Args:
             account_id: Account ID to initialize
-        
+
         Returns:
             True if successful, False otherwise
         """
         account = self._accounts.get(account_id)
         if not account:
             return False
-        
+
         try:
             # Find credentials config for this account
             creds_config = None
             for entry in self._credentials_config:
                 path = entry.get("path", "")
                 expanded_path = Path(path).expanduser()
-                
+
                 if entry.get("type") == "refresh_token":
                     # Match by deterministic hash for refresh_token type
-                    token = entry.get('refresh_token', '')
+                    token = entry.get("refresh_token", "")
                     token_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
                     if account_id == f"refresh_token_{token_hash}":
                         creds_config = entry
                         break
-                elif str(expanded_path.resolve()) == account_id or (expanded_path.is_dir() and account_id.startswith(str(expanded_path.resolve()) + os.sep)):
+                elif str(expanded_path.resolve()) == account_id or (
+                    expanded_path.is_dir() and account_id.startswith(str(expanded_path.resolve()) + os.sep)
+                ):
                     creds_config = entry
                     break
-            
+
             if not creds_config:
                 logger.error(f"No credentials config found for account: {account_id}")
                 return False
-            
+
             # Create KiroAuthManager based on type
             cred_type = creds_config.get("type")
             if cred_type == "json":
@@ -560,29 +558,29 @@ class AccountManager:
                     creds_file=account_id,
                     profile_arn=creds_config.get("profile_arn"),
                     region=creds_config.get("region", "us-east-1"),
-                    api_region=creds_config.get("api_region")
+                    api_region=creds_config.get("api_region"),
                 )
             elif cred_type == "sqlite":
                 auth_manager = KiroAuthManager(
                     sqlite_db=account_id,
                     profile_arn=creds_config.get("profile_arn"),
                     region=creds_config.get("region", "us-east-1"),
-                    api_region=creds_config.get("api_region")
+                    api_region=creds_config.get("api_region"),
                 )
             elif cred_type == "refresh_token":
                 auth_manager = KiroAuthManager(
                     refresh_token=creds_config.get("refresh_token"),
                     profile_arn=creds_config.get("profile_arn"),
                     region=creds_config.get("region", "us-east-1"),
-                    api_region=creds_config.get("api_region")
+                    api_region=creds_config.get("api_region"),
                 )
             else:
                 logger.error(f"Unknown credential type: {cred_type}")
                 return False
-            
+
             # Get token to verify credentials
             token = await auth_manager.get_access_token()
-            
+
             # Determine if we should fetch models or use static list
             if _is_runtime_endpoint(auth_manager):
                 # New runtime endpoint does not provide /ListAvailableModels (AWS limitation)
@@ -595,59 +593,54 @@ class AccountManager:
                 params = {"origin": "AI_EDITOR"}
                 if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
                     params["profileArn"] = auth_manager.profile_arn
-                
+
                 list_models_url = f"{auth_manager.q_host}/ListAvailableModels"
-                
+
                 # Use KiroHttpClient for retry logic (3 attempts with exponential backoff)
                 http_client = KiroHttpClient(auth_manager, shared_client=None)
-                
+
                 try:
                     response = await http_client.request_with_retry(
-                        method="GET",
-                        url=list_models_url,
-                        json_data=None,
-                        params=params,
-                        stream=False
+                        method="GET", url=list_models_url, json_data=None, params=params, stream=False
                     )
-                    
+
                     if response.status_code == 200:
                         data = response.json()
                         models_list = data.get("models", [])
                     else:
                         # Shouldn't happen (retry handles non-200), but keep for safety
                         raise Exception(f"HTTP {response.status_code}")
-                
+
                 except Exception as e:
                     # All retries exhausted - use fallback
                     logger.error(f"Failed to fetch models for {account_id} after retries: {e}")
-                    logger.warning("Using pre-configured fallback models. Models will be refreshed on next TTL cycle when network recovers.")
+                    logger.warning(
+                        "Using pre-configured fallback models. Models will be refreshed on next TTL cycle when network recovers."
+                    )
                     models_list = FALLBACK_MODELS
-                
+
                 finally:
                     await http_client.close()
-            
+
             # Create model cache and update
             model_cache = ModelInfoCache()
             await model_cache.update(models_list)
-            
+
             # Add hidden models
             for display_name, internal_id in HIDDEN_MODELS.items():
                 model_cache.add_hidden_model(display_name, internal_id)
-            
+
             # Create model resolver
             model_resolver = ModelResolver(
-                cache=model_cache,
-                hidden_models=HIDDEN_MODELS,
-                aliases=MODEL_ALIASES,
-                hidden_from_list=HIDDEN_FROM_LIST
+                cache=model_cache, hidden_models=HIDDEN_MODELS, aliases=MODEL_ALIASES, hidden_from_list=HIDDEN_FROM_LIST
             )
-            
+
             # Update account
             account.auth_manager = auth_manager
             account.model_cache = model_cache
             account.model_resolver = model_resolver
             account.models_cached_at = time.time()
-            
+
             # Update model_to_accounts mapping
             available_models = model_resolver.get_available_models()
             for model in available_models:
@@ -655,61 +648,59 @@ class AccountManager:
                     self._model_to_accounts[model] = ModelAccountList()
                 if account_id not in self._model_to_accounts[model].accounts:
                     self._model_to_accounts[model].accounts.append(account_id)
-            
+
             logger.info(f"Initialized account: {account_id} ({len(available_models)} models)")
             self._dirty = True
             return True
-        
+
         except Exception as e:
             logger.error(f"Failed to initialize account {account_id}: {e}")
             return False
-    
+
     async def _refresh_account_models(self, account_id: str) -> None:
         """
         Refresh model cache for account (TTL refresh).
-        
+
         Args:
             account_id: Account ID to refresh
         """
         account = self._accounts.get(account_id)
         if not account or not account.auth_manager:
             return
-        
+
         # Check if using runtime endpoint (no dynamic model list available)
         if _is_runtime_endpoint(account.auth_manager):
             # Runtime endpoint does not provide /ListAvailableModels
             # Use static list and update cache timestamp
-            logger.debug(f"Account {account_id}: Skipping model refresh for runtime.kiro.dev endpoint (using static list)")
+            logger.debug(
+                f"Account {account_id}: Skipping model refresh for runtime.kiro.dev endpoint (using static list)"
+            )
             await account.model_cache.update(FALLBACK_MODELS)
             account.models_cached_at = time.time()
             self._dirty = True
             return
-        
+
         # Old endpoint - attempt to fetch dynamic model list
         # Use KiroHttpClient for retry logic
         http_client = KiroHttpClient(account.auth_manager, shared_client=None)
-        
+
         try:
             params = {"origin": "AI_EDITOR"}
             if account.auth_manager.auth_type == AuthType.KIRO_DESKTOP and account.auth_manager.profile_arn:
                 params["profileArn"] = account.auth_manager.profile_arn
-            
+
             list_models_url = f"{account.auth_manager.q_host}/ListAvailableModels"
-            
+
             response = await http_client.request_with_retry(
-                method="GET",
-                url=list_models_url,
-                json_data=None,
-                params=params,
-                stream=False
+                method="GET", url=list_models_url, json_data=None, params=params, stream=False
             )
-            
+
             if response.status_code == 200:
                 data = response.json()
                 models_list = data.get("models", [])
                 await account.model_cache.update(models_list)
                 account.models_cached_at = time.time()
-                
+
                 # Update model_to_accounts mapping (new models may have appeared)
                 available_models = account.model_resolver.get_available_models()
                 for model in available_models:
@@ -717,21 +708,21 @@ class AccountManager:
                         self._model_to_accounts[model] = ModelAccountList()
                     if account_id not in self._model_to_accounts[model].accounts:
                         self._model_to_accounts[model].accounts.append(account_id)
-                
+
                 logger.debug(f"Refreshed models for {account_id}")
                 self._dirty = True
-        
+
         except Exception as e:
             # All retries exhausted - keep using stale cache
             logger.warning(f"Failed to refresh models for {account_id} after retries: {e}")
-        
+
         finally:
             await http_client.close()
-    
+
     async def get_next_account(self, model: str, exclude_accounts: Optional[set] = None) -> Optional[Account]:
         """
         Get next available account for model (Circuit Breaker + Sticky).
-        
+
         Implements:
         - Sticky behavior (prefer successful account)
         - Circuit Breaker with exponential backoff
@@ -740,11 +731,11 @@ class AccountManager:
         - Full exclusion of quota-exhausted accounts (no probabilistic retry)
         - TTL-based model cache refresh
         - Exclusion of already-tried accounts in current failover loop
-        
+
         Args:
             model: Model name (will be normalized)
             exclude_accounts: Set of account IDs to exclude (already tried in current failover loop)
-        
+
         Returns:
             Account object or None if no accounts available
         """
@@ -755,17 +746,17 @@ class AccountManager:
             if len(self._accounts) == 1:
                 account_id = list(self._accounts.keys())[0]
                 account = self._accounts[account_id]
-                
+
                 # Skip if already tried in current failover loop
                 if exclude_accounts and account_id in exclude_accounts:
                     return None
-                
+
                 # Lazy initialization if needed
                 if account.auth_manager is None:
                     success = await self._initialize_account(account_id)
                     if not success:
                         return None
-                
+
                 # Check TTL and refresh if needed
                 if account.models_cached_at > 0:
                     age = time.time() - account.models_cached_at
@@ -780,51 +771,49 @@ class AccountManager:
                 #     available_models = account.model_resolver.get_available_models()
                 #     if normalized_model not in available_models:
                 #         return None
-                
+
                 # Always return single account (ignore cooldown/failures)
                 # No model validation - let Kiro API decide (gateway, not gatekeeper)
                 return account
-            
+
             # Multi-account logic: GLOBAL sticky
-            normalized_model = normalize_model_name(model)
-            
             # ALWAYS start from GLOBAL index (one current account for ALL models)
             start_index = self._current_account_index
-            
+
             # ALWAYS iterate over ALL accounts
             all_account_ids = list(self._accounts.keys())
-            
+
             for i in range(len(all_account_ids)):
                 current_index = (start_index + i) % len(all_account_ids)
                 account_id = all_account_ids[current_index]
                 account = self._accounts[account_id]
-                
+
                 # Skip accounts already tried in current failover loop
                 if exclude_accounts and account_id in exclude_accounts:
                     continue
-                
+
                 # Skip accounts that cannot serve any request. A quota-exhausted
                 # account is out of the rotation entirely until its quarantine
                 # expires: no probabilistic retry, because there is nothing to
                 # discover before the quota resets.
                 if account.quota_exhausted_until > time.time():
                     continue
-                
+
                 # Skip accounts inside their rate-limit window. This is checked
                 # before the Circuit Breaker and has no probabilistic retry:
                 # retrying a rate-limited account only earns another 429.
                 if account.rate_limited_until > time.time():
                     continue
-                
+
                 # Check Circuit Breaker (Half-Open state with exponential backoff)
                 if account.failures > 0:
                     time_since_failure = time.time() - account.last_failure_time
-                    
+
                     # Exponential backoff: base * 2^(failures - 1), capped at MAX_MULTIPLIER
                     # 1 failure: 60s, 2: 120s, 3: 240s, ..., 12+: 86400s (1 day cap)
                     backoff_multiplier = min(2 ** (account.failures - 1), ACCOUNT_MAX_BACKOFF_MULTIPLIER)
                     effective_timeout = ACCOUNT_RECOVERY_TIMEOUT * backoff_multiplier
-                    
+
                     if time_since_failure < effective_timeout:
                         # Probabilistic retry (10% chance)
                         if random.random() > ACCOUNT_PROBABILISTIC_RETRY_CHANCE:
@@ -833,8 +822,10 @@ class AccountManager:
                             logger.info(f"Probabilistic retry for broken account {account_id}")
                     else:
                         # Half-Open: recovery timeout passed
-                        logger.info(f"Half-Open state for {account_id} (recovery timeout passed, effective={effective_timeout}s)")
-                
+                        logger.info(
+                            f"Half-Open state for {account_id} (recovery timeout passed, effective={effective_timeout}s)"
+                        )
+
                 # Lazy initialization
                 if account.auth_manager is None:
                     success = await self._initialize_account(account_id)
@@ -842,7 +833,7 @@ class AccountManager:
                         account.failures += 1
                         self._dirty = True
                         continue
-                
+
                 # Check TTL and refresh if needed
                 if account.models_cached_at > 0:
                     age = time.time() - account.models_cached_at
@@ -855,18 +846,18 @@ class AccountManager:
                 # available_models = account.model_resolver.get_available_models()
                 # if normalized_model not in available_models:
                 #     continue
-                
+
                 # No model validation - let Kiro API decide (gateway, not gatekeeper)
                 # Account is suitable!
                 return account
-            
+
             # All accounts unavailable
             return None
-    
+
     async def report_success(self, account_id: str, model: str) -> None:
         """
         Report successful request (reset failures, update stats, sticky, dynamic learning).
-        
+
         Args:
             account_id: Account ID
             model: Model name
@@ -875,25 +866,25 @@ class AccountManager:
             account = self._accounts.get(account_id)
             if not account:
                 return
-            
+
             # Reset failures
             if account.failures > 0:
                 account.failures = 0
                 self._dirty = True
-            
+
             # A success proves the account is accepting requests again, so drop
             # any leftover rate-limit or quota window instead of waiting it out.
             account.rate_limited_until = 0.0
             if account.quota_exhausted_until:
                 account.quota_exhausted_until = 0.0
                 logger.info(f"Account {account_id} is serving again; quota quarantine cleared")
-            
+
             # Update stats
             account.stats.total_requests += 1
             account.stats.successful_requests += 1
             self._record_routing_event(account_id, "success")
             self._dirty = True
-            
+
             # Dynamic learning: add model to mapping if successful
             # This allows system to learn about new models not in FALLBACK_MODELS
             normalized_model = normalize_model_name(model)
@@ -904,7 +895,7 @@ class AccountManager:
                 self._model_to_accounts[normalized_model].accounts.append(account_id)
                 logger.debug(f"Dynamic learning: model '{normalized_model}' works on account {account_id}")
                 self._dirty = True
-            
+
             # GLOBAL STICKY: Update global current_account_index
             all_account_ids = list(self._accounts.keys())
             try:
@@ -914,18 +905,13 @@ class AccountManager:
                     self._dirty = True
             except ValueError:
                 pass
-    
+
     async def report_failure(
-        self,
-        account_id: str,
-        model: str,
-        error_type: ErrorType,
-        status_code: int,
-        reason: Optional[str]
+        self, account_id: str, model: str, error_type: ErrorType, status_code: int, reason: Optional[str]
     ) -> None:
         """
         Report failed request (update failures, stats, failover).
-        
+
         Args:
             account_id: Account ID
             model: Model name
@@ -937,7 +923,7 @@ class AccountManager:
             account = self._accounts.get(account_id)
             if not account:
                 return
-            
+
             # Special case: INVALID_MODEL_ID is discovery process, not account failure
             # Account is healthy, model is just not available on this account
             # Log for user visibility but don't penalize account statistics
@@ -945,11 +931,10 @@ class AccountManager:
                 account.stats.total_requests += 1
                 self._dirty = True
                 logger.warning(
-                    f"Model '{model}' not available on account {account_id}: "
-                    f"status={status_code}, reason={reason}"
+                    f"Model '{model}' not available on account {account_id}: status={status_code}, reason={reason}"
                 )
                 return
-            
+
             # Special case: a request-rate rejection means the account was asked
             # too quickly, not that it is broken. Park it for a few seconds
             # without touching the Circuit Breaker so a momentary burst cannot
@@ -967,7 +952,7 @@ class AccountManager:
                     f"(failures unchanged at {account.failures})"
                 )
                 return
-            
+
             # Special case: the monthly quota is gone, so this account cannot
             # serve anything until it resets. Take it out of the rotation for a
             # long quarantine rather than leaving the Circuit Breaker to leak
@@ -984,13 +969,13 @@ class AccountManager:
                     f"excluded from routing for {_format_duration(ACCOUNT_QUOTA_QUARANTINE)}"
                 )
                 return
-            
+
             # Update failure count (only for RECOVERABLE)
             if error_type == ErrorType.RECOVERABLE:
                 account.failures += 1
                 account.last_failure_time = time.time()
                 self._dirty = True
-                
+
                 # Calculate backoff for logging
                 backoff_multiplier = min(2 ** (account.failures - 1), ACCOUNT_MAX_BACKOFF_MULTIPLIER)
                 effective_timeout = ACCOUNT_RECOVERY_TIMEOUT * backoff_multiplier
@@ -999,28 +984,31 @@ class AccountManager:
                     f"status={status_code}, reason={reason}, "
                     f"cooldown={_format_duration(effective_timeout)}"
                 )
-            
+
             # Update stats
             account.stats.total_requests += 1
             account.stats.failed_requests += 1
             self._record_routing_event(account_id, "failure")
             self._dirty = True
-            
+
             # GLOBAL STICKY: Do NOT change _current_account_index on failure
             # It only changes on success (GLOBAL sticky behavior)
             # Failover happens through exclude_accounts in get_next_account()
-    
+
     def _record_routing_event(self, account_id: str, outcome: str) -> None:
         at = time.time()
 
         # Rate at this instant, counted from persisted observations so the figure
         # is correct on the first request after a restart instead of reporting 1.
         cutoff = at - RATE_WINDOW_SECONDS
-        rpm = sum(
-            1
-            for observation in reversed(self._rate_observations)
-            if observation.at > cutoff and observation.account_id == account_id
-        ) + 1
+        rpm = (
+            sum(
+                1
+                for observation in reversed(self._rate_observations)
+                if observation.at > cutoff and observation.account_id == account_id
+            )
+            + 1
+        )
 
         observation = RateObservation(
             at=at,
@@ -1041,9 +1029,7 @@ class AccountManager:
     def load_rate_observations(self, rows: List[Tuple[str, float, int, int, str]]) -> None:
         """Restore persisted rate observations after a restart."""
         restored = [
-            RateObservation(
-                account_id=account_id, at=at, rpm=rpm, rejected=bool(rejected), outcome=outcome
-            )
+            RateObservation(account_id=account_id, at=at, rpm=rpm, rejected=bool(rejected), outcome=outcome)
             for account_id, at, rpm, rejected, outcome in rows
         ]
         self._rate_observations = restored + self._rate_observations
@@ -1076,10 +1062,7 @@ class AccountManager:
         """
         now = time.time() if now is None else now
         cutoff = now - RATE_ESTIMATE_WINDOW_SECONDS
-        samples = [
-            item for item in self._rate_observations
-            if item.account_id == account_id and item.at >= cutoff
-        ]
+        samples = [item for item in self._rate_observations if item.account_id == account_id and item.at >= cutoff]
 
         served_peak = max((item.rpm for item in samples if not item.rejected), default=0)
         rejections = [item.rpm for item in samples if item.rejected]
@@ -1168,14 +1151,16 @@ class AccountManager:
                     failure[bucket] += 1
                 peak_rpm[bucket] = max(peak_rpm[bucket], observation.rpm)
 
-            accounts.append({
-                "account": account_label(account_id),
-                "success": success,
-                "rateLimited": rate_limited,
-                "failure": failure,
-                "peakRpm": peak_rpm,
-                **self.estimate_rate_limit(account_id, now),
-            })
+            accounts.append(
+                {
+                    "account": account_label(account_id),
+                    "success": success,
+                    "rateLimited": rate_limited,
+                    "failure": failure,
+                    "peakRpm": peak_rpm,
+                    **self.estimate_rate_limit(account_id, now),
+                }
+            )
 
         return {
             "bucketSeconds": bucket_seconds,
@@ -1215,10 +1200,7 @@ class AccountManager:
             state, seconds = account_routing_state(account, now)
 
             if state == "quota_exhausted":
-                parts.append(
-                    f"{label}: monthly quota exhausted, excluded for "
-                    f"{_format_duration(seconds)}"
-                )
+                parts.append(f"{label}: monthly quota exhausted, excluded for {_format_duration(seconds)}")
             elif state == "rate_limited":
                 parts.append(f"{label}: rate limited for {_format_duration(seconds)}")
             elif state == "cooling_down":
@@ -1236,10 +1218,10 @@ class AccountManager:
     def get_first_account(self) -> Account:
         """
         Get first initialized account (for legacy mode).
-        
+
         Returns:
             First initialized account
-        
+
         Raises:
             RuntimeError: If no initialized accounts available
         """
@@ -1247,14 +1229,14 @@ class AccountManager:
             if account.auth_manager is not None:
                 return account
         raise RuntimeError("No initialized accounts available")
-    
+
     def get_all_available_models(self) -> List[str]:
         """
         Collect unique models from all initialized accounts.
-        
+
         Used by /v1/models endpoint in account system to show
         all available models across all accounts.
-        
+
         Returns:
             Sorted list of unique model IDs
         """

--- a/kiro/accounts_admin.py
+++ b/kiro/accounts_admin.py
@@ -48,9 +48,7 @@ def _validate_sqlite(path: Path) -> None:
         raise ValueError("SQLite credential file does not exist in the server filesystem")
     try:
         with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as conn:
-            found = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='auth_kv'"
-            ).fetchone()
+            found = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='auth_kv'").fetchone()
     except Exception as exc:
         raise ValueError(f"Cannot read SQLite credential database: {exc}") from exc
     if not found:

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -14,7 +14,7 @@ import json
 import os
 import re
 import sqlite3
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -23,20 +23,19 @@ import httpx
 from loguru import logger
 
 from kiro.config import (
-    TOKEN_REFRESH_THRESHOLD,
     SQLITE_READONLY,
-    get_kiro_refresh_url,
+    TOKEN_REFRESH_THRESHOLD,
+    get_aws_sso_oidc_url,
     get_kiro_api_host,
     get_kiro_q_host,
-    get_aws_sso_oidc_url,
+    get_kiro_refresh_url,
 )
 from kiro.utils import get_machine_fingerprint
 
-
 # Supported SQLite token keys (searched in priority order)
 SQLITE_TOKEN_KEYS = [
-    "kirocli:social:token",      # Social login (Google, GitHub, Microsoft, etc.)
-    "kirocli:odic:token",        # AWS SSO OIDC (kiro-cli corporate)
+    "kirocli:social:token",  # Social login (Google, GitHub, Microsoft, etc.)
+    "kirocli:odic:token",  # AWS SSO OIDC (kiro-cli corporate)
     "codewhisperer:odic:token",  # Legacy AWS SSO OIDC
 ]
 
@@ -50,16 +49,17 @@ SQLITE_REGISTRATION_KEYS = [
 class AuthType(Enum):
     """
     Type of authentication mechanism.
-    
+
     KIRO_DESKTOP: Kiro IDE credentials (default)
         - Uses https://prod.{region}.auth.desktop.kiro.dev/refreshToken
         - JSON body: {"refreshToken": "..."}
-    
+
     AWS_SSO_OIDC: AWS SSO credentials from kiro-cli
         - Uses https://oidc.{region}.amazonaws.com/token
         - Form body: grant_type=refresh_token&client_id=...&client_secret=...&refresh_token=...
         - Requires clientId and clientSecret from credentials file
     """
+
     KIRO_DESKTOP = "kiro_desktop"
     AWS_SSO_OIDC = "aws_sso_oidc"
 
@@ -67,14 +67,14 @@ class AuthType(Enum):
 class KiroAuthManager:
     """
     Manages the token lifecycle for accessing Kiro API.
-    
+
     Supports:
     - Loading credentials from .env or JSON file
     - Automatic token refresh on expiration
     - Expiration time validation (expiresAt)
     - Saving updated tokens to file
     - Both Kiro Desktop Auth and AWS SSO OIDC (kiro-cli) authentication
-    
+
     Attributes:
         profile_arn: AWS CodeWhisperer profile ARN
         region: AWS region
@@ -82,7 +82,7 @@ class KiroAuthManager:
         q_host: Q API host for the current region
         fingerprint: Unique machine fingerprint
         auth_type: Type of authentication (KIRO_DESKTOP or AWS_SSO_OIDC)
-    
+
     Example:
         >>> # Kiro Desktop Auth (default)
         >>> auth_manager = KiroAuthManager(
@@ -90,14 +90,14 @@ class KiroAuthManager:
         ...     region="us-east-1"
         ... )
         >>> token = await auth_manager.get_access_token()
-        
+
         >>> # AWS SSO OIDC (kiro-cli) - auto-detected from credentials file
         >>> auth_manager = KiroAuthManager(
         ...     creds_file="~/.aws/sso/cache/your-cache.json"
         ... )
         >>> token = await auth_manager.get_access_token()
     """
-    
+
     def __init__(
         self,
         refresh_token: Optional[str] = None,
@@ -111,7 +111,7 @@ class KiroAuthManager:
     ):
         """
         Initializes the authentication manager.
-        
+
         Args:
             refresh_token: Refresh token for obtaining access token
             profile_arn: AWS CodeWhisperer profile ARN
@@ -129,44 +129,44 @@ class KiroAuthManager:
         self._region = region
         self._creds_file = creds_file
         self._sqlite_db = sqlite_db
-        
+
         # AWS SSO OIDC specific fields
         self._client_id: Optional[str] = client_id
         self._client_secret: Optional[str] = client_secret
         self._scopes: Optional[list] = None  # OAuth scopes for AWS SSO OIDC
         self._sso_region: Optional[str] = None  # SSO region for OIDC token refresh (may differ from API region)
-        
+
         # Enterprise Kiro IDE specific fields
         self._client_id_hash: Optional[str] = None  # clientIdHash from Enterprise Kiro IDE
-        
+
         # Auto-detected API region from credentials
         # This is separate from SSO region because q.amazonaws.com endpoints
         # only exist in specific regions, while OIDC endpoints exist everywhere
         self._detected_api_region: Optional[str] = None
-        
+
         # Track which SQLite key we loaded credentials from (for saving back to correct location)
         self._sqlite_token_key: Optional[str] = None
-        
+
         self._access_token: Optional[str] = None
         self._expires_at: Optional[datetime] = None
         self._lock = asyncio.Lock()
-        
+
         # Auth type will be determined after loading credentials
         self._auth_type: AuthType = AuthType.KIRO_DESKTOP
-        
+
         # Fingerprint for User-Agent
         self._fingerprint = get_machine_fingerprint()
-        
+
         # Load credentials from SQLite if specified (takes priority over JSON)
         if sqlite_db:
             self._load_credentials_from_sqlite(sqlite_db)
         # Load credentials from JSON file if specified
         elif creds_file:
             self._load_credentials_from_file(creds_file)
-        
+
         # Determine auth type based on available credentials
         self._detect_auth_type()
-        
+
         # Determine final API region with priority hierarchy:
         # 1. Explicit api_region parameter (per-account) - HIGHEST
         # 2. KIRO_API_REGION env var (global override)
@@ -174,7 +174,7 @@ class KiroAuthManager:
         # 4. SSO region (fallback)
         # 5. Default region parameter (us-east-1)
         api_region_override = os.getenv("KIRO_API_REGION")
-        
+
         if api_region:
             # Explicit per-account override
             final_api_region = api_region
@@ -195,7 +195,7 @@ class KiroAuthManager:
             # Final fallback to default region
             final_api_region = region
             logger.info(f"API region: {final_api_region} (using default)")
-        
+
         # Set up URLs with correct regions:
         # - OIDC refresh: uses SSO region (for token refresh)
         # - API/Q hosts: use determined API region (for Q Developer API calls)
@@ -208,7 +208,7 @@ class KiroAuthManager:
         self._refresh_url = get_kiro_refresh_url(sso_region_for_oidc)
         self._api_host = get_kiro_api_host(final_api_region, is_builder_id)
         self._q_host = get_kiro_q_host(final_api_region, is_builder_id)
-        
+
         # Log initialized endpoints for diagnostics (helps with DNS issues like #58, #132, #133)
         logger.info(
             f"Auth manager initialized: "
@@ -219,11 +219,11 @@ class KiroAuthManager:
             f"api_host={self._api_host}, "
             f"q_host={self._q_host}"
         )
-    
+
     def _detect_auth_type(self) -> None:
         """
         Detects authentication type based on available credentials.
-        
+
         AWS SSO OIDC credentials contain clientId and clientSecret.
         Kiro Desktop credentials do not contain these fields.
         """
@@ -233,26 +233,26 @@ class KiroAuthManager:
         else:
             self._auth_type = AuthType.KIRO_DESKTOP
             logger.info("Detected auth type: Kiro Desktop")
-    
+
     def _load_credentials_from_sqlite(self, db_path: str) -> None:
         """
         Loads credentials from kiro-cli SQLite database.
-        
+
         The database contains an auth_kv table with key-value pairs.
         Supports multiple authentication types:
-        
+
         Token keys (searched in priority order):
         - 'kirocli:social:token': Social login (Google, GitHub, etc.)
         - 'kirocli:odic:token': AWS SSO OIDC (kiro-cli corporate)
         - 'codewhisperer:odic:token': Legacy AWS SSO OIDC
-        
+
         Device registration keys (for AWS SSO OIDC only):
         - 'kirocli:odic:device-registration': Client ID and secret
         - 'codewhisperer:odic:device-registration': Legacy format
-        
+
         The method remembers which key was used for loading, so credentials
         can be saved back to the correct location after refresh.
-        
+
         Args:
             db_path: Path to SQLite database file
         """
@@ -261,10 +261,10 @@ class KiroAuthManager:
             if not path.exists():
                 logger.warning(f"SQLite database not found: {db_path}")
                 return
-            
+
             conn = sqlite3.connect(str(path))
             cursor = conn.cursor()
-            
+
             # Try all possible token keys in priority order
             token_row = None
             for key in SQLITE_TOKEN_KEYS:
@@ -274,41 +274,41 @@ class KiroAuthManager:
                     self._sqlite_token_key = key  # Remember which key we loaded from
                     logger.debug(f"Loaded credentials from SQLite key: {key}")
                     break
-            
+
             if token_row:
                 token_data = json.loads(token_row[0])
                 if token_data:
                     # Load token fields (using snake_case as in Rust struct)
-                    if 'access_token' in token_data:
-                        self._access_token = token_data['access_token']
-                    if 'refresh_token' in token_data:
-                        self._refresh_token = token_data['refresh_token']
-                    if 'profile_arn' in token_data:
-                        self._profile_arn = token_data['profile_arn']
-                    if 'region' in token_data:
+                    if "access_token" in token_data:
+                        self._access_token = token_data["access_token"]
+                    if "refresh_token" in token_data:
+                        self._refresh_token = token_data["refresh_token"]
+                    if "profile_arn" in token_data:
+                        self._profile_arn = token_data["profile_arn"]
+                    if "region" in token_data:
                         # Store SSO region for OIDC token refresh
                         # Note: API region is determined separately (see __init__ for priority logic)
-                        self._sso_region = token_data['region']
+                        self._sso_region = token_data["region"]
                         logger.debug(f"SSO region from SQLite: {self._sso_region}")
-                    
+
                     # Load scopes if available
-                    if 'scopes' in token_data:
-                        self._scopes = token_data['scopes']
-                    
+                    if "scopes" in token_data:
+                        self._scopes = token_data["scopes"]
+
                     # Parse expires_at (RFC3339 format)
-                    if 'expires_at' in token_data:
+                    if "expires_at" in token_data:
                         try:
-                            expires_str = token_data['expires_at']
+                            expires_str = token_data["expires_at"]
                             # Handle various ISO 8601 formats
-                            if expires_str.endswith('Z'):
-                                expires_str = expires_str.replace('Z', '+00:00')
+                            if expires_str.endswith("Z"):
+                                expires_str = expires_str.replace("Z", "+00:00")
                             # Python 3.10 fromisoformat supports max 6 decimal places (microseconds)
                             # kiro-cli writes nanoseconds (9 digits) — truncate to 6
-                            expires_str = re.sub(r'(\.\d{6})\d+', r'\1', expires_str)
+                            expires_str = re.sub(r"(\.\d{6})\d+", r"\1", expires_str)
                             self._expires_at = datetime.fromisoformat(expires_str)
                         except Exception as e:
                             logger.warning(f"Failed to parse expires_at from SQLite: {e}")
-            
+
             # Load device registration (client_id, client_secret) - try all possible keys
             registration_row = None
             for key in SQLITE_REGISTRATION_KEYS:
@@ -317,17 +317,17 @@ class KiroAuthManager:
                 if registration_row:
                     logger.debug(f"Loaded device registration from SQLite key: {key}")
                     break
-            
+
             if registration_row:
                 registration_data = json.loads(registration_row[0])
                 if registration_data:
-                    if 'client_id' in registration_data:
-                        self._client_id = registration_data['client_id']
-                    if 'client_secret' in registration_data:
-                        self._client_secret = registration_data['client_secret']
+                    if "client_id" in registration_data:
+                        self._client_id = registration_data["client_id"]
+                    if "client_secret" in registration_data:
+                        self._client_secret = registration_data["client_secret"]
                     # SSO region from registration (fallback if not in token data)
-                    if 'region' in registration_data and not self._sso_region:
-                        self._sso_region = registration_data['region']
+                    if "region" in registration_data and not self._sso_region:
+                        self._sso_region = registration_data["region"]
                         logger.debug(f"SSO region from device-registration: {self._sso_region}")
 
             # Try to auto-detect API region from profile ARN in state table
@@ -348,7 +348,7 @@ class KiroAuthManager:
                         parts = arn.split(":")
                         if len(parts) >= 4 and parts[3]:
                             # Validate region format (e.g., us-east-1, eu-central-1)
-                            if re.match(r'^[a-z]+-[a-z]+-\d+$', parts[3]):
+                            if re.match(r"^[a-z]+-[a-z]+-\d+$", parts[3]):
                                 self._detected_api_region = parts[3]
                                 logger.info(f"API region auto-detected from profile ARN: {parts[3]}")
                             else:
@@ -362,34 +362,34 @@ class KiroAuthManager:
 
             conn.close()
             logger.info(f"Credentials loaded from SQLite database: {db_path}")
-            
+
         except sqlite3.Error as e:
             logger.error(f"SQLite error loading credentials: {e}")
         except json.JSONDecodeError as e:
             logger.error(f"JSON decode error in SQLite data: {e}")
         except Exception as e:
             logger.error(f"Error loading credentials from SQLite: {e}")
-    
+
     def _load_credentials_from_file(self, file_path: str) -> None:
         """
         Loads credentials from a JSON file.
-        
+
         Supported JSON fields (Kiro Desktop):
         - refreshToken: Refresh token
         - accessToken: Access token (if already available)
         - profileArn: Profile ARN
         - region: AWS region
         - expiresAt: Token expiration time (ISO 8601)
-        
+
         Additional fields for AWS SSO OIDC (kiro-cli):
         - clientId: OAuth client ID
         - clientSecret: OAuth client secret
-        
+
         For Enterprise Kiro IDE:
         - clientIdHash: Hash of client ID (Enterprise Kiro IDE)
         - When clientIdHash is present, automatically loads clientId and clientSecret
           from ~/.aws/sso/cache/{clientIdHash}.json (device registration file)
-        
+
         Args:
             file_path: Path to JSON file
         """
@@ -398,151 +398,151 @@ class KiroAuthManager:
             if not path.exists():
                 logger.warning(f"Credentials file not found: {file_path}")
                 return
-            
-            with open(path, 'r', encoding='utf-8') as f:
+
+            with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            
+
             # Load common data from file
-            if 'refreshToken' in data:
-                self._refresh_token = data['refreshToken']
-            if 'accessToken' in data:
-                self._access_token = data['accessToken']
-            if 'profileArn' in data:
-                self._profile_arn = data['profileArn']
-            if 'region' in data:
+            if "refreshToken" in data:
+                self._refresh_token = data["refreshToken"]
+            if "accessToken" in data:
+                self._access_token = data["accessToken"]
+            if "profileArn" in data:
+                self._profile_arn = data["profileArn"]
+            if "region" in data:
                 # Store as SSO region for OIDC token refresh
-                self._sso_region = data['region']
+                self._sso_region = data["region"]
                 # Also use as detected API region (can be overridden by KIRO_API_REGION env var)
-                self._detected_api_region = data['region']
+                self._detected_api_region = data["region"]
                 logger.debug(f"Region from JSON credentials: {data['region']}")
-            
+
             # Load clientIdHash and device registration for Enterprise Kiro IDE
-            if 'clientIdHash' in data:
-                self._client_id_hash = data['clientIdHash']
+            if "clientIdHash" in data:
+                self._client_id_hash = data["clientIdHash"]
                 self._load_enterprise_device_registration(self._client_id_hash)
-            
+
             # Load AWS SSO OIDC specific fields (if directly in credentials file)
-            if 'clientId' in data:
-                self._client_id = data['clientId']
-            if 'clientSecret' in data:
-                self._client_secret = data['clientSecret']
-            
+            if "clientId" in data:
+                self._client_id = data["clientId"]
+            if "clientSecret" in data:
+                self._client_secret = data["clientSecret"]
+
             # Parse expiresAt
-            if 'expiresAt' in data:
+            if "expiresAt" in data:
                 try:
-                    expires_str = data['expiresAt']
+                    expires_str = data["expiresAt"]
                     # Support for different date formats
-                    if expires_str.endswith('Z'):
-                        self._expires_at = datetime.fromisoformat(expires_str.replace('Z', '+00:00'))
+                    if expires_str.endswith("Z"):
+                        self._expires_at = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
                     else:
                         self._expires_at = datetime.fromisoformat(expires_str)
                 except Exception as e:
                     logger.warning(f"Failed to parse expiresAt: {e}")
-            
+
             logger.info(f"Credentials loaded from {file_path}")
-            
+
         except Exception as e:
             logger.error(f"Error loading credentials from file: {e}")
-    
+
     def _load_enterprise_device_registration(self, client_id_hash: str) -> None:
         """
         Loads clientId and clientSecret from Enterprise Kiro IDE device registration file.
-        
+
         Enterprise Kiro IDE uses AWS SSO OIDC authentication. Device registration is stored at:
         ~/.aws/sso/cache/{clientIdHash}.json
-        
+
         Args:
             client_id_hash: Client ID hash used to locate the device registration file
         """
         try:
             device_reg_path = Path.home() / ".aws" / "sso" / "cache" / f"{client_id_hash}.json"
-            
+
             if not device_reg_path.exists():
                 logger.warning(f"Enterprise device registration file not found: {device_reg_path}")
                 return
-            
-            with open(device_reg_path, 'r', encoding='utf-8') as f:
+
+            with open(device_reg_path, "r", encoding="utf-8") as f:
                 device_data = json.load(f)
-            
-            if 'clientId' in device_data:
-                self._client_id = device_data['clientId']
-            
-            if 'clientSecret' in device_data:
-                self._client_secret = device_data['clientSecret']
-            
+
+            if "clientId" in device_data:
+                self._client_id = device_data["clientId"]
+
+            if "clientSecret" in device_data:
+                self._client_secret = device_data["clientSecret"]
+
             logger.info(f"Enterprise device registration loaded from {device_reg_path}")
-            
+
         except Exception as e:
             logger.error(f"Error loading enterprise device registration: {e}")
-    
+
     def _save_credentials_to_file(self) -> None:
         """
         Saves updated credentials to a JSON file.
-        
+
         Updates the existing file while preserving other fields.
         """
         if not self._creds_file:
             return
-        
+
         try:
             path = Path(self._creds_file).expanduser()
-            
+
             # Read existing data
             existing_data = {}
             if path.exists():
-                with open(path, 'r', encoding='utf-8') as f:
+                with open(path, "r", encoding="utf-8") as f:
                     existing_data = json.load(f)
-            
+
             # Update data
-            existing_data['accessToken'] = self._access_token
-            existing_data['refreshToken'] = self._refresh_token
+            existing_data["accessToken"] = self._access_token
+            existing_data["refreshToken"] = self._refresh_token
             if self._expires_at:
-                existing_data['expiresAt'] = self._expires_at.isoformat()
+                existing_data["expiresAt"] = self._expires_at.isoformat()
             if self._profile_arn:
-                existing_data['profileArn'] = self._profile_arn
-            
+                existing_data["profileArn"] = self._profile_arn
+
             # Save
-            with open(path, 'w', encoding='utf-8') as f:
+            with open(path, "w", encoding="utf-8") as f:
                 json.dump(existing_data, f, indent=2, ensure_ascii=False)
-            
+
             logger.debug(f"Credentials saved to {self._creds_file}")
-            
+
         except Exception as e:
             logger.error(f"Error saving credentials: {e}")
-    
+
     def _save_credentials_to_sqlite(self) -> None:
         """
         Saves updated credentials back to SQLite database.
-        
+
         Strategy: Read-Merge-Write (Issue #131 fix)
         1. Read existing JSON from SQLite
         2. Merge only updated fields (access_token, refresh_token, expires_at)
         3. Preserve all unknown fields (startUrl, provider, registrationExpiresAt, etc.)
         4. Write back merged JSON
-        
+
         This ensures compatibility with kiro-cli and future schema changes.
         Unknown fields from kiro-cli are preserved, preventing data loss.
-        
+
         Respects SQLITE_READONLY flag - when enabled, skips write-back entirely.
         """
         if not self._sqlite_db:
             return
-        
+
         # Check read-only mode
         if SQLITE_READONLY:
             logger.debug("SQLite write-back disabled (SQLITE_READONLY=true)")
             return
-        
+
         try:
             path = Path(self._sqlite_db).expanduser()
             if not path.exists():
                 logger.warning(f"SQLite database not found for writing: {self._sqlite_db}")
                 return
-            
+
             # Use timeout to avoid blocking if database is locked
             conn = sqlite3.connect(str(path), timeout=5.0)
             cursor = conn.cursor()
-            
+
             # Try to save to the known key first (if we have it)
             if self._sqlite_token_key:
                 if self._try_save_to_key(cursor, self._sqlite_token_key):
@@ -552,7 +552,7 @@ class KiroAuthManager:
                     return
                 else:
                     logger.warning(f"Failed to save to primary key: {self._sqlite_token_key}, trying fallback")
-            
+
             # Fallback: try all keys (for edge cases where source key is unknown or deleted)
             for key in SQLITE_TOKEN_KEYS:
                 if self._try_save_to_key(cursor, key):
@@ -560,24 +560,24 @@ class KiroAuthManager:
                     conn.close()
                     logger.debug(f"Credentials saved to SQLite key: {key} (fallback, merged)")
                     return
-            
+
             # If we get here, no keys were updated
             conn.close()
-            logger.warning(f"Failed to save credentials to SQLite: no matching keys found")
-            
+            logger.warning("Failed to save credentials to SQLite: no matching keys found")
+
         except sqlite3.Error as e:
             logger.error(f"SQLite error saving credentials: {e}")
         except Exception as e:
             logger.error(f"Error saving credentials to SQLite: {e}")
-    
+
     def _try_save_to_key(self, cursor: sqlite3.Cursor, key: str) -> bool:
         """
         Attempts to save credentials to a specific SQLite key using read-merge-write.
-        
+
         Args:
             cursor: SQLite cursor
             key: SQLite key to save to
-        
+
         Returns:
             True if save was successful, False otherwise
         """
@@ -585,82 +585,79 @@ class KiroAuthManager:
             # Read existing data
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", (key,))
             row = cursor.fetchone()
-            
+
             if not row:
                 return False
-            
+
             # Parse existing JSON
             try:
                 existing_data = json.loads(row[0])
             except json.JSONDecodeError as e:
                 logger.warning(f"Failed to parse JSON for key {key}, skipping: {e}")
                 return False
-            
+
             # Merge: update ONLY our fields, preserve EVERYTHING else
             existing_data["access_token"] = self._access_token
             existing_data["refresh_token"] = self._refresh_token
             existing_data["expires_at"] = self._expires_at.isoformat() if self._expires_at else None
             existing_data["region"] = self._sso_region or self._region
-            
+
             # Update scopes if we have them
             if self._scopes:
                 existing_data["scopes"] = self._scopes
-            
+
             token_json = json.dumps(existing_data)
-            
+
             # Write back merged data
-            cursor.execute(
-                "UPDATE auth_kv SET value = ? WHERE key = ?",
-                (token_json, key)
-            )
-            
+            cursor.execute("UPDATE auth_kv SET value = ? WHERE key = ?", (token_json, key))
+
             return cursor.rowcount > 0
-            
+
         except Exception as e:
             logger.debug(f"Failed to save to key {key}: {e}")
             return False
-    
+
     def is_token_expiring_soon(self) -> bool:
         """
         Checks if the token is expiring soon.
-        
+
         Returns:
             True if the token expires within TOKEN_REFRESH_THRESHOLD seconds
             or if expiration time information is not available
         """
         if not self._expires_at:
             return True  # If no expiration info available, assume refresh is needed
-        
+
         now = datetime.now(timezone.utc)
         threshold = now.timestamp() + TOKEN_REFRESH_THRESHOLD
-        
+
         return self._expires_at.timestamp() <= threshold
-    
+
     def is_token_expired(self) -> bool:
         """
         Checks if the token is actually expired (not just expiring soon).
-        
+
         This is used for graceful degradation when refresh fails but
         the access token might still be valid for a short time.
-        
+
         Returns:
             True if the token has already expired or if expiration time
             information is not available
         """
         if not self._expires_at:
             return True  # If no expiration info available, assume expired
-        
+
         now = datetime.now(timezone.utc)
         return now >= self._expires_at
-    
+
     async def _refresh_token_request(self) -> None:
         """
         Performs a token refresh request.
-        
+
         Routes to appropriate refresh method based on auth type:
         - KIRO_DESKTOP: Uses Kiro Desktop Auth endpoint
         - AWS_SSO_OIDC: Uses AWS SSO OIDC endpoint
-        
+
         Raises:
             ValueError: If refresh token is not set or response doesn't contain accessToken
             httpx.HTTPError: On HTTP request error
@@ -669,85 +666,82 @@ class KiroAuthManager:
             await self._refresh_token_aws_sso_oidc()
         else:
             await self._refresh_token_kiro_desktop()
-    
+
     async def _refresh_token_kiro_desktop(self) -> None:
         """
         Refreshes token using Kiro Desktop Auth endpoint.
-        
+
         Endpoint: https://prod.{region}.auth.desktop.kiro.dev/refreshToken
         Method: POST
         Content-Type: application/json
         Body: {"refreshToken": "..."}
-        
+
         Raises:
             ValueError: If refresh token is not set or response doesn't contain accessToken
             httpx.HTTPError: On HTTP request error
         """
         if not self._refresh_token:
             raise ValueError("Refresh token is not set")
-        
+
         logger.info("Refreshing Kiro token via Kiro Desktop Auth...")
-        
-        payload = {'refreshToken': self._refresh_token}
+
+        payload = {"refreshToken": self._refresh_token}
         headers = {
             "Content-Type": "application/json",
             "User-Agent": f"KiroIDE-0.7.45-{self._fingerprint}",
         }
-        
+
         async with httpx.AsyncClient(timeout=30) as client:
             response = await client.post(self._refresh_url, json=payload, headers=headers)
             response.raise_for_status()
             data = response.json()
-        
+
         new_access_token = data.get("accessToken")
         new_refresh_token = data.get("refreshToken")
         expires_in = data.get("expiresIn", 3600)
         new_profile_arn = data.get("profileArn")
-        
+
         if not new_access_token:
             raise ValueError(f"Response does not contain accessToken: {data}")
-        
+
         # Update data
         self._access_token = new_access_token
         if new_refresh_token:
             self._refresh_token = new_refresh_token
         if new_profile_arn:
             self._profile_arn = new_profile_arn
-        
+
         # Calculate expiration time with buffer (minus 60 seconds)
         self._expires_at = datetime.now(timezone.utc).replace(microsecond=0)
-        self._expires_at = datetime.fromtimestamp(
-            self._expires_at.timestamp() + expires_in - 60,
-            tz=timezone.utc
-        )
-        
+        self._expires_at = datetime.fromtimestamp(self._expires_at.timestamp() + expires_in - 60, tz=timezone.utc)
+
         logger.info(f"Token refreshed via Kiro Desktop Auth, expires: {self._expires_at.isoformat()}")
-        
+
         # Save to file or SQLite depending on configuration
         if self._sqlite_db:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
-    
+
     async def _refresh_token_aws_sso_oidc(self) -> None:
         """
         Refreshes token using AWS SSO OIDC endpoint.
-        
+
         Used by kiro-cli which authenticates via AWS IAM Identity Center.
-        
+
         Strategy: Try with current in-memory token first. If it fails with 400
         (invalid_request - token was invalidated by kiro-cli re-login), reload
         credentials from SQLite and retry once.
-        
+
         This approach handles both scenarios:
         1. Container successfully refreshed token (uses in-memory token)
         2. kiro-cli re-login invalidated token (reloads from SQLite on failure)
-        
+
         Endpoint: https://oidc.{region}.amazonaws.com/token
         Method: POST
         Content-Type: application/x-www-form-urlencoded
         Body: grant_type=refresh_token&client_id=...&client_secret=...&refresh_token=...
-        
+
         Raises:
             ValueError: If required credentials are not set
             httpx.HTTPError: On HTTP request error
@@ -762,19 +756,19 @@ class KiroAuthManager:
                 await self._do_aws_sso_oidc_refresh()
             else:
                 raise
-    
+
     async def _do_aws_sso_oidc_refresh(self) -> None:
         """
         Performs the actual AWS SSO OIDC token refresh.
-        
+
         This is the internal implementation called by _refresh_token_aws_sso_oidc().
         It performs a single refresh attempt with current in-memory credentials.
-        
+
         Uses AWS SSO OIDC CreateToken API format:
         - Content-Type: application/json (not form-urlencoded)
         - Parameter names: camelCase (clientId, not client_id)
         - Payload: JSON object
-        
+
         Raises:
             ValueError: If required credentials are not set
             httpx.HTTPStatusError: On HTTP error (including 400 for invalid token)
@@ -785,14 +779,14 @@ class KiroAuthManager:
             raise ValueError("Client ID is not set (required for AWS SSO OIDC)")
         if not self._client_secret:
             raise ValueError("Client secret is not set (required for AWS SSO OIDC)")
-        
+
         logger.info("Refreshing Kiro token via AWS SSO OIDC...")
-        
+
         # AWS SSO OIDC CreateToken API uses JSON with camelCase parameters
         # Use SSO region for OIDC endpoint (may differ from API region)
         sso_region = self._sso_region or self._region
         url = get_aws_sso_oidc_url(sso_region)
-        
+
         # IMPORTANT: AWS SSO OIDC CreateToken API requires:
         # 1. JSON payload (not form-urlencoded)
         # 2. camelCase parameter names (clientId, not client_id)
@@ -802,75 +796,75 @@ class KiroAuthManager:
             "clientSecret": self._client_secret,
             "refreshToken": self._refresh_token,
         }
-        
+
         headers = {
             "Content-Type": "application/json",
         }
-        
+
         # Log request details (without secrets) for debugging
-        logger.debug(f"AWS SSO OIDC refresh request: url={url}, sso_region={sso_region}, "
-                     f"api_region={self._region}, client_id={self._client_id[:8]}...")
-        
+        logger.debug(
+            f"AWS SSO OIDC refresh request: url={url}, sso_region={sso_region}, "
+            f"api_region={self._region}, client_id={self._client_id[:8]}..."
+        )
+
         async with httpx.AsyncClient(timeout=30) as client:
             response = await client.post(url, json=payload, headers=headers)
-            
+
             # Log response details for debugging (especially on errors)
             if response.status_code != 200:
                 error_body = response.text
-                logger.error(f"AWS SSO OIDC refresh failed: status={response.status_code}, "
-                             f"body={error_body}")
+                logger.error(f"AWS SSO OIDC refresh failed: status={response.status_code}, body={error_body}")
                 # Try to parse AWS error for more details
                 try:
                     error_json = response.json()
                     error_code = error_json.get("error", "unknown")
                     error_desc = error_json.get("error_description", "no description")
-                    logger.error(f"AWS SSO OIDC error details: error={error_code}, "
-                                 f"description={error_desc}")
+                    logger.error(f"AWS SSO OIDC error details: error={error_code}, description={error_desc}")
                 except Exception:
                     pass  # Body wasn't JSON, already logged as text
                 response.raise_for_status()
-            
+
             result = response.json()
-        
+
         # AWS SSO OIDC CreateToken API returns camelCase fields
         new_access_token = result.get("accessToken")
         new_refresh_token = result.get("refreshToken")
         expires_in = result.get("expiresIn", 3600)
-        
+
         if not new_access_token:
             raise ValueError(f"AWS SSO OIDC response does not contain accessToken: {result}")
-        
+
         # Update data
         self._access_token = new_access_token
         if new_refresh_token:
             self._refresh_token = new_refresh_token
-        
+
         # Calculate expiration time with buffer (minus 60 seconds)
         self._expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in - 60)
-        
+
         logger.info(f"Token refreshed via AWS SSO OIDC, expires: {self._expires_at.isoformat()}")
-        
+
         # Save to file or SQLite depending on configuration
         if self._sqlite_db:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
-    
+
     async def get_access_token(self) -> str:
         """
         Returns a valid access_token, refreshing it if necessary.
-        
+
         Thread-safe method using asyncio.Lock.
         Automatically refreshes the token if it has expired or is about to expire.
-        
+
         For SQLite mode (kiro-cli): implements graceful degradation when refresh fails.
         If kiro-cli has been running and refreshing tokens in memory (without persisting
         to SQLite), the refresh_token in SQLite becomes stale. In this case, we fall back
         to using the access_token directly until it actually expires.
-        
+
         Returns:
             Valid access token
-        
+
         Raises:
             ValueError: If unable to obtain access token
         """
@@ -878,7 +872,7 @@ class KiroAuthManager:
             # Token is valid and not expiring soon - just return it
             if self._access_token and not self.is_token_expiring_soon():
                 return self._access_token
-            
+
             # SQLite mode: reload credentials first, kiro-cli might have updated them
             if self._sqlite_db and self.is_token_expiring_soon():
                 logger.debug("SQLite mode: reloading credentials before refresh attempt")
@@ -887,7 +881,7 @@ class KiroAuthManager:
                 if self._access_token and not self.is_token_expiring_soon():
                     logger.debug("SQLite reload provided fresh token, no refresh needed")
                     return self._access_token
-            
+
             # Try to refresh the token
             try:
                 await self._refresh_token_request()
@@ -908,58 +902,57 @@ class KiroAuthManager:
                         return self._access_token
                     else:
                         raise ValueError(
-                            "Token expired and refresh failed. "
-                            "Please run 'kiro-cli login' to refresh your credentials."
+                            "Token expired and refresh failed. Please run 'kiro-cli login' to refresh your credentials."
                         )
                 # Non-SQLite mode or non-400 error - propagate the exception
                 raise
             except Exception:
                 # For any other exception, propagate it
                 raise
-            
+
             if not self._access_token:
                 raise ValueError("Failed to obtain access token")
-            
+
             return self._access_token
-    
+
     async def force_refresh(self) -> str:
         """
         Forces a token refresh.
-        
+
         Used when receiving a 403 error from the API.
-        
+
         Returns:
             New access token
         """
         async with self._lock:
             await self._refresh_token_request()
             return self._access_token
-    
+
     @property
     def profile_arn(self) -> Optional[str]:
         """AWS CodeWhisperer profile ARN."""
         return self._profile_arn
-    
+
     @property
     def region(self) -> str:
         """AWS region."""
         return self._region
-    
+
     @property
     def api_host(self) -> str:
         """API host for the current region."""
         return self._api_host
-    
+
     @property
     def q_host(self) -> str:
         """Q API host for the current region."""
         return self._q_host
-    
+
     @property
     def fingerprint(self) -> str:
         """Unique machine fingerprint."""
         return self._fingerprint
-    
+
     @property
     def auth_type(self) -> AuthType:
         """Authentication type (KIRO_DESKTOP or AWS_SSO_OIDC)."""

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -926,6 +926,7 @@ class KiroAuthManager:
         """
         async with self._lock:
             await self._refresh_token_request()
+            assert self._access_token is not None
             return self._access_token
 
     @property

--- a/kiro/cache.py
+++ b/kiro/cache.py
@@ -12,30 +12,30 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 
-from kiro.config import MODEL_CACHE_TTL, DEFAULT_MAX_INPUT_TOKENS
+from kiro.config import DEFAULT_MAX_INPUT_TOKENS, MODEL_CACHE_TTL
 
 
 class ModelInfoCache:
     """
     Thread-safe cache for storing model metadata.
-    
+
     Uses Lazy Loading for population - data is loaded
     only on first access or when cache is stale.
-    
+
     Attributes:
         cache_ttl: Cache time-to-live in seconds
-    
+
     Example:
         >>> cache = ModelInfoCache()
         >>> await cache.update([{"modelId": "claude-sonnet-4", "tokenLimits": {...}}])
         >>> info = cache.get("claude-sonnet-4")
         >>> max_tokens = cache.get_max_input_tokens("claude-sonnet-4")
     """
-    
+
     def __init__(self, cache_ttl: int = MODEL_CACHE_TTL):
         """
         Initializes the model cache.
-        
+
         Args:
             cache_ttl: Cache time-to-live in seconds (default from config)
         """
@@ -43,13 +43,13 @@ class ModelInfoCache:
         self._lock = asyncio.Lock()
         self._last_update: Optional[float] = None
         self._cache_ttl = cache_ttl
-    
+
     async def update(self, models_data: List[Dict[str, Any]]) -> None:
         """
         Updates the model cache.
-        
+
         Thread-safely replaces cache contents with new data.
-        
+
         Args:
             models_data: List of dictionaries with model information.
                         Each dictionary must contain the "modelId" key.
@@ -58,41 +58,41 @@ class ModelInfoCache:
             logger.info(f"Updating model cache. Found {len(models_data)} models.")
             self._cache = {model["modelId"]: model for model in models_data}
             self._last_update = time.time()
-    
+
     def get(self, model_id: str) -> Optional[Dict[str, Any]]:
         """
         Returns model information.
-        
+
         Args:
             model_id: Model ID
-        
+
         Returns:
             Dictionary with model information or None if model not found
         """
         return self._cache.get(model_id)
-    
+
     def is_valid_model(self, model_id: str) -> bool:
         """
         Check if model exists in dynamic cache.
-        
+
         Used by ModelResolver to verify if a model is available.
-        
+
         Args:
             model_id: Model ID to check
-        
+
         Returns:
             True if model exists in cache, False otherwise
         """
         return model_id in self._cache
-    
+
     def add_hidden_model(self, display_name: str, internal_id: str) -> None:
         """
         Add a hidden model to the cache.
-        
+
         Hidden models are not returned by Kiro /ListAvailableModels API
         but are still functional. They are added to the cache so they
         appear in our /v1/models endpoint.
-        
+
         Args:
             display_name: Model name to display (e.g., "claude-3.7-sonnet")
             internal_id: Internal Kiro ID (e.g., "CLAUDE_3_7_SONNET_20250219_V1_0")
@@ -107,14 +107,14 @@ class ModelInfoCache:
                 "_is_hidden": True,  # Mark as hidden model
             }
             logger.debug(f"Added hidden model: {display_name} → {internal_id}")
-    
+
     def get_max_input_tokens(self, model_id: str) -> int:
         """
         Returns maxInputTokens for the model.
-        
+
         Args:
             model_id: Model ID
-        
+
         Returns:
             Maximum number of input tokens or DEFAULT_MAX_INPUT_TOKENS
         """
@@ -122,20 +122,20 @@ class ModelInfoCache:
         if model and model.get("tokenLimits"):
             return model["tokenLimits"].get("maxInputTokens") or DEFAULT_MAX_INPUT_TOKENS
         return DEFAULT_MAX_INPUT_TOKENS
-    
+
     def is_empty(self) -> bool:
         """
         Checks if the cache is empty.
-        
+
         Returns:
             True if cache is empty
         """
         return not self._cache
-    
+
     def is_stale(self) -> bool:
         """
         Checks if the cache is stale.
-        
+
         Returns:
             True if cache is stale (more than cache_ttl seconds have passed)
             or if cache was never updated
@@ -143,21 +143,21 @@ class ModelInfoCache:
         if not self._last_update:
             return True
         return time.time() - self._last_update > self._cache_ttl
-    
+
     def get_all_model_ids(self) -> List[str]:
         """
         Returns a list of all model IDs in the cache.
-        
+
         Returns:
             List of model IDs
         """
         return list(self._cache.keys())
-    
+
     @property
     def size(self) -> int:
         """Number of models in the cache."""
         return len(self._cache)
-    
+
     @property
     def last_update_time(self) -> Optional[float]:
         """Last update time (timestamp) or None."""

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -10,6 +10,7 @@ import os
 import re
 from pathlib import Path
 from typing import Dict, List, Optional
+
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -19,44 +20,45 @@ load_dotenv()
 def _get_raw_env_value(var_name: str, env_file: str = ".env") -> Optional[str]:
     """
     Read variable value from .env file without processing escape sequences.
-    
+
     This is necessary for correct handling of Windows paths where backslashes
     (e.g., D:\\Projects\\file.json) may be incorrectly interpreted
     as escape sequences (\\a -> bell, \\n -> newline, etc.).
-    
+
     Args:
         var_name: Environment variable name
         env_file: Path to .env file (default ".env")
-    
+
     Returns:
         Raw variable value or None if not found
     """
     env_path = Path(env_file)
     if not env_path.exists():
         return None
-    
+
     try:
         # Read file as-is, without interpretation
         content = env_path.read_text(encoding="utf-8")
-        
+
         # Search for variable considering different formats:
         # VAR="value" or VAR='value' or VAR=value
         # Pattern captures value with or without quotes
         pattern = rf'^{re.escape(var_name)}=(["\']?)(.+?)\1\s*$'
-        
+
         for line in content.splitlines():
             line = line.strip()
             if line.startswith("#") or not line:
                 continue
-            
+
             match = re.match(pattern, line)
             if match:
                 # Return value as-is, without processing escape sequences
                 return match.group(2)
     except Exception:
         pass
-    
+
     return None
+
 
 # ==================================================================================================
 # Server Settings
@@ -389,12 +391,8 @@ def _bounded_debug_int(
     return value
 
 
-DEBUG_CAPTURE_CONTENT: bool = (
-    os.getenv("DEBUG_CAPTURE_CONTENT", "false").lower() == "true"
-)
-DEBUG_CAPTURE_SUCCESS: bool = (
-    os.getenv("DEBUG_CAPTURE_SUCCESS", "false").lower() == "true"
-)
+DEBUG_CAPTURE_CONTENT: bool = os.getenv("DEBUG_CAPTURE_CONTENT", "false").lower() == "true"
+DEBUG_CAPTURE_SUCCESS: bool = os.getenv("DEBUG_CAPTURE_SUCCESS", "false").lower() == "true"
 DEBUG_CAPTURE_MAX_BYTES: int = _bounded_debug_int(
     "DEBUG_CAPTURE_MAX_BYTES",
     4 * 1024 * 1024,
@@ -413,32 +411,34 @@ def _warn_timeout_configuration():
     """
     Print warning if timeout configuration is suboptimal.
     Called at application startup.
-    
+
     FIRST_TOKEN_TIMEOUT should be less than STREAMING_READ_TIMEOUT:
     - FIRST_TOKEN_TIMEOUT: time to wait for model to START responding
     - STREAMING_READ_TIMEOUT: time to wait BETWEEN chunks during streaming
     """
     if FIRST_TOKEN_TIMEOUT >= STREAMING_READ_TIMEOUT:
         import sys
+
         YELLOW = "\033[93m"
         RESET = "\033[0m"
-        
+
         warning_text = f"""
 {YELLOW}⚠️  WARNING: Suboptimal timeout configuration detected.
-    
+
     FIRST_TOKEN_TIMEOUT ({FIRST_TOKEN_TIMEOUT}s) >= STREAMING_READ_TIMEOUT ({STREAMING_READ_TIMEOUT}s)
-    
+
     These timeouts serve different purposes:
       - FIRST_TOKEN_TIMEOUT: time to wait for model to START responding (default: 15s)
       - STREAMING_READ_TIMEOUT: time to wait BETWEEN chunks during streaming (default: 300s)
-    
+
     Recommendation: FIRST_TOKEN_TIMEOUT should be LESS than STREAMING_READ_TIMEOUT.
-    
+
     Example configuration:
       FIRST_TOKEN_TIMEOUT=15
       STREAMING_READ_TIMEOUT=300{RESET}
 """
         print(warning_text, file=sys.stderr)
+
 
 # ==================================================================================================
 # Payload Size Guard Settings
@@ -562,7 +562,9 @@ USAGE_REFRESH_INTERVAL_SECONDS: int = int(os.getenv("USAGE_REFRESH_INTERVAL_SECO
 
 APP_VERSION: str = "0.1.0"
 APP_TITLE: str = "kiro-lb"
-APP_DESCRIPTION: str = "Private Kiro API load balancer. OpenAI and Anthropic compatible; never fabricates reasoning content."
+APP_DESCRIPTION: str = (
+    "Private Kiro API load balancer. OpenAI and Anthropic compatible; never fabricates reasoning content."
+)
 
 
 def get_kiro_refresh_url(region: str) -> str:
@@ -585,4 +587,3 @@ def get_kiro_q_host(region: str, is_builder_id: bool = False) -> str:
     """Return the Q API host for the region, routing Builder ID to Q Developer."""
     template = KIRO_BUILDER_ID_HOST_TEMPLATE if is_builder_id else KIRO_Q_HOST_TEMPLATE
     return template.format(region=region)
-

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -365,11 +365,12 @@ FIRST_TOKEN_MAX_RETRIES: int = int(os.getenv("FIRST_TOKEN_MAX_RETRIES", "3"))
 # - errors: save logs only for failed requests (4xx, 5xx)
 # - all: save logs for every request (overwrites on each request)
 _DEBUG_MODE_RAW: str = os.getenv("DEBUG_MODE", "").lower()
+DEBUG_MODE: str
 
 if _DEBUG_MODE_RAW in ("off", "errors", "all"):
-    DEBUG_MODE: str = _DEBUG_MODE_RAW
+    DEBUG_MODE = _DEBUG_MODE_RAW
 else:
-    DEBUG_MODE: str = "off"
+    DEBUG_MODE = "off"
 
 # Directory for debug log files
 DEBUG_DIR: str = os.getenv("DEBUG_DIR", "debug_logs")

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -187,8 +187,6 @@ def extract_images_from_tool_results(content: Any) -> List[Dict[str, Any]]:
 
     return images
 
-    return tool_results
-
 
 def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any]]:
     """

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -107,7 +107,7 @@ def extract_tool_results_from_anthropic_content(content: Any) -> List[Dict[str, 
     Returns:
         List of tool results in unified format
     """
-    tool_results = []
+    tool_results: List[Dict[str, Any]] = []
 
     if not isinstance(content, list):
         return tool_results
@@ -200,7 +200,7 @@ def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any
     Returns:
         List of tool calls in unified format
     """
-    tool_calls = []
+    tool_calls: List[Dict[str, Any]] = []
 
     if not isinstance(content, list):
         return tool_calls

--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -11,20 +11,20 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 
 from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
-from kiro.model_resolver import get_model_id_for_kiro
-from kiro.native_thinking import apply_native_thinking, effort_from_anthropic
-from kiro.models_anthropic import (
-    AnthropicMessagesRequest,
-    AnthropicMessage,
-    AnthropicTool,
-)
 from kiro.converters_core import (
     UnifiedMessage,
     UnifiedTool,
     build_kiro_payload,
-    extract_text_content,
     extract_images_from_content,
+    extract_text_content,
 )
+from kiro.model_resolver import get_model_id_for_kiro
+from kiro.models_anthropic import (
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+    AnthropicTool,
+)
+from kiro.native_thinking import apply_native_thinking, effort_from_anthropic
 
 
 def convert_anthropic_content_to_text(content: Any) -> str:
@@ -229,9 +229,7 @@ def extract_tool_uses_from_anthropic_content(content: Any) -> List[Dict[str, Any
                     "type": "function",
                     "function": {
                         "name": tool_name,
-                        "arguments": tool_input
-                        if isinstance(tool_input, str)
-                        else tool_input,
+                        "arguments": tool_input if isinstance(tool_input, str) else tool_input,
                     },
                 }
             )
@@ -347,12 +345,9 @@ def convert_anthropic_tools(
             description = tool.description
             input_schema = tool.input_schema
 
-        unified_tools.append(
-            UnifiedTool(name=name, description=description, input_schema=input_schema)
-        )
+        unified_tools.append(UnifiedTool(name=name, description=description, input_schema=input_schema))
 
     return unified_tools if unified_tools else None
-
 
 
 def split_inline_system_messages(messages: List[Any]) -> tuple[List[Any], List[str]]:
@@ -384,9 +379,7 @@ def split_inline_system_messages(messages: List[Any]) -> tuple[List[Any], List[s
     return conversation, system_fragments
 
 
-def anthropic_to_kiro(
-    request: AnthropicMessagesRequest, conversation_id: str, profile_arn: str
-) -> dict:
+def anthropic_to_kiro(request: AnthropicMessagesRequest, conversation_id: str, profile_arn: str) -> dict:
     """
     Converts Anthropic Messages API request to Kiro API payload.
 

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -13,31 +13,31 @@ to convert their formats to Kiro API format.
 """
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from loguru import logger
 
 from kiro.config import (
-    TOOL_DESCRIPTION_MAX_LENGTH,
-    KIRO_MAX_PAYLOAD_BYTES,
     AUTO_TRIM_PAYLOAD,
+    KIRO_MAX_PAYLOAD_BYTES,
+    TOOL_DESCRIPTION_MAX_LENGTH,
 )
 from kiro.payload_guards import check_payload_size, trim_payload_to_limit
-
 
 # ==================================================================================================
 # Data Classes for Unified Message Format
 # ==================================================================================================
 
+
 @dataclass
 class UnifiedMessage:
     """
     Unified message format used internally by converters.
-    
+
     This format is API-agnostic and can be created from both OpenAI and Anthropic formats.
     Serves as the canonical representation for all message data before conversion to Kiro API.
-    
+
     Attributes:
         role: Message role (user, assistant, system)
         content: Text content or list of content blocks
@@ -46,6 +46,7 @@ class UnifiedMessage:
         images: List of images in unified format (for multimodal user messages)
                 Format: [{"media_type": "image/jpeg", "data": "base64..."}]
     """
+
     role: str
     content: Any = ""
     tool_calls: Optional[List[Dict[str, Any]]] = None
@@ -57,12 +58,13 @@ class UnifiedMessage:
 class UnifiedTool:
     """
     Unified tool format used internally by converters.
-    
+
     Attributes:
         name: Tool name
         description: Tool description
         input_schema: JSON Schema for tool parameters
     """
+
     name: str
     description: Optional[str] = None
     input_schema: Optional[Dict[str, Any]] = None
@@ -72,11 +74,12 @@ class UnifiedTool:
 class KiroPayloadResult:
     """
     Result of building Kiro payload.
-    
+
     Attributes:
         payload: The complete Kiro API payload
         tool_documentation: Documentation for tools with long descriptions (to add to system prompt)
     """
+
     payload: Dict[str, Any]
     tool_documentation: str = ""
 
@@ -85,21 +88,22 @@ class KiroPayloadResult:
 # Text Content Extraction
 # ==================================================================================================
 
+
 def extract_text_content(content: Any) -> str:
     """
     Extracts text content from various formats.
-    
+
     Supports multiple content formats used by different APIs:
     - String: "Hello, world!"
     - List of content blocks: [{"type": "text", "text": "Hello"}]
     - None: empty message
-    
+
     Args:
         content: Content in any supported format
-    
+
     Returns:
         Extracted text or empty string
-    
+
     Example:
         >>> extract_text_content("Hello")
         'Hello'
@@ -135,31 +139,31 @@ def extract_text_content(content: Any) -> str:
 def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts images from message content in unified format.
-    
+
     Supports multiple image formats used by different APIs:
-    
+
     OpenAI format (image_url with data URL):
         {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,/9j/..."}}
-    
+
     Anthropic format (image with source):
         {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "/9j/..."}}
-    
+
     Args:
         content: Content in any supported format (usually a list of content blocks)
-    
+
     Returns:
         List of images in unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
         Empty list if no images found or content is not a list.
-    
+
     Example:
         >>> extract_images_from_content([{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "abc123"}}])
         [{'media_type': 'image/png', 'data': 'abc123'}]
     """
     images: List[Dict[str, Any]] = []
-    
+
     if not isinstance(content, list):
         return images
-    
+
     for item in content:
         # Handle both dict and Pydantic model objects
         if isinstance(item, dict):
@@ -168,21 +172,21 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
             item_type = item.type
         else:
             continue
-        
+
         # OpenAI format: {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
         if item_type == "image_url":
             if isinstance(item, dict):
                 image_url_obj = item.get("image_url", {})
             else:
                 image_url_obj = getattr(item, "image_url", {})
-            
+
             if isinstance(image_url_obj, dict):
                 url = image_url_obj.get("url", "")
             elif hasattr(image_url_obj, "url"):
                 url = image_url_obj.url
             else:
                 url = ""
-            
+
             if url.startswith("data:"):
                 # Parse data URL: data:image/jpeg;base64,/9j/4AAQ...
                 try:
@@ -190,60 +194,51 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
                     # Extract media type from "data:image/jpeg;base64"
                     media_part = header.split(";")[0]  # "data:image/jpeg"
                     media_type = media_part.replace("data:", "")  # "image/jpeg"
-                    
+
                     if data:
-                        images.append({
-                            "media_type": media_type,
-                            "data": data
-                        })
+                        images.append({"media_type": media_type, "data": data})
                 except (ValueError, IndexError) as e:
                     logger.warning(f"Failed to parse image data URL: {e}")
             elif url.startswith("http"):
                 # URL-based images require fetching - not supported by Kiro API directly
                 logger.warning(f"URL-based images are not supported by Kiro API, skipping: {url[:80]}...")
-        
+
         # Anthropic format: {"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}
         elif item_type == "image":
             source = item.get("source", {}) if isinstance(item, dict) else getattr(item, "source", None)
-            
+
             if source is None:
                 continue
-            
+
             if isinstance(source, dict):
                 source_type = source.get("type")
-                
+
                 if source_type == "base64":
                     media_type = source.get("media_type", "image/jpeg")
                     data = source.get("data", "")
-                    
+
                     if data:
-                        images.append({
-                            "media_type": media_type,
-                            "data": data
-                        })
+                        images.append({"media_type": media_type, "data": data})
                 elif source_type == "url":
                     # URL-based images in Anthropic format
                     url = source.get("url", "")
                     logger.warning(f"URL-based images are not supported by Kiro API, skipping: {url[:80]}...")
-            
+
             # Handle Pydantic model objects (ImageContentBlock.source)
             elif hasattr(source, "type"):
                 if source.type == "base64":
                     media_type = getattr(source, "media_type", "image/jpeg")
                     data = getattr(source, "data", "")
-                    
+
                     if data:
-                        images.append({
-                            "media_type": media_type,
-                            "data": data
-                        })
+                        images.append({"media_type": media_type, "data": data})
                 elif source.type == "url":
                     url = getattr(source, "url", "")
                     logger.warning(f"URL-based images are not supported by Kiro API, skipping: {url[:80]}...")
-    
+
     if images:
         logger.debug(f"Extracted {len(images)} image(s) from content")
-    
+
     return images
 
 
@@ -251,36 +246,37 @@ def extract_images_from_content(content: Any) -> List[Dict[str, Any]]:
 # JSON Schema Sanitization
 # ==================================================================================================
 
+
 def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Sanitizes JSON Schema from fields that Kiro API doesn't accept.
-    
+
     Kiro API returns 400 "Improperly formed request" error if:
     - required is an empty array []
     - additionalProperties is present in schema
-    
+
     This function recursively processes the schema and removes problematic fields.
-    
+
     Args:
         schema: JSON Schema to sanitize
-    
+
     Returns:
         Sanitized copy of schema
     """
     if not schema:
         return {}
-    
+
     result = {}
-    
+
     for key, value in schema.items():
         # Skip empty required arrays
         if key == "required" and isinstance(value, list) and len(value) == 0:
             continue
-        
+
         # Skip additionalProperties - Kiro API doesn't support it
         if key == "additionalProperties":
             continue
-        
+
         # Recursively process nested objects
         if key == "properties" and isinstance(value, dict):
             result[key] = {
@@ -291,13 +287,10 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             result[key] = sanitize_json_schema(value)
         elif isinstance(value, list):
             # Process lists (e.g., anyOf, oneOf)
-            result[key] = [
-                sanitize_json_schema(item) if isinstance(item, dict) else item
-                for item in value
-            ]
+            result[key] = [sanitize_json_schema(item) if isinstance(item, dict) else item for item in value]
         else:
             result[key] = value
-    
+
     return result
 
 
@@ -305,19 +298,18 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 # Tool Processing
 # ==================================================================================================
 
-def process_tools_with_long_descriptions(
-    tools: Optional[List[UnifiedTool]]
-) -> Tuple[Optional[List[UnifiedTool]], str]:
+
+def process_tools_with_long_descriptions(tools: Optional[List[UnifiedTool]]) -> Tuple[Optional[List[UnifiedTool]], str]:
     """
     Processes tools with long descriptions.
-    
+
     Kiro API has a limit on description length in toolSpecification.
     If description exceeds the limit, full description is moved to system prompt,
     and a reference to documentation remains in the tool.
-    
+
     Args:
         tools: List of tools in unified format
-    
+
     Returns:
         Tuple of:
         - List of tools with processed descriptions (or None if tools is empty)
@@ -325,17 +317,17 @@ def process_tools_with_long_descriptions(
     """
     if not tools:
         return None, ""
-    
+
     # If limit is disabled (0), return tools unchanged
     if TOOL_DESCRIPTION_MAX_LENGTH <= 0:
         return tools, ""
-    
+
     tool_documentation_parts = []
     processed_tools = []
-    
+
     for tool in tools:
         description = tool.description or ""
-        
+
         if len(description) <= TOOL_DESCRIPTION_MAX_LENGTH:
             # Description is short - leave as is
             processed_tools.append(tool)
@@ -345,20 +337,18 @@ def process_tools_with_long_descriptions(
                 f"Tool '{tool.name}' has long description ({len(description)} chars > {TOOL_DESCRIPTION_MAX_LENGTH}), "
                 f"moving to system prompt"
             )
-            
+
             # Create documentation for system prompt
             tool_documentation_parts.append(f"## Tool: {tool.name}\n\n{description}")
-            
+
             # Create copy of tool with reference description
             reference_description = f"[Full documentation in system prompt under '## Tool: {tool.name}']"
-            
+
             processed_tool = UnifiedTool(
-                name=tool.name,
-                description=reference_description,
-                input_schema=tool.input_schema
+                name=tool.name, description=reference_description, input_schema=tool.input_schema
             )
             processed_tools.append(processed_tool)
-    
+
     # Form final documentation
     tool_documentation = ""
     if tool_documentation_parts:
@@ -368,23 +358,23 @@ def process_tools_with_long_descriptions(
             "The following tools have detailed documentation that couldn't fit in the tool definition.\n\n"
             + "\n\n---\n\n".join(tool_documentation_parts)
         )
-    
+
     return processed_tools if processed_tools else None, tool_documentation
 
 
 def validate_tool_names(tools: Optional[List[UnifiedTool]]) -> None:
     """
     Validates tool names against Kiro API 64-character limit.
-    
+
     Logs WARNING for each problematic tool and raises ValueError
     with complete list of violations.
-    
+
     Args:
         tools: List of tools to validate
-    
+
     Raises:
         ValueError: If any tool name exceeds 64 characters
-    
+
     Example:
         >>> validate_tool_names([UnifiedTool(name="short_name", description="test")])
         # No error
@@ -393,19 +383,16 @@ def validate_tool_names(tools: Optional[List[UnifiedTool]]) -> None:
     """
     if not tools:
         return
-    
+
     problematic_tools = []
     for tool in tools:
         if len(tool.name) > 64:
             problematic_tools.append((tool.name, len(tool.name)))
-    
+
     if problematic_tools:
         # Build detailed error message for client (no logging here - routes will log)
-        tool_list = "\n".join([
-            f"  - '{name}' ({length} characters)"
-            for name, length in problematic_tools
-        ])
-        
+        tool_list = "\n".join([f"  - '{name}' ({length} characters)" for name, length in problematic_tools])
+
         raise ValueError(
             f"Tool name(s) exceed Kiro API limit of 64 characters:\n"
             f"{tool_list}\n\n"
@@ -417,35 +404,37 @@ def validate_tool_names(tools: Optional[List[UnifiedTool]]) -> None:
 def convert_tools_to_kiro_format(tools: Optional[List[UnifiedTool]]) -> List[Dict[str, Any]]:
     """
     Converts unified tools to Kiro API format.
-    
+
     Args:
         tools: List of tools in unified format
-    
+
     Returns:
         List of tools in Kiro toolSpecification format
     """
     if not tools:
         return []
-    
+
     kiro_tools = []
     for tool in tools:
         # Sanitize parameters from fields that Kiro API doesn't accept
         sanitized_params = sanitize_json_schema(tool.input_schema)
-        
+
         # Kiro API requires non-empty description
         description = tool.description
         if not description or not description.strip():
             description = f"Tool: {tool.name}"
             logger.debug(f"Tool '{tool.name}' has empty description, using placeholder")
-        
-        kiro_tools.append({
-            "toolSpecification": {
-                "name": tool.name,
-                "description": description,
-                "inputSchema": {"json": sanitized_params}
+
+        kiro_tools.append(
+            {
+                "toolSpecification": {
+                    "name": tool.name,
+                    "description": description,
+                    "inputSchema": {"json": sanitized_params},
+                }
             }
-        })
-    
+        )
+
     return kiro_tools
 
 
@@ -453,41 +442,42 @@ def convert_tools_to_kiro_format(tools: Optional[List[UnifiedTool]]) -> List[Dic
 # Image Conversion to Kiro Format
 # ==================================================================================================
 
+
 def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
     """
     Converts unified images to Kiro API format.
-    
+
     Unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
     Kiro format: [{"format": "jpeg", "source": {"bytes": "base64..."}}]
-    
+
     IMPORTANT: Images must be placed directly in userInputMessage.images,
     NOT in userInputMessageContext.images. This matches the native Kiro IDE format.
-    
+
     Also handles the case where data contains a full data URL (data:image/jpeg;base64,...)
     by stripping the prefix and extracting pure base64.
-    
+
     Args:
         images: List of images in unified format
-    
+
     Returns:
         List of images in Kiro format, ready for userInputMessage.images
-    
+
     Example:
         >>> convert_images_to_kiro_format([{"media_type": "image/png", "data": "abc123"}])
         [{'format': 'png', 'source': {'bytes': 'abc123'}}]
     """
     if not images:
         return []
-    
+
     kiro_images = []
     for img in images:
         media_type = img.get("media_type", "image/jpeg")
         data = img.get("data", "")
-        
+
         if not data:
             logger.warning("Skipping image with empty data")
             continue
-        
+
         # Strip data URL prefix if present (some clients send "data:image/jpeg;base64,..." in data field)
         # Kiro API expects pure base64 without the prefix
         if data.startswith("data:"):
@@ -502,20 +492,15 @@ def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> Lis
                 logger.debug(f"Stripped data URL prefix, extracted media_type: {media_type}")
             except (ValueError, IndexError) as e:
                 logger.warning(f"Failed to parse data URL prefix: {e}")
-        
+
         # Extract format from media_type: "image/jpeg" -> "jpeg"
         format_str = media_type.split("/")[-1] if "/" in media_type else media_type
-        
-        kiro_images.append({
-            "format": format_str,
-            "source": {
-                "bytes": data
-            }
-        })
-    
+
+        kiro_images.append({"format": format_str, "source": {"bytes": data}})
+
     if kiro_images:
         logger.debug(f"Converted {len(kiro_images)} image(s) to Kiro format")
-    
+
     return kiro_images
 
 
@@ -523,16 +508,17 @@ def convert_images_to_kiro_format(images: Optional[List[Dict[str, Any]]]) -> Lis
 # Tool Results and Tool Uses Extraction
 # ==================================================================================================
 
+
 def convert_tool_results_to_kiro_format(tool_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Converts unified tool results to Kiro API format.
-    
+
     Unified format: {"type": "tool_result", "tool_use_id": "...", "content": "..."}
     Kiro format: {"content": [{"text": "..."}], "status": "success", "toolUseId": "..."}
-    
+
     Args:
         tool_results: List of tool results in unified format
-    
+
     Returns:
         List of tool results in Kiro format
     """
@@ -543,67 +529,70 @@ def convert_tool_results_to_kiro_format(tool_results: List[Dict[str, Any]]) -> L
             content_text = content
         else:
             content_text = extract_text_content(content)
-        
+
         # Ensure content is not empty - Kiro API requires non-empty content
         if not content_text:
             content_text = "(empty result)"
-        
-        kiro_results.append({
-            "content": [{"text": content_text}],
-            "status": "error" if tr.get("is_error") else "success",
-            "toolUseId": tr.get("tool_use_id", "")
-        })
-    
+
+        kiro_results.append(
+            {
+                "content": [{"text": content_text}],
+                "status": "error" if tr.get("is_error") else "success",
+                "toolUseId": tr.get("tool_use_id", ""),
+            }
+        )
+
     return kiro_results
 
 
 def extract_tool_results_from_content(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool results from message content.
-    
+
     Looks for content blocks with type="tool_result" and converts them
     to Kiro API format.
-    
+
     Args:
         content: Message content (can be a list of content blocks)
-    
+
     Returns:
         List of tool results in Kiro format
     """
     tool_results = []
-    
+
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_result":
-                tool_results.append({
-                    "content": [{"text": extract_text_content(item.get("content", "")) or "(empty result)"}],
-                    "status": "success",
-                    "toolUseId": item.get("tool_use_id", "")
-                })
-    
+                tool_results.append(
+                    {
+                        "content": [{"text": extract_text_content(item.get("content", "")) or "(empty result)"}],
+                        "status": "success",
+                        "toolUseId": item.get("tool_use_id", ""),
+                    }
+                )
+
     return tool_results
 
 
 def extract_tool_uses_from_message(
-    content: Any,
-    tool_calls: Optional[List[Dict[str, Any]]] = None
+    content: Any, tool_calls: Optional[List[Dict[str, Any]]] = None
 ) -> List[Dict[str, Any]]:
     """
     Extracts tool uses from assistant message.
-    
+
     Looks for tool calls in both:
     - tool_calls field (OpenAI format)
     - content blocks with type="tool_use" (Anthropic format)
-    
+
     Args:
         content: Message content
         tool_calls: List of tool calls (OpenAI format)
-    
+
     Returns:
         List of tool uses in Kiro format
     """
     tool_uses = []
-    
+
     # From tool_calls field (OpenAI format or unified format from Anthropic)
     if tool_calls:
         for tc in tool_calls:
@@ -615,22 +604,16 @@ def extract_tool_uses_from_message(
                     input_data = json.loads(arguments) if arguments else {}
                 else:
                     input_data = arguments if arguments else {}
-                tool_uses.append({
-                    "name": func.get("name", ""),
-                    "input": input_data,
-                    "toolUseId": tc.get("id", "")
-                })
-    
+                tool_uses.append({"name": func.get("name", ""), "input": input_data, "toolUseId": tc.get("id", "")})
+
     # From content blocks (Anthropic format)
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_use":
-                tool_uses.append({
-                    "name": item.get("name", ""),
-                    "input": item.get("input", {}),
-                    "toolUseId": item.get("id", "")
-                })
-    
+                tool_uses.append(
+                    {"name": item.get("name", ""), "input": item.get("input", {}), "toolUseId": item.get("id", "")}
+                )
+
     return tool_uses
 
 
@@ -638,84 +621,85 @@ def extract_tool_uses_from_message(
 # Tool Content to Text Conversion (for stripping when no tools defined)
 # ==================================================================================================
 
+
 def tool_calls_to_text(tool_calls: List[Dict[str, Any]]) -> str:
     """
     Converts tool_calls to human-readable text representation.
-    
+
     This is used when stripping tool content from messages (when no tools are defined).
     Instead of losing the context, we convert tool calls to text so the model
     can still understand what happened in the conversation.
-    
+
     Args:
         tool_calls: List of tool calls in unified format
-    
+
     Returns:
         Text representation of tool calls
-    
+
     Example:
         >>> tool_calls_to_text([{"id": "call_123", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}])
         '[Tool: bash] (call_123)\\n{"command": "ls"}'
     """
     if not tool_calls:
         return ""
-    
+
     parts = []
     for tc in tool_calls:
         func = tc.get("function", {})
         name = func.get("name", "unknown")
         arguments = func.get("arguments", "{}")
         tool_id = tc.get("id", "")
-        
+
         # Format: [Tool: name] (id)\narguments
         if tool_id:
             parts.append(f"[Tool: {name} ({tool_id})]\n{arguments}")
         else:
             parts.append(f"[Tool: {name}]\n{arguments}")
-    
+
     return "\n\n".join(parts)
 
 
 def tool_results_to_text(tool_results: List[Dict[str, Any]]) -> str:
     """
     Converts tool_results to human-readable text representation.
-    
+
     This is used when stripping tool content from messages (when no tools are defined).
     Instead of losing the context, we convert tool results to text so the model
     can still understand what happened in the conversation.
-    
+
     Args:
         tool_results: List of tool results in unified format
-    
+
     Returns:
         Text representation of tool results
-    
+
     Example:
         >>> tool_results_to_text([{"tool_use_id": "call_123", "content": "file1.txt\\nfile2.txt"}])
         '[Tool Result] (call_123)\\nfile1.txt\\nfile2.txt'
     """
     if not tool_results:
         return ""
-    
+
     parts = []
     for tr in tool_results:
         content = tr.get("content", "")
         tool_use_id = tr.get("tool_use_id", "")
-        
+
         if isinstance(content, str):
             content_text = content
         else:
             content_text = extract_text_content(content)
-        
+
         # Use placeholder if content is empty
         if not content_text:
             content_text = "(empty result)"
-        
+
         # Format: [Tool Result] (id)\ncontent
         if tool_use_id:
             parts.append(f"[Tool Result ({tool_use_id})]\n{content_text}")
         else:
             parts.append(f"[Tool Result]\n{content_text}")
-    
+
     return "\n\n".join(parts)
 
 
@@ -723,20 +707,21 @@ def tool_results_to_text(tool_results: List[Dict[str, Any]]) -> str:
 # Message Merging
 # ==================================================================================================
 
+
 def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[UnifiedMessage], bool]:
     """
     Strips ALL tool-related content from messages, converting it to text representation.
-    
+
     This is used when no tools are defined in the request. Kiro API rejects
     requests that have toolResults but no tools defined.
-    
+
     Instead of simply removing tool content, this function converts tool_calls
     and tool_results to human-readable text, preserving the context for
     summarization and other use cases.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         Tuple of:
         - List of messages with tool content converted to text
@@ -744,85 +729,81 @@ def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[Unified
     """
     if not messages:
         return [], False
-    
+
     result = []
     total_tool_calls_stripped = 0
     total_tool_results_stripped = 0
-    
+
     for msg in messages:
         # Check if this message has any tool content
         has_tool_calls = bool(msg.tool_calls)
         has_tool_results = bool(msg.tool_results)
-        
+
         if has_tool_calls or has_tool_results:
             if has_tool_calls:
                 total_tool_calls_stripped += len(msg.tool_calls)
             if has_tool_results:
                 total_tool_results_stripped += len(msg.tool_results)
-            
+
             # Start with existing text content
             existing_content = extract_text_content(msg.content)
             content_parts = []
-            
+
             if existing_content:
                 content_parts.append(existing_content)
-            
+
             # Convert tool_calls to text (for assistant messages)
             if has_tool_calls:
                 tool_text = tool_calls_to_text(msg.tool_calls)
                 if tool_text:
                     content_parts.append(tool_text)
-            
+
             # Convert tool_results to text (for user messages)
             if has_tool_results:
                 result_text = tool_results_to_text(msg.tool_results)
                 if result_text:
                     content_parts.append(result_text)
-            
+
             # Join all parts with double newline
             content = "\n\n".join(content_parts)
-            
+
             # Create a copy of the message without tool content but with text representation
             # IMPORTANT: Preserve images from the original message (e.g., screenshots from MCP tools)
             cleaned_msg = UnifiedMessage(
-                role=msg.role,
-                content=content,
-                tool_calls=None,
-                tool_results=None,
-                images=msg.images
+                role=msg.role, content=content, tool_calls=None, tool_results=None, images=msg.images
             )
             result.append(cleaned_msg)
         else:
             result.append(msg)
-    
+
     had_tool_content = total_tool_calls_stripped > 0 or total_tool_results_stripped > 0
-    
+
     # Log summary once (DEBUG level - this is normal for clients like Cline/Roo/Cursor)
     if had_tool_content:
         logger.debug(
             f"Converted tool content to text (no tools defined): "
             f"{total_tool_calls_stripped} tool_calls, {total_tool_results_stripped} tool_results"
         )
-    
+
     return result, had_tool_content
 
 
 def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tuple[List[UnifiedMessage], bool]:
     """
     Ensures that messages with tool_results have a preceding assistant message with tool_calls.
-    
+
     Kiro API requires that when toolResults are present, there must be a preceding
     assistantResponseMessage with toolUses. Some clients (like Cline/Roo/Cursor) may send
     truncated conversations where the assistant message is missing.
-    
+
     Since we don't know the original tool name and arguments when the assistant message
     is missing, we cannot create a valid synthetic assistant message. Instead, we convert
     the tool_results to text representation and append to the message content, preserving
     the context for the model while avoiding Kiro API rejection.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         Tuple of:
         - List of messages with orphaned tool_results converted to text
@@ -830,20 +811,16 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
     """
     if not messages:
         return [], False
-    
+
     result = []
     converted_any_tool_results = False
-    
+
     for msg in messages:
         # Check if this message has tool_results
         if msg.tool_results:
             # Check if the previous message is an assistant with tool_calls
-            has_preceding_assistant = (
-                result and
-                result[-1].role == "assistant" and
-                result[-1].tool_calls
-            )
-            
+            has_preceding_assistant = result and result[-1].role == "assistant" and result[-1].tool_calls
+
             if not has_preceding_assistant:
                 # We cannot create a valid synthetic assistant message because we don't know
                 # the original tool name and arguments. Kiro API validates tool names.
@@ -853,10 +830,10 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
                     f"(no preceding assistant message with tool_calls). "
                     f"Tool IDs: {[tr.get('tool_use_id', 'unknown') for tr in msg.tool_results]}"
                 )
-                
+
                 # Convert tool_results to text representation
                 tool_results_text = tool_results_to_text(msg.tool_results)
-                
+
                 # Append to existing content
                 original_content = extract_text_content(msg.content) or ""
                 if original_content and tool_results_text:
@@ -865,51 +842,51 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
                     new_content = tool_results_text
                 else:
                     new_content = original_content
-                
+
                 # Create a copy of the message with tool_results converted to text
                 cleaned_msg = UnifiedMessage(
                     role=msg.role,
                     content=new_content,
                     tool_calls=msg.tool_calls,
                     tool_results=None,  # Remove orphaned tool_results (now in text)
-                    images=msg.images
+                    images=msg.images,
                 )
                 result.append(cleaned_msg)
                 converted_any_tool_results = True
                 continue
-        
+
         result.append(msg)
-    
+
     return result, converted_any_tool_results
 
 
 def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessage]:
     """
     Merges adjacent messages with the same role.
-    
+
     Kiro API does not accept multiple consecutive messages from the same role.
     This function merges such messages into one.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         List of messages with merged adjacent messages
     """
     if not messages:
         return []
-    
+
     merged = []
     # Statistics for summary logging
     merge_counts = {"user": 0, "assistant": 0}
     total_tool_calls_merged = 0
     total_tool_results_merged = 0
-    
+
     for msg in messages:
         if not merged:
             merged.append(msg)
             continue
-        
+
         last = merged[-1]
         if msg.role == last.role:
             # Merge content
@@ -923,27 +900,27 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
                 last_text = extract_text_content(last.content)
                 current_text = extract_text_content(msg.content)
                 last.content = f"{last_text}\n{current_text}"
-            
+
             # Merge tool_calls for assistant messages
             if msg.role == "assistant" and msg.tool_calls:
                 if last.tool_calls is None:
                     last.tool_calls = []
                 last.tool_calls = list(last.tool_calls) + list(msg.tool_calls)
                 total_tool_calls_merged += len(msg.tool_calls)
-            
+
             # Merge tool_results for user messages
             if msg.role == "user" and msg.tool_results:
                 if last.tool_results is None:
                     last.tool_results = []
                 last.tool_results = list(last.tool_results) + list(msg.tool_results)
                 total_tool_results_merged += len(msg.tool_results)
-            
+
             # Count merges by role
             if msg.role in merge_counts:
                 merge_counts[msg.role] += 1
         else:
             merged.append(msg)
-    
+
     # Log summary if any merges occurred
     total_merges = sum(merge_counts.values())
     if total_merges > 0:
@@ -952,39 +929,39 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
             if count > 0:
                 parts.append(f"{count} {role}")
         merge_summary = ", ".join(parts)
-        
+
         extras = []
         if total_tool_calls_merged > 0:
             extras.append(f"{total_tool_calls_merged} tool_calls")
         if total_tool_results_merged > 0:
             extras.append(f"{total_tool_results_merged} tool_results")
-        
+
         if extras:
             logger.debug(f"Merged {total_merges} adjacent messages ({merge_summary}), including {', '.join(extras)}")
         else:
             logger.debug(f"Merged {total_merges} adjacent messages ({merge_summary})")
-    
+
     return merged
 
 
 def ensure_first_message_is_user(messages: List[UnifiedMessage]) -> List[UnifiedMessage]:
     """
     Ensures that the first message in the conversation is from user role.
-    
+
     Kiro API requires conversations to start with a user message. If the first
     message is from assistant (or any other non-user role), we prepend a minimal
     synthetic user message.
-    
+
     This matches LiteLLM behavior for Anthropic API compatibility and fixes
     issue #60 where conversations starting with assistant messages cause
     "Improperly formed request" errors.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         List of messages with guaranteed user-first order
-    
+
     Example:
         >>> messages = [
         ...     UnifiedMessage(role="assistant", content="Hello"),
@@ -998,7 +975,7 @@ def ensure_first_message_is_user(messages: List[UnifiedMessage]) -> List[Unified
     """
     if not messages:
         return messages
-    
+
     if messages[0].role != "user":
         logger.debug(
             f"First message is '{messages[0].role}', prepending synthetic user message "
@@ -1007,30 +984,30 @@ def ensure_first_message_is_user(messages: List[UnifiedMessage]) -> List[Unified
         # Synthetic turns carry no text: upstream accepts empty content, and any
         # literal here is read by the model as a real user instruction.
         synthetic_user = UnifiedMessage(role="user", content="")
-        
+
         return [synthetic_user] + messages
-    
+
     return messages
 
 
 def normalize_message_roles(messages: List[UnifiedMessage]) -> List[UnifiedMessage]:
     """
     Normalizes unknown message roles to 'user'.
-    
+
     Kiro API only supports 'user' and 'assistant' roles in history.
     Any other role (e.g., 'developer', 'system') is converted to 'user'
     to maintain compatibility.
-    
+
     This normalization MUST happen before ensure_alternating_roles()
     to ensure consecutive messages with unknown roles are properly detected
     and synthetic assistant messages are inserted between them.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         List of messages with normalized roles
-    
+
     Example:
         >>> messages = [
         ...     UnifiedMessage(role="developer", content="Context 1"),
@@ -1043,10 +1020,10 @@ def normalize_message_roles(messages: List[UnifiedMessage]) -> List[UnifiedMessa
     """
     if not messages:
         return messages
-    
+
     normalized = []
     converted_count = 0
-    
+
     for msg in messages:
         if msg.role not in ("user", "assistant"):
             logger.debug(f"Normalizing role '{msg.role}' to 'user'")
@@ -1055,36 +1032,36 @@ def normalize_message_roles(messages: List[UnifiedMessage]) -> List[UnifiedMessa
                 content=msg.content,
                 tool_calls=msg.tool_calls,
                 tool_results=msg.tool_results,
-                images=msg.images
+                images=msg.images,
             )
             normalized.append(normalized_msg)
             converted_count += 1
         else:
             normalized.append(msg)
-    
+
     if converted_count > 0:
         logger.debug(f"Normalized {converted_count} message(s) with unknown roles to 'user'")
-    
+
     return normalized
 
 
 def ensure_alternating_roles(messages: List[UnifiedMessage]) -> List[UnifiedMessage]:
     """
     Ensures alternating user/assistant roles by inserting synthetic assistant messages.
-    
+
     Kiro API requires alternating userInputMessage and assistantResponseMessage.
     When consecutive user messages are detected, synthetic assistant messages
     with empty content are inserted between them to maintain alternation.
-    
+
     This fixes multiple unknown roles (converted to user)
     create consecutive userInputMessage entries that violate Kiro API requirements.
-    
+
     Args:
         messages: List of messages in unified format
-    
+
     Returns:
         List of messages with synthetic assistant messages inserted where needed
-    
+
     Example:
         >>> messages = [
         ...     UnifiedMessage(role="user", content="First"),
@@ -1101,24 +1078,24 @@ def ensure_alternating_roles(messages: List[UnifiedMessage]) -> List[UnifiedMess
     """
     if not messages or len(messages) < 2:
         return messages
-    
+
     result = [messages[0]]
     synthetic_count = 0
-    
+
     for msg in messages[1:]:
         prev_role = result[-1].role
-        
+
         # If both current and previous are user → insert synthetic assistant
         if msg.role == "user" and prev_role == "user":
             synthetic_assistant = UnifiedMessage(role="assistant", content="")
             result.append(synthetic_assistant)
             synthetic_count += 1
-        
+
         result.append(msg)
-    
+
     if synthetic_count > 0:
         logger.debug(f"Inserted {synthetic_count} synthetic assistant message(s) to ensure alternation")
-    
+
     return result
 
 
@@ -1126,35 +1103,36 @@ def ensure_alternating_roles(messages: List[UnifiedMessage]) -> List[UnifiedMess
 # Kiro History Building
 # ==================================================================================================
 
+
 def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Dict[str, Any]]:
     """
     Builds history array for Kiro API from unified messages.
-    
+
     Kiro API expects alternating userInputMessage and assistantResponseMessage.
     This function converts unified format to Kiro format.
-    
+
     All messages should have 'user' or 'assistant' roles at this point,
     as unknown roles are normalized earlier in the pipeline by normalize_message_roles().
-    
+
     Args:
         messages: List of messages in unified format (with normalized roles)
         model_id: Internal Kiro model ID
-    
+
     Returns:
         List of dictionaries for history field in Kiro API
     """
     history = []
-    
+
     for msg in messages:
         if msg.role == "user":
             content = extract_text_content(msg.content)
-            
+
             user_input = {
                 "content": content,
                 "modelId": model_id,
                 "origin": "AI_EDITOR",
             }
-            
+
             # Process images - extract from message or content
             # IMPORTANT: images go directly into userInputMessage, NOT into userInputMessageContext
             # This matches the native Kiro IDE format
@@ -1163,10 +1141,10 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
                 kiro_images = convert_images_to_kiro_format(images)
                 if kiro_images:
                     user_input["images"] = kiro_images
-            
+
             # Build userInputMessageContext for tools and toolResults only
             user_input_context: Dict[str, Any] = {}
-            
+
             # Process tool_results - convert to Kiro format if present
             if msg.tool_results:
                 kiro_tool_results = convert_tool_results_to_kiro_format(msg.tool_results)
@@ -1177,31 +1155,32 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
                 tool_results = extract_tool_results_from_content(msg.content)
                 if tool_results:
                     user_input_context["toolResults"] = tool_results
-            
+
             # Add context if not empty (contains toolResults only, not images)
             if user_input_context:
                 user_input["userInputMessageContext"] = user_input_context
-            
+
             history.append({"userInputMessage": user_input})
-            
+
         elif msg.role == "assistant":
             content = extract_text_content(msg.content)
-            
+
             assistant_response = {"content": content}
-            
+
             # Process tool_calls
             tool_uses = extract_tool_uses_from_message(msg.content, msg.tool_calls)
             if tool_uses:
                 assistant_response["toolUses"] = tool_uses
-            
+
             history.append({"assistantResponseMessage": assistant_response})
-    
+
     return history
 
 
 # ==================================================================================================
 # Main Payload Building
 # ==================================================================================================
+
 
 def build_kiro_payload(
     messages: List[UnifiedMessage],
@@ -1213,10 +1192,10 @@ def build_kiro_payload(
 ) -> KiroPayloadResult:
     """
     Builds complete payload for Kiro API from unified data.
-    
+
     This is the main function that assembles the Kiro API payload from
     API-agnostic unified message and tool formats.
-    
+
     Args:
         messages: List of messages in unified format (without system messages)
         system_prompt: Already extracted system prompt
@@ -1224,24 +1203,26 @@ def build_kiro_payload(
         tools: List of tools in unified format (or None)
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
-    
+
     Returns:
         KiroPayloadResult with payload and tool documentation
-    
+
     Raises:
         ValueError: If there are no messages to send
     """
     # Process tools with long descriptions
     processed_tools, tool_documentation = process_tools_with_long_descriptions(tools)
-    
+
     # Validate tool names against Kiro API 64-character limit
     validate_tool_names(processed_tools)
-    
+
     # Add tool documentation to system prompt if present
     full_system_prompt = system_prompt
     if tool_documentation:
-        full_system_prompt = full_system_prompt + tool_documentation if full_system_prompt else tool_documentation.strip()
-    
+        full_system_prompt = (
+            full_system_prompt + tool_documentation if full_system_prompt else tool_documentation.strip()
+        )
+
     # If no tools are defined, strip ALL tool-related content from messages
     # Kiro API rejects requests with toolResults but no tools
     if not tools:
@@ -1252,56 +1233,52 @@ def build_kiro_payload(
         # Ensure assistant messages exist before tool_results (Kiro API requirement)
         # Also returns flag if any tool_results were converted (to skip thinking tag injection)
         messages_with_assistants, converted_tool_results = ensure_assistant_before_tool_results(messages)
-    
+
     # Merge adjacent messages with the same role
     merged_messages = merge_adjacent_messages(messages_with_assistants)
-    
+
     # Ensure first message is from user (Kiro API requirement, fixes issue #60)
     merged_messages = ensure_first_message_is_user(merged_messages)
-    
+
     # Normalize unknown roles to 'user' (fixes issue #64)
     # This must happen BEFORE ensure_alternating_roles() so that consecutive
     # messages with unknown roles (e.g., 'developer') are properly detected
     merged_messages = normalize_message_roles(merged_messages)
-    
+
     # Ensure alternating user/assistant roles (fixes issue #64)
     # Insert synthetic assistant messages between consecutive user messages
     merged_messages = ensure_alternating_roles(merged_messages)
-    
+
     if not merged_messages:
         raise ValueError("No messages to send")
-    
+
     # Build history (all messages except the last one)
     history_messages = merged_messages[:-1] if len(merged_messages) > 1 else []
-    
+
     # If there's a system prompt, add it to the first user message in history
     if full_system_prompt and history_messages:
         first_msg = history_messages[0]
         if first_msg.role == "user":
             original_content = extract_text_content(first_msg.content)
             first_msg.content = f"{full_system_prompt}\n\n{original_content}"
-    
+
     history = build_kiro_history(history_messages, model_id)
-    
+
     # Current message (the last one)
     current_message = merged_messages[-1]
     current_content = extract_text_content(current_message.content)
-    
+
     # If system prompt exists but history is empty - add to current message
     if full_system_prompt and not history:
         current_content = f"{full_system_prompt}\n\n{current_content}"
-    
+
     # If current message is assistant, need to add it to history
     # and create user message placeholder
     if current_message.role == "assistant":
-        history.append({
-            "assistantResponseMessage": {
-                "content": current_content
-            }
-        })
+        history.append({"assistantResponseMessage": {"content": current_content}})
         # No filler text: the assistant turn above is the prompt to continue.
         current_content = ""
-    
+
     # Process images in current message - extract from message or content
     # IMPORTANT: images go directly into userInputMessage, NOT into userInputMessageContext
     # This matches the native Kiro IDE format
@@ -1311,15 +1288,15 @@ def build_kiro_payload(
         kiro_images = convert_images_to_kiro_format(images)
         if kiro_images:
             logger.debug(f"Added {len(kiro_images)} image(s) to current message")
-    
+
     # Build user_input_context for tools and toolResults only (NOT images)
     user_input_context: Dict[str, Any] = {}
-    
+
     # Add tools if present
     kiro_tools = convert_tools_to_kiro_format(processed_tools)
     if kiro_tools:
         user_input_context["tools"] = kiro_tools
-    
+
     # Process tool_results in current message - convert to Kiro format if present
     if current_message.tool_results:
         # Convert unified format to Kiro format
@@ -1331,37 +1308,35 @@ def build_kiro_payload(
         tool_results = extract_tool_results_from_content(current_message.content)
         if tool_results:
             user_input_context["toolResults"] = tool_results
-    
+
     # Build userInputMessage
     user_input_message = {
         "content": current_content,
         "modelId": model_id,
         "origin": "AI_EDITOR",
     }
-    
+
     # Add images directly to userInputMessage (NOT to userInputMessageContext)
     if kiro_images:
         user_input_message["images"] = kiro_images
-    
+
     # Add user_input_context if present (contains tools and toolResults only)
     if user_input_context:
         user_input_message["userInputMessageContext"] = user_input_context
-    
+
     # Assemble final payload
     payload = {
         "conversationState": {
             "chatTriggerType": "MANUAL",
             "conversationId": conversation_id,
-            "currentMessage": {
-                "userInputMessage": user_input_message
-            }
+            "currentMessage": {"userInputMessage": user_input_message},
         }
     }
-    
+
     # Add history only if not empty
     if history:
         payload["conversationState"]["history"] = history
-    
+
     # Add profileArn
     if profile_arn:
         payload["profileArn"] = profile_arn

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -266,7 +266,7 @@ def sanitize_json_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if not schema:
         return {}
 
-    result = {}
+    result: Dict[str, Any] = {}
 
     for key, value in schema.items():
         # Skip empty required arrays
@@ -736,14 +736,14 @@ def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[Unified
 
     for msg in messages:
         # Check if this message has any tool content
-        has_tool_calls = bool(msg.tool_calls)
-        has_tool_results = bool(msg.tool_results)
+        tool_calls = msg.tool_calls
+        tool_results = msg.tool_results
 
-        if has_tool_calls or has_tool_results:
-            if has_tool_calls:
-                total_tool_calls_stripped += len(msg.tool_calls)
-            if has_tool_results:
-                total_tool_results_stripped += len(msg.tool_results)
+        if tool_calls or tool_results:
+            if tool_calls:
+                total_tool_calls_stripped += len(tool_calls)
+            if tool_results:
+                total_tool_results_stripped += len(tool_results)
 
             # Start with existing text content
             existing_content = extract_text_content(msg.content)
@@ -753,14 +753,14 @@ def strip_all_tool_content(messages: List[UnifiedMessage]) -> Tuple[List[Unified
                 content_parts.append(existing_content)
 
             # Convert tool_calls to text (for assistant messages)
-            if has_tool_calls:
-                tool_text = tool_calls_to_text(msg.tool_calls)
+            if tool_calls:
+                tool_text = tool_calls_to_text(tool_calls)
                 if tool_text:
                     content_parts.append(tool_text)
 
             # Convert tool_results to text (for user messages)
-            if has_tool_results:
-                result_text = tool_results_to_text(msg.tool_results)
+            if tool_results:
+                result_text = tool_results_to_text(tool_results)
                 if result_text:
                     content_parts.append(result_text)
 
@@ -812,7 +812,7 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
     if not messages:
         return [], False
 
-    result = []
+    result: List[UnifiedMessage] = []
     converted_any_tool_results = False
 
     for msg in messages:
@@ -876,7 +876,7 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
     if not messages:
         return []
 
-    merged = []
+    merged: List[UnifiedMessage] = []
     # Statistics for summary logging
     merge_counts = {"user": 0, "assistant": 0}
     total_tool_calls_merged = 0
@@ -1127,7 +1127,7 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
         if msg.role == "user":
             content = extract_text_content(msg.content)
 
-            user_input = {
+            user_input: Dict[str, Any] = {
                 "content": content,
                 "modelId": model_id,
                 "origin": "AI_EDITOR",
@@ -1165,7 +1165,7 @@ def build_kiro_history(messages: List[UnifiedMessage], model_id: str) -> List[Di
         elif msg.role == "assistant":
             content = extract_text_content(msg.content)
 
-            assistant_response = {"content": content}
+            assistant_response: Dict[str, Any] = {"content": content}
 
             # Process tool_calls
             tool_uses = extract_tool_uses_from_message(msg.content, msg.tool_calls)
@@ -1310,7 +1310,7 @@ def build_kiro_payload(
             user_input_context["toolResults"] = tool_results
 
     # Build userInputMessage
-    user_input_message = {
+    user_input_message: Dict[str, Any] = {
         "content": current_content,
         "modelId": model_id,
         "origin": "AI_EDITOR",
@@ -1325,7 +1325,7 @@ def build_kiro_payload(
         user_input_message["userInputMessageContext"] = user_input_context
 
     # Assemble final payload
-    payload = {
+    payload: Dict[str, Any] = {
         "conversationState": {
             "chatTriggerType": "MANUAL",
             "conversationId": conversation_id,

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -16,61 +16,65 @@ from typing import Any, Dict, List, Optional, Tuple
 from loguru import logger
 
 from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
-from kiro.model_resolver import get_model_id_for_kiro
-from kiro.native_thinking import apply_native_thinking
-from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool
 
 # Import from core - reuse shared logic
 from kiro.converters_core import (
-    extract_text_content,
-    extract_images_from_content,
     UnifiedMessage,
     UnifiedTool,
+    extract_images_from_content,
+    extract_text_content,
+)
+from kiro.converters_core import (
     build_kiro_payload as core_build_kiro_payload,
 )
-
+from kiro.model_resolver import get_model_id_for_kiro
+from kiro.models_openai import ChatCompletionRequest, ChatMessage, Tool
+from kiro.native_thinking import apply_native_thinking
 
 # ==================================================================================================
 # OpenAI-specific Message Processing
 # ==================================================================================================
 
+
 def _extract_tool_results_from_openai(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts tool results from OpenAI message content.
-    
+
     Args:
         content: Message content (can be a list with tool_result blocks)
-    
+
     Returns:
         List of tool results in unified format for UnifiedMessage
     """
     tool_results = []
-    
+
     if isinstance(content, list):
         for item in content:
             if isinstance(item, dict) and item.get("type") == "tool_result":
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": item.get("tool_use_id", ""),
-                    "content": extract_text_content(item.get("content", "")) or "(empty result)"
-                })
-    
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": item.get("tool_use_id", ""),
+                        "content": extract_text_content(item.get("content", "")) or "(empty result)",
+                    }
+                )
+
     return tool_results
 
 
 def _extract_images_from_tool_message(content: Any) -> List[Dict[str, Any]]:
     """
     Extracts images from OpenAI tool message content.
-    
+
     Tool messages from MCP servers (e.g., browsermcp) can contain images
     (screenshots) alongside text. This function extracts those images.
-    
+
     Args:
         content: Tool message content (can be string or list of content blocks)
-    
+
     Returns:
         List of images in unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
-    
+
     Example:
         >>> content = [
         ...     {"type": "text", "text": "Screenshot captured"},
@@ -83,70 +87,72 @@ def _extract_images_from_tool_message(content: Any) -> List[Dict[str, Any]]:
     # If content is not a list, no images to extract
     if not isinstance(content, list):
         return []
-    
+
     # Use core function to extract images from content list
     images = extract_images_from_content(content)
-    
+
     if images:
         logger.debug(f"Extracted {len(images)} image(s) from tool message content")
-    
+
     return images
 
 
 def _extract_tool_calls_from_openai(msg: ChatMessage) -> List[Dict[str, Any]]:
     """
     Extracts tool calls from OpenAI assistant message.
-    
+
     Args:
         msg: OpenAI ChatMessage
-    
+
     Returns:
         List of tool calls in unified format
     """
     tool_calls = []
-    
+
     if msg.tool_calls:
         for tc in msg.tool_calls:
             if isinstance(tc, dict):
-                tool_calls.append({
-                    "id": tc.get("id", ""),
-                    "type": "function",
-                    "function": {
-                        "name": tc.get("function", {}).get("name", ""),
-                        "arguments": tc.get("function", {}).get("arguments", "{}")
+                tool_calls.append(
+                    {
+                        "id": tc.get("id", ""),
+                        "type": "function",
+                        "function": {
+                            "name": tc.get("function", {}).get("name", ""),
+                            "arguments": tc.get("function", {}).get("arguments", "{}"),
+                        },
                     }
-                })
-    
+                )
+
     return tool_calls
 
 
 def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str, List[UnifiedMessage]]:
     """
     Converts OpenAI messages to unified format.
-    
+
     Handles:
     - System messages (extracted as system prompt)
     - Tool messages (converted to user messages with tool_results)
     - Tool calls in assistant messages
-    
+
     Args:
         messages: List of OpenAI ChatMessage objects
-    
+
     Returns:
         Tuple of (system_prompt, unified_messages)
     """
     # Extract system prompt
     system_prompt = ""
     non_system_messages = []
-    
+
     for msg in messages:
         if msg.role in ("system", "developer"):
             system_prompt += extract_text_content(msg.content) + "\n"
         else:
             non_system_messages.append(msg)
-    
+
     system_prompt = system_prompt.strip()
-    
+
     # Process tool messages - convert to user messages with tool_results
     processed = []
     pending_tool_results = []
@@ -161,11 +167,11 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
             tool_result = {
                 "type": "tool_result",
                 "tool_use_id": msg.tool_call_id or "",
-                "content": extract_text_content(msg.content) or "(empty result)"
+                "content": extract_text_content(msg.content) or "(empty result)",
             }
             pending_tool_results.append(tool_result)
             total_tool_results += 1
-            
+
             # Extract images from tool message content (e.g., screenshots from MCP tools)
             tool_images = _extract_images_from_tool_message(msg.content)
             if tool_images:
@@ -178,12 +184,12 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
                     role="user",
                     content="",
                     tool_results=pending_tool_results.copy(),
-                    images=pending_tool_images.copy() if pending_tool_images else None
+                    images=pending_tool_images.copy() if pending_tool_images else None,
                 )
                 processed.append(unified_msg)
                 pending_tool_results.clear()
                 pending_tool_images.clear()
-            
+
             # Convert regular message
             tool_calls = None
             tool_results = None
@@ -207,117 +213,113 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
                 content=extract_text_content(msg.content),
                 tool_calls=tool_calls,
                 tool_results=tool_results,
-                images=images
+                images=images,
             )
             processed.append(unified_msg)
-    
+
     # If tool results remain at the end
     if pending_tool_results:
         unified_msg = UnifiedMessage(
             role="user",
             content="",
             tool_results=pending_tool_results.copy(),
-            images=pending_tool_images.copy() if pending_tool_images else None
+            images=pending_tool_images.copy() if pending_tool_images else None,
         )
         processed.append(unified_msg)
-    
+
     # Log summary if any tool content or images were found
     if total_tool_calls > 0 or total_tool_results > 0 or total_images > 0:
         logger.debug(
             f"Converted {len(messages)} OpenAI messages: "
             f"{total_tool_calls} tool_calls, {total_tool_results} tool_results, {total_images} images"
         )
-    
+
     return system_prompt, processed
 
 
 def convert_openai_tools_to_unified(tools: Optional[List[Tool]]) -> Optional[List[UnifiedTool]]:
     """
     Converts OpenAI tools to unified format.
-    
+
     Supports two formats:
     1. Standard OpenAI format: {"type": "function", "function": {"name": "...", ...}}
     2. Flat format (Cursor-style): {"name": "...", "description": "...", "input_schema": {...}}
-    
+
     Args:
         tools: List of OpenAI Tool objects
-    
+
     Returns:
         List of UnifiedTool objects, or None if no tools
     """
     if not tools:
         return None
-    
+
     unified_tools = []
     for tool in tools:
         if tool.type != "function":
             continue
-        
+
         # Standard OpenAI format (function field) takes priority
         if tool.function is not None:
-            unified_tools.append(UnifiedTool(
-                name=tool.function.name,
-                description=tool.function.description,
-                input_schema=tool.function.parameters
-            ))
+            unified_tools.append(
+                UnifiedTool(
+                    name=tool.function.name,
+                    description=tool.function.description,
+                    input_schema=tool.function.parameters,
+                )
+            )
         # Flat format compatibility (Cursor-style)
         elif tool.name is not None:
-            unified_tools.append(UnifiedTool(
-                name=tool.name,
-                description=tool.description,
-                input_schema=tool.input_schema
-            ))
+            unified_tools.append(
+                UnifiedTool(name=tool.name, description=tool.description, input_schema=tool.input_schema)
+            )
         # Skip invalid tools
         else:
-            logger.warning(f"Skipping invalid tool: no function or name field found")
+            logger.warning("Skipping invalid tool: no function or name field found")
             continue
-    
-    return unified_tools if unified_tools else None
 
+    return unified_tools if unified_tools else None
 
 
 # ==================================================================================================
 # Main Entry Point
 # ==================================================================================================
 
-def build_kiro_payload(
-    request_data: ChatCompletionRequest,
-    conversation_id: str,
-    profile_arn: str
-) -> dict:
+
+def build_kiro_payload(request_data: ChatCompletionRequest, conversation_id: str, profile_arn: str) -> dict:
     """
     Builds complete payload for Kiro API from OpenAI request.
-    
+
     This is the main entry point for OpenAI → Kiro conversion.
     Uses the core build_kiro_payload function with OpenAI-specific adapters.
-    
+
     Args:
         request_data: Request in OpenAI format
         conversation_id: Unique conversation ID
         profile_arn: AWS CodeWhisperer profile ARN
-    
+
     Returns:
         Payload dictionary for POST request to Kiro API
-    
+
     Raises:
         ValueError: If there are no messages to send
     """
     # Convert messages to unified format
     system_prompt, unified_messages = convert_openai_messages_to_unified(request_data.messages)
-    
+
     # Convert tools to unified format
     unified_tools = convert_openai_tools_to_unified(request_data.tools)
-    
+
     # Get model ID for Kiro API (normalizes + resolves hidden models)
     # Pass-through principle: we normalize and send to Kiro, Kiro decides if valid
     model_id = get_model_id_for_kiro(request_data.model, HIDDEN_MODELS, MODEL_ALIASES)
-    
+
     logger.debug(
         f"Converting OpenAI request: model={request_data.model} -> {model_id}, "
         f"messages={len(unified_messages)}, tools={len(unified_tools) if unified_tools else 0}, "
         f"system_prompt_length={len(system_prompt)}"
     )
-    
+
     # Use core function to build payload
     result = core_build_kiro_payload(
         messages=unified_messages,
@@ -325,7 +327,7 @@ def build_kiro_payload(
         model_id=model_id,
         tools=unified_tools,
         conversation_id=conversation_id,
-        profile_arn=profile_arn
+        profile_arn=profile_arn,
     )
 
     # Native Kiro adaptive thinking is an upstream protocol capability, not a

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -683,7 +683,7 @@ async def dashboard_request_rate(request: Request, window: int = 900, bucket: in
 async def dashboard_models(request: Request) -> dict[str, list[dict[str, str]]]:
     _require_auth(request)
     models = request.app.state.account_manager.get_all_available_models() or FALLBACK_MODELS
-    return {"models": [{"id": item.get("modelId", item) if isinstance(item, dict) else item} for item in models]}
+    return {"models": [{"id": item["modelId"] if isinstance(item, dict) else item} for item in models]}
 
 
 @router.get("/api/dashboard/request-logs")

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
-import json
 import os
 import secrets
 import sqlite3
@@ -23,12 +22,12 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import FileResponse
 
 from kiro.account_manager import account_label, account_routing_state
+from kiro.accounts_admin import register_account
 from kiro.config import (
     FALLBACK_MODELS,
     RATE_OBSERVATION_RETENTION_DAYS,
     REQUEST_LOG_RETENTION_DAYS,
 )
-from kiro.accounts_admin import register_account
 from kiro.device_login import (
     DeviceLoginError,
     discard_flow,
@@ -37,8 +36,8 @@ from kiro.device_login import (
     start_device_login,
     write_builder_id_credentials,
 )
-from kiro.usage_tracking import ROOT_KEY_ID, current_api_key_id, drain_pending_usage
 from kiro.usage import fetch_account_usage
+from kiro.usage_tracking import ROOT_KEY_ID, drain_pending_usage
 
 router = APIRouter(tags=["dashboard"])
 
@@ -220,7 +219,10 @@ def flush_key_model_usage() -> int:
                     completion_tokens = completion_tokens + excluded.completion_tokens,
                     requests = requests + excluded.requests,
                     updated_at = excluded.updated_at""",
-                [(key_id, model, prompt, completion, requests, now) for key_id, model, prompt, completion, requests in pending],
+                [
+                    (key_id, model, prompt, completion, requests, now)
+                    for key_id, model, prompt, completion, requests in pending
+                ],
             )
         return len(pending)
     except Exception:
@@ -238,14 +240,16 @@ def key_model_usage() -> dict[str, list[dict[str, Any]]]:
         return {}
     grouped: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
-        grouped.setdefault(row["key_id"], []).append({
-            "model": row["model"],
-            "promptTokens": row["prompt_tokens"],
-            "completionTokens": row["completion_tokens"],
-            "totalTokens": row["prompt_tokens"] + row["completion_tokens"],
-            "requests": row["requests"],
-            "updatedAt": row["updated_at"],
-        })
+        grouped.setdefault(row["key_id"], []).append(
+            {
+                "model": row["model"],
+                "promptTokens": row["prompt_tokens"],
+                "completionTokens": row["completion_tokens"],
+                "totalTokens": row["prompt_tokens"] + row["completion_tokens"],
+                "requests": row["requests"],
+                "updatedAt": row["updated_at"],
+            }
+        )
     return grouped
 
 
@@ -282,7 +286,13 @@ def create_data_api_key(name: str) -> tuple[str, dict[str, Any]]:
             "INSERT INTO api_keys(id, name, key_prefix, salt, key_hash, created_at) VALUES (?, ?, ?, ?, ?, ?)",
             (key_id, name.strip() or "Unnamed key", key_prefix, salt, _hash_api_key(raw_key, salt), created_at),
         )
-    return raw_key, {"id": key_id, "name": name.strip() or "Unnamed key", "prefix": key_prefix, "createdAt": created_at, "revokedAt": None}
+    return raw_key, {
+        "id": key_id,
+        "name": name.strip() or "Unnamed key",
+        "prefix": key_prefix,
+        "createdAt": created_at,
+        "revokedAt": None,
+    }
 
 
 def identify_data_api_key(value: str) -> str | None:
@@ -316,13 +326,26 @@ def verify_data_api_key(value: str) -> bool:
 
 def list_data_api_keys() -> list[dict[str, Any]]:
     with _db() as conn:
-        rows = conn.execute("SELECT id, name, key_prefix, created_at, revoked_at FROM api_keys ORDER BY created_at DESC").fetchall()
-    return [{"id": r["id"], "name": r["name"], "prefix": r["key_prefix"], "createdAt": r["created_at"], "revokedAt": r["revoked_at"]} for r in rows]
+        rows = conn.execute(
+            "SELECT id, name, key_prefix, created_at, revoked_at FROM api_keys ORDER BY created_at DESC"
+        ).fetchall()
+    return [
+        {
+            "id": r["id"],
+            "name": r["name"],
+            "prefix": r["key_prefix"],
+            "createdAt": r["created_at"],
+            "revokedAt": r["revoked_at"],
+        }
+        for r in rows
+    ]
 
 
 def revoke_data_api_key(key_id: str) -> bool:
     with _db() as conn:
-        result = conn.execute("UPDATE api_keys SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL", (int(time.time()), key_id))
+        result = conn.execute(
+            "UPDATE api_keys SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL", (int(time.time()), key_id)
+        )
     return result.rowcount > 0
 
 
@@ -348,12 +371,19 @@ def _cached_usage(account_id: str) -> dict[str, Any] | None:
     if not row:
         return None
     return {
-        "subscriptionTitle": row["subscription_title"], "subscriptionType": row["subscription_type"],
-        "resourceType": row["resource_type"], "currentUsage": row["current_usage"],
-        "usageLimit": row["usage_limit"], "usagePercent": row["usage_percent"], "unit": row["unit"],
-        "nextDateReset": row["next_date_reset"], "daysUntilReset": row["days_until_reset"],
-        "overageStatus": row["overage_status"], "overageUsed": row["overage_used"],
-        "updatedAt": row["updated_at"], "error": row["error"],
+        "subscriptionTitle": row["subscription_title"],
+        "subscriptionType": row["subscription_type"],
+        "resourceType": row["resource_type"],
+        "currentUsage": row["current_usage"],
+        "usageLimit": row["usage_limit"],
+        "usagePercent": row["usage_percent"],
+        "unit": row["unit"],
+        "nextDateReset": row["next_date_reset"],
+        "daysUntilReset": row["days_until_reset"],
+        "overageStatus": row["overage_status"],
+        "overageUsed": row["overage_used"],
+        "updatedAt": row["updated_at"],
+        "error": row["error"],
     }
 
 
@@ -367,7 +397,21 @@ async def refresh_account_usage(account: Any) -> dict[str, Any]:
                 """INSERT INTO account_usage(account_id, subscription_title, subscription_type, resource_type, current_usage, usage_limit, usage_percent, unit, next_date_reset, days_until_reset, overage_status, overage_used, updated_at, error)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
                 ON CONFLICT(account_id) DO UPDATE SET subscription_title=excluded.subscription_title, subscription_type=excluded.subscription_type, resource_type=excluded.resource_type, current_usage=excluded.current_usage, usage_limit=excluded.usage_limit, usage_percent=excluded.usage_percent, unit=excluded.unit, next_date_reset=excluded.next_date_reset, days_until_reset=excluded.days_until_reset, overage_status=excluded.overage_status, overage_used=excluded.overage_used, updated_at=excluded.updated_at, error=NULL""",
-                (account.id, usage["subscriptionTitle"], usage["subscriptionType"], usage["resourceType"], usage["currentUsage"], usage["usageLimit"], usage["usagePercent"], usage["unit"], str(usage["nextDateReset"] or ""), usage["daysUntilReset"], usage["overageStatus"], usage["overageUsed"], updated_at),
+                (
+                    account.id,
+                    usage["subscriptionTitle"],
+                    usage["subscriptionType"],
+                    usage["resourceType"],
+                    usage["currentUsage"],
+                    usage["usageLimit"],
+                    usage["usagePercent"],
+                    usage["unit"],
+                    str(usage["nextDateReset"] or ""),
+                    usage["daysUntilReset"],
+                    usage["overageStatus"],
+                    usage["overageUsed"],
+                    updated_at,
+                ),
             )
         return {**usage, "updatedAt": updated_at, "error": None}
     except Exception as exc:
@@ -430,7 +474,14 @@ async def dashboard_login(request: Request, response: Response) -> dict[str, boo
         raise HTTPException(status_code=401, detail="Invalid password")
     token = secrets.token_urlsafe(32)
     _sessions[token] = time.time() + _SESSION_TTL_SECONDS
-    response.set_cookie(_COOKIE, token, httponly=True, samesite="strict", secure=request.url.scheme == "https", max_age=_SESSION_TTL_SECONDS)
+    response.set_cookie(
+        _COOKIE,
+        token,
+        httponly=True,
+        samesite="strict",
+        secure=request.url.scheme == "https",
+        max_age=_SESSION_TTL_SECONDS,
+    )
     return {"ok": True}
 
 
@@ -450,14 +501,16 @@ async def dashboard_list_keys(request: Request) -> dict[str, list[dict[str, Any]
     # and it cannot be revoked from here because it lives in the environment.
     legacy = os.getenv("PROXY_API_KEY", "")
     if legacy:
-        keys.append({
-            "id": ROOT_KEY_ID,
-            "name": "Root key (environment)",
-            "prefix": legacy[:4] + "…",
-            "createdAt": None,
-            "revokedAt": None,
-            "readOnly": True,
-        })
+        keys.append(
+            {
+                "id": ROOT_KEY_ID,
+                "name": "Root key (environment)",
+                "prefix": legacy[:4] + "…",
+                "createdAt": None,
+                "revokedAt": None,
+                "readOnly": True,
+            }
+        )
     keys.extend({**key, "readOnly": False} for key in list_data_api_keys())
     return {"apiKeys": keys}
 

--- a/kiro/debug_capture.py
+++ b/kiro/debug_capture.py
@@ -42,20 +42,22 @@ class CaptureLogBuffer(io.StringIO):
         )
         self._state.stored_bytes += len(stored)
         if stored:
-            super().write(
-                stored.decode("utf-8", errors="replace")
-            )
-        metadata = self._state.artifact_meta.setdefault("app_logs", {
-            "original_bytes": 0,
-            "stored_bytes": 0,
-            "truncated": False,
-            "omitted_bytes": 0,
-        })
+            super().write(stored.decode("utf-8", errors="replace"))
+        metadata = self._state.artifact_meta.setdefault(
+            "app_logs",
+            {
+                "original_bytes": 0,
+                "stored_bytes": 0,
+                "truncated": False,
+                "omitted_bytes": 0,
+            },
+        )
         metadata["original_bytes"] += len(encoded)
         metadata["stored_bytes"] += len(stored)
         metadata["truncated"] = metadata["truncated"] or truncated
         metadata["omitted_bytes"] += omitted
         return len(message)
+
 
 @dataclass
 class CaptureState:
@@ -133,12 +135,15 @@ class CaptureState:
         self.sequence += 1
         if record is not None:
             getattr(self, target).append(record)
-        metadata = self.artifact_meta.setdefault(target, {
-            "original_bytes": 0,
-            "stored_bytes": 0,
-            "truncated": False,
-            "omitted_bytes": 0,
-        })
+        metadata = self.artifact_meta.setdefault(
+            target,
+            {
+                "original_bytes": 0,
+                "stored_bytes": 0,
+                "truncated": False,
+                "omitted_bytes": 0,
+            },
+        )
         metadata["original_bytes"] += len(data)
         metadata["stored_bytes"] += len(stored)
         metadata["truncated"] = metadata["truncated"] or truncated
@@ -255,9 +260,7 @@ def _translated_protocol(records: list[dict[str, Any]]) -> str:
 
 def _jsonl_bytes(records: list[dict[str, Any]]) -> bytes:
     return b"".join(
-        json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode()
-        + b"\n"
-        for record in records
+        json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode() + b"\n" for record in records
     )
 
 
@@ -283,11 +286,7 @@ def _fsync_directory(path: Path) -> None:
 
 
 def _prune_completed(failures_dir: Path, retention: int) -> None:
-    completed = sorted(
-        path
-        for path in failures_dir.iterdir()
-        if path.is_dir() and not path.name.startswith(".tmp-")
-    )
+    completed = sorted(path for path in failures_dir.iterdir() if path.is_dir() and not path.name.startswith(".tmp-"))
     for stale in completed[:-retention]:
         shutil.rmtree(stale)
 

--- a/kiro/debug_capture.py
+++ b/kiro/debug_capture.py
@@ -167,7 +167,7 @@ class CaptureState:
 
         try:
             failure = redact_patterns(error_message)
-            validation = {"valid": True, "failure": None}
+            validation: dict[str, Any] = {"valid": True, "failure": None}
             if self.translated_sse:
                 from kiro.sse_validation import (
                     StreamProtocolError,

--- a/kiro/debug_logger.py
+++ b/kiro/debug_logger.py
@@ -20,6 +20,7 @@ import shutil
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, Optional
+
 from loguru import logger
 
 from kiro.config import (
@@ -40,12 +41,13 @@ from kiro.debug_capture import (
 class DebugLogger:
     """
     Singleton for managing debug request logs.
-    
+
     Operating modes:
     - off: does nothing
     - errors: buffers data, flushes to files only on errors
     - all: writes data immediately to files (as before)
     """
+
     _instance = None
 
     def __new__(cls):
@@ -60,13 +62,13 @@ class DebugLogger:
         self.debug_dir = Path(DEBUG_DIR)
         prune_stale_temporaries(self.debug_dir)
         self._initialized = True
-        
+
         # Buffers for "errors" mode
         self._request_body_buffer: Optional[bytes] = None
         self._kiro_request_body_buffer: Optional[bytes] = None
         self._raw_chunks_buffer: bytearray = bytearray()
         self._modified_chunks_buffer: bytearray = bytearray()
-        
+
         # Buffer for application logs (loguru)
         self._app_logs_buffer: io.StringIO = io.StringIO()
         self._loguru_sink_id: Optional[int] = None
@@ -74,15 +76,15 @@ class DebugLogger:
             f"debug_capture_state_{id(self)}",
             default=None,
         )
-    
+
     def _is_enabled(self) -> bool:
         """Checks if logging is enabled."""
         return DEBUG_MODE in ("errors", "all")
-    
+
     def _is_immediate_write(self) -> bool:
         """Checks if immediate file writing is needed (all mode)."""
         return DEBUG_MODE == "all"
-    
+
     def _clear_buffers(self):
         """Clears all buffers."""
         self._request_body_buffer = None
@@ -95,15 +97,11 @@ class DebugLogger:
 
     def _current_capture(self) -> Optional[CaptureState]:
         return self._capture_state.get()
-    
+
     def _clear_app_logs_buffer(self):
         """Clears the application logs buffer and removes sink."""
         capture = self._current_capture()
-        sink_id = (
-            capture.loguru_sink_id
-            if capture is not None
-            else self._loguru_sink_id
-        )
+        sink_id = capture.loguru_sink_id if capture is not None else self._loguru_sink_id
         if sink_id is not None:
             try:
                 logger.remove(sink_id)
@@ -118,11 +116,11 @@ class DebugLogger:
         else:
             self._loguru_sink_id = None
             self._app_logs_buffer = io.StringIO()
-    
+
     def _setup_app_logs_capture(self):
         """
         Sets up application log capture to buffer.
-        
+
         Adds a temporary sink to loguru that writes to StringIO buffer.
         Captures ALL logs without filtering, as sink is active only
         during processing of a specific request.
@@ -150,14 +148,14 @@ class DebugLogger:
     def prepare_new_request(self):
         """
         Prepares the logger for a new request.
-        
+
         In "all" mode: clears the logs folder.
         In "errors" mode: clears buffers.
         In both modes: sets up application log capture.
         """
         if not self._is_enabled():
             return
-        
+
         if self._current_capture() is not None:
             self._clear_buffers()
         else:
@@ -167,14 +165,12 @@ class DebugLogger:
             self._modified_chunks_buffer.clear()
         capture = CaptureState(
             debug_dir=self.debug_dir,
-            capture_content=(
-                DEBUG_CAPTURE_CONTENT or self._is_immediate_write()
-            ),
+            capture_content=(DEBUG_CAPTURE_CONTENT or self._is_immediate_write()),
             max_bytes=DEBUG_CAPTURE_MAX_BYTES,
             retention=DEBUG_CAPTURE_RETENTION,
         )
         self._capture_state.set(capture)
-        
+
         # Set up application log capture
         self._setup_app_logs_capture()
 
@@ -192,7 +188,7 @@ class DebugLogger:
     def log_request_body(self, body: bytes):
         """
         Saves the request body (from client, OpenAI format).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -211,7 +207,7 @@ class DebugLogger:
     def log_kiro_request_body(self, body: bytes):
         """
         Saves the modified request body (to Kiro API).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -230,7 +226,7 @@ class DebugLogger:
     def log_raw_chunk(self, chunk: bytes):
         """
         Appends raw response chunk (from provider).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -263,7 +259,7 @@ class DebugLogger:
     def log_modified_chunk(self, chunk: bytes):
         """
         Appends modified chunk (to client).
-        
+
         In "all" mode: writes immediately to file.
         In "errors" mode: buffers.
         """
@@ -278,34 +274,31 @@ class DebugLogger:
             self._append_modified_chunk_to_file(chunk)
         elif capture is None:
             self._modified_chunks_buffer.extend(chunk)
-    
+
     def log_error_info(self, status_code: int, error_message: str = ""):
         """
         Writes error information to file.
-        
+
         Works in both modes (errors and all).
         In "all" mode writes immediately to file.
         In "errors" mode called from flush_on_error().
-        
+
         Args:
             status_code: HTTP error status code
             error_message: Error message (optional)
         """
         if not self._is_enabled():
             return
-        
+
         try:
             # Ensure directory exists
             self.debug_dir.mkdir(parents=True, exist_ok=True)
-            
-            error_info = {
-                "status_code": status_code,
-                "error_message": error_message
-            }
+
+            error_info = {"status_code": status_code, "error_message": error_message}
             error_file = self.debug_dir / "error_info.json"
             with open(error_file, "w", encoding="utf-8") as f:
                 json.dump(error_info, f, indent=2, ensure_ascii=False)
-            
+
             logger.debug(f"[DebugLogger] Error info saved (status={status_code})")
         except Exception as e:
             logger.error(f"[DebugLogger] Error writing error_info: {e}")
@@ -317,10 +310,10 @@ class DebugLogger:
     ) -> Optional[Path]:
         """
         Flushes buffers to files on error.
-        
+
         In "errors" mode: flushes buffers and saves error_info.
         In "all" mode: only saves error_info (data already written).
-        
+
         Args:
             status_code: HTTP error status code
             error_message: Error message (optional)
@@ -332,7 +325,7 @@ class DebugLogger:
         capture_path: Optional[Path] = None
         if capture is not None:
             capture.app_logs = capture.app_log_buffer.getvalue()
-        
+
         # In "all" mode data is already written, add error_info and app logs
         if self._is_immediate_write():
             if capture is not None:
@@ -342,40 +335,40 @@ class DebugLogger:
             self._clear_app_logs_buffer()
             self._capture_state.set(None)
             return capture_path
-        
+
         # Check if there's anything to flush
         has_capture_data = False
         if capture is not None:
-            has_capture_data = any([
-                capture.client_request is not None,
-                capture.kiro_request is not None,
-                capture.upstream_chunks,
-                capture.translated_sse,
-            ])
-        has_legacy_data = any([
-            self._request_body_buffer,
-            self._kiro_request_body_buffer,
-            self._raw_chunks_buffer,
-            self._modified_chunks_buffer,
-        ])
+            has_capture_data = any(
+                [
+                    capture.client_request is not None,
+                    capture.kiro_request is not None,
+                    capture.upstream_chunks,
+                    capture.translated_sse,
+                ]
+            )
+        has_legacy_data = any(
+            [
+                self._request_body_buffer,
+                self._kiro_request_body_buffer,
+                self._raw_chunks_buffer,
+                self._modified_chunks_buffer,
+            ]
+        )
         if not has_capture_data and not has_legacy_data:
             self._clear_buffers()
             return
-        
+
         try:
             self.debug_dir.mkdir(parents=True, exist_ok=True)
             if capture is not None:
                 capture_path = capture.publish(status_code, error_message)
-            
+
             if capture is None:
                 if self._request_body_buffer:
-                    self._write_request_body_to_file(
-                        self._request_body_buffer
-                    )
+                    self._write_request_body_to_file(self._request_body_buffer)
                 if self._kiro_request_body_buffer:
-                    self._write_kiro_request_body_to_file(
-                        self._kiro_request_body_buffer
-                    )
+                    self._write_kiro_request_body_to_file(self._kiro_request_body_buffer)
                 if self._raw_chunks_buffer:
                     file_path = self.debug_dir / "response_stream_raw.txt"
                     with open(file_path, "wb") as f:
@@ -386,20 +379,20 @@ class DebugLogger:
                         f.write(self._modified_chunks_buffer)
                 self.log_error_info(status_code, error_message)
                 self._write_app_logs_to_file()
-            
+
             logger.info(f"[DebugLogger] Error logs flushed to {self.debug_dir} (status={status_code})")
-            
+
         except Exception as e:
             logger.error(f"[DebugLogger] Error flushing buffers: {e}")
         finally:
             # Clear buffers after flush
             self._clear_buffers()
         return capture_path
-    
+
     def discard_buffers(self):
         """
         Clears buffers without writing to files.
-        
+
         Called when request completed successfully in "errors" mode.
         Also called in "all" mode to save logs of successful request.
         """
@@ -413,9 +406,7 @@ class DebugLogger:
                     category="requests",
                 )
             except (OSError, ValueError) as exc:
-                logger.warning(
-                    f"[DebugLogger] Success capture skipped: {exc}"
-                )
+                logger.warning(f"[DebugLogger] Success capture skipped: {exc}")
 
         if DEBUG_MODE == "errors":
             self._clear_buffers()
@@ -423,9 +414,9 @@ class DebugLogger:
             # In "all" mode save logs even for successful requests
             self._write_app_logs_to_file()
             self._clear_app_logs_buffer()
-    
+
     # ==================== Private file writing methods ====================
-    
+
     def _write_request_body_to_file(self, body: bytes):
         """Writes request body to file."""
         try:
@@ -439,7 +430,7 @@ class DebugLogger:
                     f.write(body)
         except Exception as e:
             logger.error(f"[DebugLogger] Error writing request_body: {e}")
-    
+
     def _write_kiro_request_body_to_file(self, body: bytes):
         """Writes Kiro request body to file."""
         try:
@@ -453,7 +444,7 @@ class DebugLogger:
                     f.write(body)
         except Exception as e:
             logger.error(f"[DebugLogger] Error writing kiro_request_body: {e}")
-    
+
     def _append_raw_chunk_to_file(self, chunk: bytes):
         """Appends raw chunk to file."""
         try:
@@ -462,7 +453,7 @@ class DebugLogger:
                 f.write(chunk)
         except Exception:
             pass
-    
+
     def _append_modified_chunk_to_file(self, chunk: bytes):
         """Appends modified chunk to file."""
         try:
@@ -471,7 +462,7 @@ class DebugLogger:
                 f.write(chunk)
         except Exception:
             pass
-    
+
     def _write_app_logs_to_file(
         self,
         logs_content: Optional[str] = None,
@@ -480,19 +471,19 @@ class DebugLogger:
         try:
             if logs_content is None:
                 logs_content = self._app_logs_buffer.getvalue()
-            
+
             if not logs_content.strip():
                 return
-            
+
             # Ensure directory exists
             self.debug_dir.mkdir(parents=True, exist_ok=True)
-            
+
             file_path = self.debug_dir / "app_logs.txt"
             with open(file_path, "w", encoding="utf-8") as f:
                 f.write(logs_content)
-            
+
             logger.debug(f"[DebugLogger] App logs saved to {file_path}")
-        except Exception as e:
+        except Exception:
             # Don't log error via logger to avoid recursion
             pass
 

--- a/kiro/debug_logger.py
+++ b/kiro/debug_logger.py
@@ -319,7 +319,7 @@ class DebugLogger:
             error_message: Error message (optional)
         """
         if not self._is_enabled():
-            return
+            return None
 
         capture = self._current_capture()
         capture_path: Optional[Path] = None
@@ -357,7 +357,7 @@ class DebugLogger:
         )
         if not has_capture_data and not has_legacy_data:
             self._clear_buffers()
-            return
+            return None
 
         try:
             self.debug_dir.mkdir(parents=True, exist_ok=True)

--- a/kiro/debug_middleware.py
+++ b/kiro/debug_middleware.py
@@ -16,69 +16,70 @@ Flush/discard operations are handled by:
 - Exception handlers (for validation errors and other exceptions)
 """
 
+from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from loguru import logger
 
 from kiro.config import DEBUG_MODE
 
-
 # API endpoints that should have debug logging enabled
 # These are the main API endpoints that process user requests
-LOGGED_ENDPOINTS = frozenset({
-    "/v1/chat/completions",  # OpenAI-compatible endpoint
-    "/v1/messages",          # Anthropic-compatible endpoint
-})
+LOGGED_ENDPOINTS = frozenset(
+    {
+        "/v1/chat/completions",  # OpenAI-compatible endpoint
+        "/v1/messages",  # Anthropic-compatible endpoint
+    }
+)
 
 
 class DebugLoggerMiddleware(BaseHTTPMiddleware):
     """
     Middleware for initializing debug logging on API requests.
-    
+
     This middleware runs BEFORE Pydantic validation, which means it can
     capture the raw request body even for requests that fail validation.
-    
+
     The middleware only activates for API endpoints defined in LOGGED_ENDPOINTS.
     Health checks, documentation, and other endpoints are not logged.
-    
+
     Lifecycle:
     - prepare_new_request(): Called here (before validation)
     - log_request_body(): Called here (raw body from client)
     - log_kiro_request_body(): Called in route handlers (transformed payload)
     - flush_on_error() / discard_buffers(): Called in routes or exception handlers
     """
-    
+
     async def dispatch(self, request: Request, call_next) -> Response:
         """
         Process the request and initialize debug logging if needed.
-        
+
         Args:
             request: The incoming HTTP request
             call_next: The next middleware or route handler
-            
+
         Returns:
             The response from the next handler
         """
         # Skip logging for non-API endpoints (health, docs, etc.)
         if request.url.path not in LOGGED_ENDPOINTS:
             return await call_next(request)
-        
+
         # Skip if debug mode is disabled
         if DEBUG_MODE == "off":
             return await call_next(request)
-        
+
         # Import here to avoid circular imports and allow graceful degradation
         try:
             from kiro.debug_logger import debug_logger
         except ImportError:
             logger.warning("debug_logger not available, skipping debug logging")
             return await call_next(request)
-        
+
         # Initialize debug logging for this request
         # This sets up buffers and creates a loguru sink to capture app logs
         debug_logger.prepare_new_request()
-        
+
         # Read and log the raw request body
         # FastAPI caches the body after first read, so this is safe
         try:
@@ -87,12 +88,12 @@ class DebugLoggerMiddleware(BaseHTTPMiddleware):
                 debug_logger.log_request_body(body)
         except Exception as e:
             logger.warning(f"Failed to read request body for debug logging: {e}")
-        
+
         # Continue to validation and route handler
         # flush_on_error() or discard_buffers() will be called by:
         # - Route handlers (for successful requests and Kiro API errors)
         # - validation_exception_handler (for 422 validation errors)
         # - Generic exception handlers (for other errors)
         response = await call_next(request)
-        
+
         return response

--- a/kiro/debug_replay.py
+++ b/kiro/debug_replay.py
@@ -17,7 +17,6 @@ from kiro.sse_validation import (
     validate_openai_records,
 )
 
-
 _SECRET_PATTERNS = (
     re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+"),
     re.compile(r"\b(?:klb|apik)_[A-Za-z0-9_-]{8,}\b"),
@@ -49,8 +48,7 @@ def replay_to_file(
 ) -> None:
     """Write the sanitized translated stream and then validate its lifecycle."""
     payload = b"".join(
-        base64.b64decode(record.get("payload_base64", ""))
-        for record in replay.get("translated_sse", [])
+        base64.b64decode(record.get("payload_base64", "")) for record in replay.get("translated_sse", [])
     )
     _write_private_atomic(output, payload)
     validate_replay(replay, protocol)
@@ -89,9 +87,7 @@ def _decode_capture_payloads(replay: dict[str, Any]) -> list[str]:
                     validate=True,
                 ).decode("utf-8")
             except (ValueError, UnicodeDecodeError) as exc:
-                raise ValueError(
-                    "Capture contains invalid base64 payload"
-                ) from exc
+                raise ValueError("Capture contains invalid base64 payload") from exc
             decoded_payloads.append(decoded)
     return decoded_payloads
 
@@ -101,16 +97,11 @@ def _contains_credential(
     decoded_payloads: list[str],
 ) -> bool:
     values = [json.dumps(replay, ensure_ascii=False), *decoded_payloads]
-    return any(
-        pattern.search(value)
-        for value in values
-        for pattern in _SECRET_PATTERNS
-    ) or any(
-        redact_patterns(value) != value
-        for value in values
-    ) or _contains_unredacted_sensitive_field(replay) or any(
-        _text_contains_unredacted_sensitive_field(value)
-        for value in decoded_payloads
+    return (
+        any(pattern.search(value) for value in values for pattern in _SECRET_PATTERNS)
+        or any(redact_patterns(value) != value for value in values)
+        or _contains_unredacted_sensitive_field(replay)
+        or any(_text_contains_unredacted_sensitive_field(value) for value in decoded_payloads)
     )
 
 
@@ -133,11 +124,7 @@ def _contains_unredacted_sensitive_field(value: Any) -> bool:
 
 def _text_contains_unredacted_sensitive_field(value: str) -> bool:
     candidates = [value]
-    candidates.extend(
-        line.removeprefix("data:").strip()
-        for line in value.splitlines()
-        if line.startswith("data:")
-    )
+    candidates.extend(line.removeprefix("data:").strip() for line in value.splitlines() if line.startswith("data:"))
     json_start = value.find("{")
     if json_start > 0:
         candidates.append(value[json_start:])
@@ -146,9 +133,7 @@ def _text_contains_unredacted_sensitive_field(value: str) -> bool:
             parsed = json.loads(candidate)
         except json.JSONDecodeError:
             continue
-        if isinstance(parsed, (dict, list)) and (
-            _contains_unredacted_sensitive_field(parsed)
-        ):
+        if isinstance(parsed, (dict, list)) and (_contains_unredacted_sensitive_field(parsed)):
             return True
     return False
 

--- a/kiro/debug_sanitize.py
+++ b/kiro/debug_sanitize.py
@@ -4,27 +4,28 @@ import json
 import re
 from typing import Any, Optional
 
-
-_SENSITIVE_KEYS = frozenset({
-    "authorization",
-    "proxyauthorization",
-    "xapikey",
-    "apikey",
-    "accesstoken",
-    "refreshtoken",
-    "idtoken",
-    "clientsecret",
-    "cookie",
-    "setcookie",
-    "signature",
-    "thinkingsignature",
-    "profilearn",
-    "password",
-    "token",
-    "secret",
-    "credential",
-    "privatekey",
-})
+_SENSITIVE_KEYS = frozenset(
+    {
+        "authorization",
+        "proxyauthorization",
+        "xapikey",
+        "apikey",
+        "accesstoken",
+        "refreshtoken",
+        "idtoken",
+        "clientsecret",
+        "cookie",
+        "setcookie",
+        "signature",
+        "thinkingsignature",
+        "profilearn",
+        "password",
+        "token",
+        "secret",
+        "credential",
+        "privatekey",
+    }
+)
 _SENSITIVE_KEY_SUFFIXES = (
     "token",
     "secret",
@@ -38,17 +39,19 @@ _SENSITIVE_KEY_SUFFIXES = (
     "sessionid",
     "sessionkey",
 )
-_STRUCTURAL_TEXT_KEYS = frozenset({
-    "type",
-    "role",
-    "model",
-    "name",
-    "id",
-    "tooluseid",
-    "toolcallid",
-    "stopreason",
-    "finishreason",
-})
+_STRUCTURAL_TEXT_KEYS = frozenset(
+    {
+        "type",
+        "role",
+        "model",
+        "name",
+        "id",
+        "tooluseid",
+        "toolcallid",
+        "stopreason",
+        "finishreason",
+    }
+)
 _TOKEN_PATTERNS = (
     re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+"),
     re.compile(r"\bklb_[A-Za-z0-9_-]{8,}\b"),
@@ -59,9 +62,7 @@ _TOKEN_PATTERNS = (
         r"-----END [A-Z ]*PRIVATE KEY-----",
         re.DOTALL,
     ),
-    re.compile(
-        r"(?i)([?&](?:key|token|signature|credential)=)[^&#\s]+"
-    ),
+    re.compile(r"(?i)([?&](?:key|token|signature|credential)=)[^&#\s]+"),
 )
 
 
@@ -77,9 +78,7 @@ def sensitive_key_kind(key: Optional[str]) -> Optional[str]:
     normalized = re.sub(r"[^a-z0-9]", "", (key or "").lower())
     if normalized.endswith("signature"):
         return "signature"
-    if normalized in _SENSITIVE_KEYS or normalized.endswith(
-        _SENSITIVE_KEY_SUFFIXES
-    ):
+    if normalized in _SENSITIVE_KEYS or normalized.endswith(_SENSITIVE_KEY_SUFFIXES):
         return "credential"
     return None
 
@@ -108,11 +107,7 @@ def sanitize_value(
     if isinstance(value, list):
         return [sanitize_value(item, capture_content, key) for item in value]
     if isinstance(value, str):
-        if (
-            normalized_key == "data"
-            and len(value) >= 256
-            and re.fullmatch(r"[A-Za-z0-9+/=_-]+", value)
-        ):
+        if normalized_key == "data" and len(value) >= 256 and re.fullmatch(r"[A-Za-z0-9+/=_-]+", value):
             return "[REDACTED_BINARY]"
         try:
             encoded_json = json.loads(value)
@@ -137,18 +132,17 @@ def sanitize_bytes(data: bytes, capture_content: bool) -> bytes:
     try:
         decoded = data.decode("utf-8")
     except UnicodeDecodeError:
-        return json.dumps({
-            "$redacted_bytes": True,
-            "bytes": len(data),
-        }).encode()
+        return json.dumps(
+            {
+                "$redacted_bytes": True,
+                "bytes": len(data),
+            }
+        ).encode()
     try:
         parsed = json.loads(decoded)
     except json.JSONDecodeError:
         json_start = decoded.find("{")
-        if (
-            json_start > 0
-            and not decoded.lstrip().startswith(("data:", "event:"))
-        ):
+        if json_start > 0 and not decoded.lstrip().startswith(("data:", "event:")):
             try:
                 parsed = json.loads(decoded[json_start:])
             except json.JSONDecodeError:

--- a/kiro/exceptions.py
+++ b/kiro/exceptions.py
@@ -6,7 +6,8 @@ Contains functions for handling validation errors and other exceptions
 in a JSON-serialization compatible format.
 """
 
-from typing import Any, Dict, List
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
@@ -14,7 +15,7 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 
 
-def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def sanitize_validation_errors(errors: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     """
     Converts validation errors to JSON-serializable format.
 
@@ -27,9 +28,9 @@ def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, A
     Returns:
         List of errors with bytes converted to strings
     """
-    sanitized = []
+    sanitized: list[dict[str, Any]] = []
     for error in errors:
-        sanitized_error = {}
+        sanitized_error: dict[str, Any] = {}
         for key, value in error.items():
             if isinstance(value, bytes):
                 # Convert bytes to string

--- a/kiro/exceptions.py
+++ b/kiro/exceptions.py
@@ -6,7 +6,7 @@ Contains functions for handling validation errors and other exceptions
 in a JSON-serialization compatible format.
 """
 
-from typing import Any, List, Dict
+from typing import Any, Dict, List
 
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
@@ -17,13 +17,13 @@ from loguru import logger
 def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Converts validation errors to JSON-serializable format.
-    
+
     Pydantic may include bytes objects in the 'input' field, which
     are not JSON-serializable. This function converts them to strings.
-    
+
     Args:
         errors: List of validation errors from Pydantic
-    
+
     Returns:
         List of errors with bytes converted to strings
     """
@@ -37,8 +37,7 @@ def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, A
             elif isinstance(value, (list, tuple)):
                 # Recursively process lists
                 sanitized_error[key] = [
-                    v.decode("utf-8", errors="replace") if isinstance(v, bytes) else v
-                    for v in value
+                    v.decode("utf-8", errors="replace") if isinstance(v, bytes) else v for v in value
                 ]
             else:
                 sanitized_error[key] = value
@@ -49,39 +48,40 @@ def sanitize_validation_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, A
 async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """
     Pydantic validation error handler.
-    
+
     Logs error details and returns an informative response.
     Correctly handles bytes objects in errors by converting them to strings.
     Also flushes debug logs for validation errors when DEBUG_MODE is enabled.
-    
+
     Args:
         request: FastAPI Request object
         exc: Validation exception from Pydantic
-    
+
     Returns:
         JSONResponse with error details and status 422
     """
     body = await request.body()
     body_str = body.decode("utf-8", errors="replace")
-    
+
     # Sanitize errors for JSON serialization
     sanitized_errors = sanitize_validation_errors(exc.errors())
-    
+
     logger.error(f"Validation error (422): {sanitized_errors}")
     # Log body at DEBUG level to avoid cluttering console with potentially large payloads
     # logger.debug(f"Request body: {body_str[:500]}...")
-    
+
     # Flush debug logs for validation errors
     # This is called AFTER middleware has initialized debug logging,
     # so all app logs during request processing will be captured
     try:
         from kiro.debug_logger import debug_logger
+
         if debug_logger:
             error_message = f"Validation error: {sanitized_errors}"
             debug_logger.flush_on_error(422, error_message)
     except ImportError:
         pass  # debug_logger not available
-    
+
     return JSONResponse(
         status_code=422,
         content={"detail": sanitized_errors, "body": body_str[:500]},

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -20,52 +20,48 @@ import httpx
 from fastapi import HTTPException
 from loguru import logger
 
-from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
 from kiro.auth import KiroAuthManager
+from kiro.config import BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.network_errors import NetworkErrorInfo, classify_network_error, get_short_error_message
 from kiro.utils import get_kiro_headers
-from kiro.network_errors import classify_network_error, get_short_error_message, NetworkErrorInfo
 
 
 class KiroHttpClient:
     """
     HTTP client for Kiro API with retry logic support.
-    
+
     Automatically handles errors and retries requests:
     - 403: refreshes token and retries
     - 429: waits with exponential backoff
     - 5xx: waits with exponential backoff
     - Timeouts: waits with exponential backoff
-    
+
     Supports two modes of operation:
     1. Per-request client: Creates and owns its own httpx.AsyncClient
     2. Shared client: Uses an application-level shared client (recommended)
-    
+
     Using a shared client reduces memory usage and enables connection pooling,
     which is especially important for handling concurrent requests.
-    
+
     Attributes:
         auth_manager: Authentication manager for obtaining tokens
         client: httpx HTTP client (owned or shared)
-    
+
     Example:
         >>> # Per-request client (legacy mode)
         >>> client = KiroHttpClient(auth_manager)
         >>> response = await client.request_with_retry(...)
-        
+
         >>> # Shared client (recommended)
         >>> shared = httpx.AsyncClient(limits=httpx.Limits(...))
         >>> client = KiroHttpClient(auth_manager, shared_client=shared)
         >>> response = await client.request_with_retry(...)
     """
-    
-    def __init__(
-        self,
-        auth_manager: KiroAuthManager,
-        shared_client: Optional[httpx.AsyncClient] = None
-    ):
+
+    def __init__(self, auth_manager: KiroAuthManager, shared_client: Optional[httpx.AsyncClient] = None):
         """
         Initializes the HTTP client.
-        
+
         Args:
             auth_manager: Authentication manager
             shared_client: Optional shared httpx.AsyncClient for connection pooling.
@@ -80,27 +76,27 @@ class KiroHttpClient:
         # rotate immediately instead of sleeping through retries on an account
         # already known to be rate-limited.
         self.retry_rate_limits = True
-    
+
     async def _get_client(self, stream: bool = False) -> httpx.AsyncClient:
         """
         Returns or creates an HTTP client with proper timeouts.
-        
+
         If a shared client was provided at initialization, it is returned as-is.
         Otherwise, creates a new client with appropriate timeout configuration.
-        
+
         httpx timeouts:
         - connect: TCP handshake (DNS + TCP SYN/ACK)
         - read: waiting for data from server between chunks
         - write: sending data to server
         - pool: waiting for free connection from pool
-        
+
         IMPORTANT: FIRST_TOKEN_TIMEOUT is NOT used here!
         It is applied in streaming_openai.py via asyncio.wait_for() to control
         the wait time for the first token from the model (retry business logic).
-        
+
         Args:
             stream: If True, uses STREAMING_READ_TIMEOUT for read (only for new clients)
-        
+
         Returns:
             Active HTTP client
         """
@@ -108,7 +104,7 @@ class KiroHttpClient:
         # Shared client should be pre-configured with appropriate timeouts
         if self._shared_client is not None:
             return self._shared_client
-        
+
         # Create new client if needed (per-request mode)
         if self.client is None or self.client.is_closed:
             if stream:
@@ -116,35 +112,30 @@ class KiroHttpClient:
                 # - connect: 30 sec (TCP connection, usually < 1 sec)
                 # - read: STREAMING_READ_TIMEOUT (300 sec) - model may "think" between chunks
                 # - write/pool: standard values
-                timeout_config = httpx.Timeout(
-                    connect=30.0,
-                    read=STREAMING_READ_TIMEOUT,
-                    write=30.0,
-                    pool=30.0
-                )
+                timeout_config = httpx.Timeout(connect=30.0, read=STREAMING_READ_TIMEOUT, write=30.0, pool=30.0)
                 logger.debug(f"Creating streaming HTTP client (read_timeout={STREAMING_READ_TIMEOUT}s)")
             else:
                 # For regular requests: single timeout of 300 sec
                 timeout_config = httpx.Timeout(timeout=300.0)
                 logger.debug("Creating non-streaming HTTP client (timeout=300s)")
-            
+
             self.client = httpx.AsyncClient(timeout=timeout_config, follow_redirects=True)
         return self.client
-    
+
     async def close(self) -> None:
         """
         Closes the HTTP client if this instance owns it.
-        
+
         If using a shared client, this method does nothing - the shared client
         should be closed by the application lifecycle manager.
-        
+
         Uses graceful exception handling to prevent errors during cleanup
         from masking the original exception in finally blocks.
         """
         # Don't close shared clients - they're managed by the application
         if not self._owns_client:
             return
-        
+
         if self.client and not self.client.is_closed:
             try:
                 await self.client.aclose()
@@ -152,7 +143,7 @@ class KiroHttpClient:
                 # Log but don't propagate - we're in cleanup code
                 # Propagating here could mask the original exception
                 logger.warning(f"Error closing HTTP client: {e}")
-    
+
     async def request_with_retry(
         self,
         method: str,
@@ -164,26 +155,26 @@ class KiroHttpClient:
     ) -> httpx.Response:
         """
         Executes an HTTP request with retry logic.
-        
+
         Automatically handles various error types:
         - 403: refreshes token via auth_manager.force_refresh() and retries
         - 429: waits with exponential backoff (1s, 2s, 4s)
         - 5xx: waits with exponential backoff
         - Timeouts: waits with exponential backoff
-        
+
         For streaming, STREAMING_READ_TIMEOUT is used for waiting between chunks.
         First token timeout is controlled separately in streaming_openai.py via asyncio.wait_for().
-        
+
         Args:
             method: HTTP method (GET, POST, etc.)
             url: Request URL
             json_data: Optional JSON body (for POST/PUT/PATCH)
             params: Optional query parameters (for GET)
             stream: Use streaming (default False)
-        
+
         Returns:
             httpx.Response with successful response
-        
+
         Raises:
             HTTPException: On failure after all attempts (502/504)
         """
@@ -192,27 +183,26 @@ class KiroHttpClient:
         max_retries = FIRST_TOKEN_MAX_RETRIES if stream else MAX_RETRIES
         if retry_rate_limits is None:
             retry_rate_limits = self.retry_rate_limits
-        
+
         client = await self._get_client(stream=stream)
-        last_error = None
         last_error_info: Optional[NetworkErrorInfo] = None
         last_response: Optional[httpx.Response] = None  # Для сохранения последнего 429/5xx
-        
+
         for attempt in range(max_retries):
             try:
                 # Get current token
                 token = await self.auth_manager.get_access_token()
                 headers = get_kiro_headers(self.auth_manager, token)
-                
+
                 # Build request kwargs based on parameters
                 request_kwargs = {"headers": headers}
-                
+
                 if json_data is not None:
                     request_kwargs["content"] = json.dumps(json_data).encode()
-                
+
                 if params is not None:
                     request_kwargs["params"] = params
-                
+
                 if stream:
                     # Prevent CLOSE_WAIT connection leak (issue #38)
                     headers["Connection"] = "close"
@@ -222,11 +212,11 @@ class KiroHttpClient:
                 else:
                     logger.debug("Sending request to Kiro API...")
                     response = await client.request(method, url, **request_kwargs)
-                
+
                 # Check status
                 if response.status_code == 200:
                     return response
-                
+
                 # 403 - token expired, refresh and retry
                 if response.status_code == 403:
                     logger.warning(f"Received 403, refreshing token (attempt {attempt + 1}/{MAX_RETRIES})")
@@ -234,7 +224,7 @@ class KiroHttpClient:
                         await response.aclose()
                     await self.auth_manager.force_refresh()
                     continue
-                
+
                 # With an account pool, a 429 belongs to this account. Return
                 # immediately so the route can rotate instead of adding 1/2/4s
                 # latency before trying a healthy account.
@@ -247,11 +237,11 @@ class KiroHttpClient:
                         break
                     if stream:
                         await response.aclose()
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
+                    delay = BASE_RETRY_DELAY * (2**attempt)
                     logger.warning(f"Received 429, waiting {delay}s (attempt {attempt + 1}/{max_retries})")
                     await asyncio.sleep(delay)
                     continue
-                
+
                 # 5xx - server error, wait and retry
                 if 500 <= response.status_code < 600:
                     last_response = response  # Сохраняем для возврата после exhaustion
@@ -259,52 +249,50 @@ class KiroHttpClient:
                         break
                     if stream:
                         await response.aclose()
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
-                    logger.warning(f"Received {response.status_code}, waiting {delay}s (attempt {attempt + 1}/{max_retries})")
+                    delay = BASE_RETRY_DELAY * (2**attempt)
+                    logger.warning(
+                        f"Received {response.status_code}, waiting {delay}s (attempt {attempt + 1}/{max_retries})"
+                    )
                     await asyncio.sleep(delay)
                     continue
-                
+
                 # Other errors - return as is
                 return response
-                
+
             except httpx.TimeoutException as e:
-                last_error = e
-                
                 # Classify timeout error for user-friendly messaging
                 error_info = classify_network_error(e)
                 last_error_info = error_info
-                
+
                 # Log with user-friendly message
                 short_msg = get_short_error_message(error_info)
-                
+
                 if error_info.is_retryable and attempt < max_retries - 1:
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
+                    delay = BASE_RETRY_DELAY * (2**attempt)
                     logger.warning(f"{short_msg} - waiting {delay}s (attempt {attempt + 1}/{max_retries})")
                     await asyncio.sleep(delay)
                 else:
                     logger.error(f"{short_msg} - no more retries (attempt {attempt + 1}/{max_retries})")
                     if not error_info.is_retryable:
                         break  # Don't retry non-retryable errors
-                
+
             except httpx.RequestError as e:
-                last_error = e
-                
                 # Classify the error for user-friendly messaging
                 error_info = classify_network_error(e)
                 last_error_info = error_info
-                
+
                 # Log with user-friendly message
                 short_msg = get_short_error_message(error_info)
-                
+
                 if error_info.is_retryable and attempt < max_retries - 1:
-                    delay = BASE_RETRY_DELAY * (2 ** attempt)
+                    delay = BASE_RETRY_DELAY * (2**attempt)
                     logger.warning(f"{short_msg} - waiting {delay}s (attempt {attempt + 1}/{max_retries})")
                     await asyncio.sleep(delay)
                 else:
                     logger.error(f"{short_msg} - no more retries (attempt {attempt + 1}/{max_retries})")
                     if not error_info.is_retryable:
                         break  # Don't retry non-retryable errors
-        
+
         # If we have a last_response (429/5xx retry exhausted), return it
         # This allows the caller to see the real status code and error body
         if last_response is not None:
@@ -313,42 +301,37 @@ class KiroHttpClient:
                 f"returning response to caller for classification"
             )
             return last_response
-        
+
         # All attempts exhausted - provide detailed, user-friendly error message
         if last_error_info:
             # Use classified error information
             error_message = last_error_info.user_message
-            
+
             # Add troubleshooting steps
             if last_error_info.troubleshooting_steps:
                 error_message += "\n\nTroubleshooting:\n"
                 for i, step in enumerate(last_error_info.troubleshooting_steps, 1):
                     error_message += f"{i}. {step}\n"
-            
+
             # Add technical details for debugging
             error_message += f"\nTechnical details: {last_error_info.technical_details}"
-            
-            raise HTTPException(
-                status_code=last_error_info.suggested_http_code,
-                detail=error_message.strip()
-            )
+
+            raise HTTPException(status_code=last_error_info.suggested_http_code, detail=error_message.strip())
         else:
             # Fallback if no error was captured (shouldn't happen)
             if stream:
                 raise HTTPException(
-                    status_code=504,
-                    detail=f"Streaming failed after {max_retries} attempts. Unknown error."
+                    status_code=504, detail=f"Streaming failed after {max_retries} attempts. Unknown error."
                 )
             else:
                 raise HTTPException(
-                    status_code=502,
-                    detail=f"Request failed after {max_retries} attempts. Unknown error."
+                    status_code=502, detail=f"Request failed after {max_retries} attempts. Unknown error."
                 )
-    
+
     async def __aenter__(self) -> "KiroHttpClient":
         """Async context manager support."""
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         """Closes the client when exiting context."""
         await self.close()

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -14,7 +14,7 @@ with connection pooling for better resource management.
 
 import asyncio
 import json
-from typing import Optional
+from typing import Optional, TypedDict
 
 import httpx
 from fastapi import HTTPException
@@ -24,6 +24,14 @@ from kiro.auth import KiroAuthManager
 from kiro.config import BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, MAX_RETRIES, STREAMING_READ_TIMEOUT
 from kiro.network_errors import NetworkErrorInfo, classify_network_error, get_short_error_message
 from kiro.utils import get_kiro_headers
+
+
+class RequestKwargs(TypedDict, total=False):
+    """Keyword arguments shared by httpx request construction methods."""
+
+    headers: dict
+    content: bytes
+    params: dict
 
 
 class KiroHttpClient:
@@ -195,7 +203,7 @@ class KiroHttpClient:
                 headers = get_kiro_headers(self.auth_manager, token)
 
                 # Build request kwargs based on parameters
-                request_kwargs = {"headers": headers}
+                request_kwargs: RequestKwargs = {"headers": headers}
 
                 if json_data is not None:
                     request_kwargs["content"] = json.dumps(json_data).encode()

--- a/kiro/kiro_errors.py
+++ b/kiro/kiro_errors.py
@@ -18,25 +18,23 @@ Example:
 """
 
 from dataclasses import dataclass
-from enum import Enum
-from typing import Dict, Any
-
-from loguru import logger
+from typing import Any, Dict
 
 
 @dataclass
 class KiroErrorInfo:
     """
     Structured information about a Kiro API error.
-    
+
     Contains both the enhanced user-friendly message and the original
     error details for logging and debugging.
-    
+
     Attributes:
         reason: Error reason code from Kiro API (as string, e.g. "CONTENT_LENGTH_EXCEEDS_THRESHOLD")
         user_message: Enhanced, user-friendly message for end users
         original_message: Original message from Kiro API (for logging)
     """
+
     reason: str
     user_message: str
     original_message: str
@@ -45,19 +43,19 @@ class KiroErrorInfo:
 def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
     """
     Enhances Kiro API error with user-friendly message.
-    
+
     Takes raw error JSON from Kiro API and returns structured information
     with enhanced, user-friendly messages that help users understand what
     went wrong without technical jargon.
-    
+
     Args:
         error_json: Parsed JSON from Kiro API error response
                    Expected format: {"message": "...", "reason": "..."}
                    The "reason" field is optional.
-    
+
     Returns:
         KiroErrorInfo with enhanced message and original details
-    
+
     Example:
         >>> error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
         >>> error_info = enhance_kiro_error(error_json)
@@ -65,7 +63,7 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
         "Model context limit reached. Conversation size exceeds model capacity."
         >>> print(error_info.original_message)
         "Input is too long."
-    
+
     Example (unknown error):
         >>> error_json = {"message": "Something went wrong.", "reason": "UNKNOWN_REASON"}
         >>> error_info = enhance_kiro_error(error_json)
@@ -77,20 +75,20 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
     original_message = error_json.get("message")
     if original_message is None:
         original_message = "Unknown error"
-    
+
     reason = error_json.get("reason")
     if reason is None:
         reason = "UNKNOWN"
-    
+
     # Map known reasons to user-friendly messages
     if reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD":
         # Context limit exceeded - conversation is too long
         user_message = "Model context limit reached. Conversation size exceeds model capacity."
-    
+
     elif reason == "MONTHLY_REQUEST_COUNT":
         # Monthly request limit exceeded - account quota exhausted
         user_message = "Monthly request limit exceeded. Account has reached its monthly quota."
-    
+
     elif reason == "INVALID_MODEL_ID":
         # Invalid model name or subscription tier insufficient
         user_message = "Invalid model ID or insufficient subscription level to use it."
@@ -107,7 +105,7 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
     #     user_message = "Rate limit exceeded. Too many requests in a short time."
     # elif reason == "INVALID_MODEL":
     #     user_message = "Invalid model specified. The requested model is not available."
-    
+
     else:
         # Unknown error or no enhancement available
         # Keep original message and append reason if present
@@ -115,9 +113,5 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
             user_message = f"{original_message} (reason: {reason})"
         else:
             user_message = original_message
-    
-    return KiroErrorInfo(
-        reason=reason,
-        user_message=user_message,
-        original_message=original_message
-    )
+
+    return KiroErrorInfo(reason=reason, user_message=user_message, original_message=original_message)

--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -16,7 +16,7 @@ import string
 import time
 import uuid
 from datetime import datetime
-from typing import Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 import httpx
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -24,11 +24,17 @@ from loguru import logger
 
 from kiro.tokenizer import count_message_tokens, count_tokens
 
+if TYPE_CHECKING:
+    from kiro.debug_logger import DebugLogger
+
 # Import debug_logger
+debug_logger: Optional["DebugLogger"] = None
 try:
-    from kiro.debug_logger import debug_logger
+    from kiro.debug_logger import debug_logger as _loaded_debug_logger
 except ImportError:
-    debug_logger = None
+    pass
+else:
+    debug_logger = _loaded_debug_logger
 
 
 # ==================================================================================================
@@ -576,6 +582,7 @@ async def handle_native_web_search(request, request_data, auth_manager, api_form
                 "error": {"type": "api_error", "message": "Web search failed. Please try again."},
             },
         )
+    assert tool_use_id is not None
 
     # Count tokens WITHOUT Claude correction (MCP API, not model)
     input_tokens = count_message_tokens(

--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -11,12 +11,12 @@ This module provides:
 """
 
 import json
-import time
-import uuid
 import random
 import string
+import time
+import uuid
 from datetime import datetime
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import httpx
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -35,45 +35,44 @@ except ImportError:
 # ID Generation
 # ==================================================================================================
 
+
 def generate_random_id(length: int) -> str:
     """
     Generate random alphanumeric string.
-    
+
     Args:
         length: Length of string to generate
-    
+
     Returns:
         Random string of specified length
-    
+
     Example:
         >>> generate_random_id(22)
         'aBcD1234567890XyZ12345'
     """
-    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+    return "".join(random.choices(string.ascii_letters + string.digits, k=length))
 
 
 # ==================================================================================================
 # MCP API Functions
 # ==================================================================================================
 
-async def call_kiro_mcp_api(
-    query: str,
-    auth_manager
-) -> Tuple[Optional[str], Optional[Dict]]:
+
+async def call_kiro_mcp_api(query: str, auth_manager) -> Tuple[Optional[str], Optional[Dict]]:
     """
     Call Kiro MCP API for web_search.
-    
+
     URL: {auth_manager.q_host}/mcp
     Headers: Authorization, x-amzn-codewhisperer-optout, Content-Type
     Timeout: 60 seconds
-    
+
     Args:
         query: Search query
         auth_manager: KiroAuthManager instance
-    
+
     Returns:
         Tuple of (tool_use_id, results_dict) or (None, None) on error
-    
+
     MCP Request Format:
         {
             "id": "web_search_tooluse_{22random}_{timestamp}_{8random}",
@@ -84,7 +83,7 @@ async def call_kiro_mcp_api(
                 "arguments": {"query": "..."}
             }
         }
-    
+
     MCP Response Format:
         {
             "id": "web_search_tooluse_...",
@@ -97,7 +96,7 @@ async def call_kiro_mcp_api(
                 "isError": false
             }
         }
-    
+
     CRITICAL: result.content[0].text is a JSON STRING, not a dict!
     """
     # Generate IDs
@@ -106,70 +105,67 @@ async def call_kiro_mcp_api(
     random_8 = generate_random_id(8)
     request_id = f"web_search_tooluse_{random_22}_{timestamp}_{random_8}"
     tool_use_id = f"srvtoolu_{uuid.uuid4().hex[:32]}"
-    
+
     # Build MCP request
     mcp_request = {
         "id": request_id,
         "jsonrpc": "2.0",
         "method": "tools/call",
-        "params": {
-            "name": "web_search",
-            "arguments": {"query": query}
-        }
+        "params": {"name": "web_search", "arguments": {"query": query}},
     }
-    
+
     # Log MCP request
     try:
-        mcp_request_json = json.dumps(mcp_request, ensure_ascii=False, indent=2).encode('utf-8')
+        mcp_request_json = json.dumps(mcp_request, ensure_ascii=False, indent=2).encode("utf-8")
         if debug_logger:
             debug_logger.log_raw_chunk(b"[MCP REQUEST]\n" + mcp_request_json)
     except Exception as e:
         logger.warning(f"Failed to log MCP request: {e}")
-    
+
     try:
         token = await auth_manager.get_access_token()
-        
+
         # EXACT headers from architecture
         headers = {
             "Authorization": f"Bearer {token}",
             "x-amzn-codewhisperer-optout": "false",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
-        
+
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")
-        
+
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(mcp_url, json=mcp_request, headers=headers)
-            
+
             if response.status_code != 200:
                 logger.error(f"MCP API error: {response.status_code}")
                 return None, None
-            
+
             mcp_response = response.json()
-            
+
             # Log MCP response
             try:
-                mcp_response_json = json.dumps(mcp_response, ensure_ascii=False, indent=2).encode('utf-8')
+                mcp_response_json = json.dumps(mcp_response, ensure_ascii=False, indent=2).encode("utf-8")
                 if debug_logger:
                     debug_logger.log_raw_chunk(b"[MCP RESPONSE]\n" + mcp_response_json)
             except Exception as e:
                 logger.warning(f"Failed to log MCP response: {e}")
-            
+
             # DEBUG: Log full MCP response to see what we actually got
             # logger.debug(f"MCP API full response: {json.dumps(mcp_response, ensure_ascii=False)}")
-            
+
             if "error" in mcp_response and mcp_response["error"] is not None:
                 logger.error(f"MCP API returned error: {mcp_response['error']}")
                 return None, None
-            
+
             # Parse results: result.content[0].text is JSON STRING (CRITICAL!)
             result_text = mcp_response.get("result", {}).get("content", [{}])[0].get("text", "{}")
             results = json.loads(result_text)  # Parse JSON string to dict
-            
+
             logger.debug(f"MCP API returned {results.get('totalResults', 0)} results")
             return tool_use_id, results
-            
+
     except httpx.TimeoutException as e:
         logger.error(f"MCP API timeout: {e}")
         return None, None
@@ -187,24 +183,24 @@ async def call_kiro_mcp_api(
 def generate_search_summary(query: str, results: Dict) -> str:
     """
     Generate human-readable summary from search results wrapped in XML tags.
-    
+
     Wraps results in <web_search>...</web_search> tags to visually distinguish
     tool output from model's own text. Returns FULL snippets without truncation
     so the model has complete information.
-    
+
     Format per result:
     - Title
     - Published date (converted from milliseconds timestamp)
     - URL
     - Full snippet (no truncation)
-    
+
     Args:
         query: Original search query
         results: Parsed MCP response (dict with "results" key)
-    
+
     Returns:
         Formatted summary text wrapped in XML tags with full snippets
-    
+
     Example:
         '<web_search>\nSearch results for "Python tutorials":\n\n
         1. Title: **Learn Python - Official Tutorial**\n
@@ -215,17 +211,17 @@ def generate_search_summary(query: str, results: Dict) -> str:
     """
     # Start with opening tag
     summary = f'\n<web_search>\nSearch results for "{query}":\n\n'
-    
+
     if results and "results" in results:
         for i, result in enumerate(results["results"], 1):
             title = result.get("title", "Untitled")
             url = result.get("url", "")
             snippet = result.get("snippet", "")
             published_date_ms = result.get("publishedDate")
-            
+
             # Format: Title
             summary += f"{i}. Title: **{title}**\n"
-            
+
             # Format: Published date (convert from milliseconds timestamp)
             if published_date_ms:
                 try:
@@ -237,22 +233,22 @@ def generate_search_summary(query: str, results: Dict) -> str:
                 except (ValueError, OSError):
                     # Invalid timestamp - skip date
                     pass
-            
+
             # Format: URL
             if url:
                 summary += f"   URL: {url}\n"
-            
+
             # Format: Snippet (NO truncation - model needs full information)
             if snippet:
                 summary += f"   {snippet}\n"
-            
+
             summary += "\n"
     else:
         summary += "No results found.\n"
-    
+
     # Close with closing tag
     summary += "</web_search>\n"
-    
+
     return summary
 
 
@@ -260,16 +256,11 @@ def generate_search_summary(query: str, results: Dict) -> str:
 # SSE Emulation (Anthropic Format)
 # ==================================================================================================
 
-async def generate_anthropic_web_search_sse(
-    model: str,
-    query: str,
-    tool_use_id: str,
-    results: Dict,
-    input_tokens: int
-):
+
+async def generate_anthropic_web_search_sse(model: str, query: str, tool_use_id: str, results: Dict, input_tokens: int):
     """
     Generate Anthropic SSE stream for web_search response.
-    
+
     Emulates 11 events (EXACT structure from architecture):
     1. message_start - with usage (input_tokens)
     2. content_block_start - server_tool_use
@@ -282,229 +273,204 @@ async def generate_anthropic_web_search_sse(
     N+1. content_block_stop - text
     N+2. message_delta - stop_reason + output_tokens
     N+3. message_stop
-    
+
     Args:
         model: Model name
         query: Search query
         tool_use_id: Tool use ID
         results: Search results dict
         input_tokens: Input token count
-    
+
     Yields:
         SSE formatted strings
     """
     from kiro.streaming_anthropic import format_sse_event
-    
+
     message_id = f"msg_{uuid.uuid4().hex[:24]}"
     summary = generate_search_summary(query, results)
-    
+
     # Count output tokens WITHOUT Claude correction (MCP API response, not model generation)
     output_tokens = count_tokens(summary, apply_claude_correction=False)
-    
+
     # Event 1: message_start
-    yield format_sse_event("message_start", {
-        "type": "message_start",
-        "message": {
-            "id": message_id,
-            "type": "message",
-            "role": "assistant",
-            "model": model,
-            "content": [],
-            "stop_reason": None,
-            "usage": {"input_tokens": input_tokens, "output_tokens": 0}
-        }
-    })
-    
+    yield format_sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+            },
+        },
+    )
+
     # Event 2: content_block_start (server_tool_use)
-    yield format_sse_event("content_block_start", {
-        "type": "content_block_start",
-        "index": 0,
-        "content_block": {
-            "id": tool_use_id,
-            "type": "server_tool_use",
-            "name": "web_search",
-            "input": {}
-        }
-    })
-    
+    yield format_sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"id": tool_use_id, "type": "server_tool_use", "name": "web_search", "input": {}},
+        },
+    )
+
     # Event 3: content_block_delta (input_json_delta)
-    yield format_sse_event("content_block_delta", {
-        "type": "content_block_delta",
-        "index": 0,
-        "delta": {
-            "type": "input_json_delta",
-            "partial_json": json.dumps({"query": query})
-        }
-    })
-    
+    yield format_sse_event(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": json.dumps({"query": query})},
+        },
+    )
+
     # Event 4: content_block_stop (server_tool_use)
-    yield format_sse_event("content_block_stop", {
-        "type": "content_block_stop",
-        "index": 0
-    })
-    
+    yield format_sse_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+
     # Event 5: content_block_start (web_search_tool_result)
     search_content = []
     for r in results.get("results", []):
-        search_content.append({
-            "type": "web_search_result",
-            "title": r.get("title", ""),
-            "url": r.get("url", ""),
-            "encrypted_content": r.get("snippet", ""),
-            "page_age": None
-        })
-    
-    yield format_sse_event("content_block_start", {
-        "type": "content_block_start",
-        "index": 1,
-        "content_block": {
-            "type": "web_search_tool_result",
-            "tool_use_id": tool_use_id,
-            "content": search_content
-        }
-    })
-    
+        search_content.append(
+            {
+                "type": "web_search_result",
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "encrypted_content": r.get("snippet", ""),
+                "page_age": None,
+            }
+        )
+
+    yield format_sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {"type": "web_search_tool_result", "tool_use_id": tool_use_id, "content": search_content},
+        },
+    )
+
     # Event 6: content_block_stop (web_search_tool_result)
-    yield format_sse_event("content_block_stop", {
-        "type": "content_block_stop",
-        "index": 1
-    })
-    
+    yield format_sse_event("content_block_stop", {"type": "content_block_stop", "index": 1})
+
     # Event 7: content_block_start (text)
-    yield format_sse_event("content_block_start", {
-        "type": "content_block_start",
-        "index": 2,
-        "content_block": {"type": "text", "text": ""}
-    })
-    
+    yield format_sse_event(
+        "content_block_start",
+        {"type": "content_block_start", "index": 2, "content_block": {"type": "text", "text": ""}},
+    )
+
     # Events 8-N: content_block_delta (text_delta) - stream summary in chunks
     chunk_size = 100
     for i in range(0, len(summary), chunk_size):
-        chunk = summary[i:i + chunk_size]
-        yield format_sse_event("content_block_delta", {
-            "type": "content_block_delta",
-            "index": 2,
-            "delta": {"type": "text_delta", "text": chunk}
-        })
-    
+        chunk = summary[i : i + chunk_size]
+        yield format_sse_event(
+            "content_block_delta",
+            {"type": "content_block_delta", "index": 2, "delta": {"type": "text_delta", "text": chunk}},
+        )
+
     # Event N+1: content_block_stop (text)
-    yield format_sse_event("content_block_stop", {
-        "type": "content_block_stop",
-        "index": 2
-    })
-    
+    yield format_sse_event("content_block_stop", {"type": "content_block_stop", "index": 2})
+
     # Event N+2: message_delta
-    yield format_sse_event("message_delta", {
-        "type": "message_delta",
-        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
-        "usage": {"output_tokens": output_tokens}
-    })
-    
+    yield format_sse_event(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": output_tokens},
+        },
+    )
+
     # Event N+3: message_stop
-    yield format_sse_event("message_stop", {
-        "type": "message_stop"
-    })
+    yield format_sse_event("message_stop", {"type": "message_stop"})
 
 
 # ==================================================================================================
 # SSE Emulation (OpenAI Format)
 # ==================================================================================================
 
-async def generate_openai_web_search_sse(
-    model: str,
-    query: str,
-    tool_use_id: str,
-    results: Dict,
-    input_tokens: int
-):
+
+async def generate_openai_web_search_sse(model: str, query: str, tool_use_id: str, results: Dict, input_tokens: int):
     """
     Generate OpenAI SSE stream for web_search response.
-    
+
     CRITICAL: OpenAI format is COMPLETELY different from Anthropic:
     - data: {...} WITHOUT event: prefix
     - choices[0].delta structure
     - finish_reason instead of stop_reason
     - chat.completion.chunk object type
-    
+
     Emulates server-side execution: returns summary directly as content,
     WITHOUT tool_calls flow (model doesn't call tool, MCP API already executed).
-    
+
     Args:
         model: Model name
         query: Search query
         tool_use_id: Tool use ID (not used in OpenAI format)
         results: Search results dict
         input_tokens: Input token count
-    
+
     Yields:
         SSE formatted strings (OpenAI format)
-    
+
     Example OpenAI SSE:
         data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"claude-sonnet-4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
-        
+
         data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1234567890,"model":"claude-sonnet-4","choices":[{"index":0,"delta":{"content":"Here"},"finish_reason":null}]}
-        
+
         data: [DONE]
     """
     from kiro.utils import generate_completion_id
-    
+
     completion_id = generate_completion_id()
     created_time = int(time.time())
     summary = generate_search_summary(query, results)
-    
+
     # Count output tokens WITHOUT Claude correction (MCP API response, not model generation)
     output_tokens = count_tokens(summary, apply_claude_correction=False)
-    
+
     # Chunk 1: role
     chunk = {
         "id": completion_id,
         "object": "chat.completion.chunk",
         "created": created_time,
         "model": model,
-        "choices": [{
-            "index": 0,
-            "delta": {"role": "assistant"},
-            "finish_reason": None
-        }]
+        "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
     }
     yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-    
+
     # Chunks 2-N: content (stream summary in chunks)
     chunk_size = 100
     for i in range(0, len(summary), chunk_size):
-        content_chunk = summary[i:i + chunk_size]
+        content_chunk = summary[i : i + chunk_size]
         chunk = {
             "id": completion_id,
             "object": "chat.completion.chunk",
             "created": created_time,
             "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {"content": content_chunk},
-                "finish_reason": None
-            }]
+            "choices": [{"index": 0, "delta": {"content": content_chunk}, "finish_reason": None}],
         }
         yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-    
+
     # Chunk N+1: finish_reason + usage
     chunk = {
         "id": completion_id,
         "object": "chat.completion.chunk",
         "created": created_time,
         "model": model,
-        "choices": [{
-            "index": 0,
-            "delta": {},
-            "finish_reason": "stop"
-        }],
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
         "usage": {
             "prompt_tokens": input_tokens,
             "completion_tokens": output_tokens,
-            "total_tokens": input_tokens + output_tokens
-        }
+            "total_tokens": input_tokens + output_tokens,
+        },
     }
     yield f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-    
+
     # Final: [DONE]
     yield "data: [DONE]\n\n"
 
@@ -513,33 +479,34 @@ async def generate_openai_web_search_sse(
 # Path A: Native Anthropic Handler
 # ==================================================================================================
 
+
 def extract_query_from_messages(messages, api_format: str) -> Optional[str]:
     """
     Extract search query from first user message.
-    
+
     IMPORTANT: messages is a list of Pydantic models, NOT dicts.
     Use hasattr() and getattr() to access fields.
-    
+
     LIMITATION: Extracts query only from the FIRST message (single-turn).
     This is acceptable for web_search use case.
-    
+
     Args:
         messages: List of messages from request (Pydantic models)
         api_format: "anthropic" or "openai"
-    
+
     Returns:
         Search query string or None
     """
     if not messages:
         return None
-    
+
     first_msg = messages[0]
-    
+
     # Extract content (Pydantic model - always use hasattr/getattr)
-    content = getattr(first_msg, 'content', None)
+    content = getattr(first_msg, "content", None)
     if content is None:
         return None
-    
+
     # Convert to text
     if isinstance(content, str):
         text = content
@@ -548,7 +515,7 @@ def extract_query_from_messages(messages, api_format: str) -> Optional[str]:
         text_parts = []
         for block in content:
             # Handle both Pydantic models and dicts
-            if hasattr(block, 'type') and hasattr(block, 'text'):
+            if hasattr(block, "type") and hasattr(block, "text"):
                 # Pydantic model (TextContentBlock)
                 if block.type == "text":
                     text_parts.append(block.text)
@@ -558,35 +525,30 @@ def extract_query_from_messages(messages, api_format: str) -> Optional[str]:
         text = "".join(text_parts)
     else:
         return None
-    
+
     # Remove prefix if present (some clients add this)
     prefix = "Perform a web search for the query: "
     if text.startswith(prefix):
-        query = text[len(prefix):]
+        query = text[len(prefix) :]
     else:
         query = text
-    
+
     return query.strip() if query.strip() else None
 
 
-async def handle_native_web_search(
-    request,
-    request_data,
-    auth_manager,
-    api_format: str = "anthropic"
-):
+async def handle_native_web_search(request, request_data, auth_manager, api_format: str = "anthropic"):
     """
     Handle native Anthropic web_search (Path A).
-    
+
     This function bypasses /generateAssistantResponse entirely.
     Direct MCP API call → SSE emulation → return to client.
-    
+
     Args:
         request: FastAPI Request
         request_data: Validated request (AnthropicMessagesRequest or ChatCompletionRequest)
         auth_manager: KiroAuthManager instance
         api_format: "anthropic" or "openai"
-    
+
     Returns:
         StreamingResponse or JSONResponse
     """
@@ -597,139 +559,107 @@ async def handle_native_web_search(
             status_code=400,
             content={
                 "type": "error",
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": "Cannot extract search query from messages"
-                }
-            }
+                "error": {"type": "invalid_request_error", "message": "Cannot extract search query from messages"},
+            },
         )
-    
+
     logger.info(f"WebSearch query (Path A - native): {query}")
-    
+
     # Call MCP API
     tool_use_id, results = await call_kiro_mcp_api(query, auth_manager)
-    
+
     if results is None:
         return JSONResponse(
             status_code=500,
             content={
                 "type": "error",
-                "error": {
-                    "type": "api_error",
-                    "message": "Web search failed. Please try again."
-                }
-            }
+                "error": {"type": "api_error", "message": "Web search failed. Please try again."},
+            },
         )
-    
+
     # Count tokens WITHOUT Claude correction (MCP API, not model)
     input_tokens = count_message_tokens(
-        [msg.model_dump() for msg in request_data.messages],
-        apply_claude_correction=False
+        [msg.model_dump() for msg in request_data.messages], apply_claude_correction=False
     )
-    
+
     # Return response based on streaming mode and API format
     if request_data.stream:
         # Streaming mode - generate SSE
         logger.debug(f"Returning streaming web_search response (api_format={api_format})")
-        
+
         if api_format == "openai":
             sse_generator = generate_openai_web_search_sse(
-                request_data.model,
-                query,
-                tool_use_id,
-                results,
-                input_tokens
+                request_data.model, query, tool_use_id, results, input_tokens
             )
         else:  # anthropic
             sse_generator = generate_anthropic_web_search_sse(
-                request_data.model,
-                query,
-                tool_use_id,
-                results,
-                input_tokens
+                request_data.model, query, tool_use_id, results, input_tokens
             )
-        
+
         return StreamingResponse(
             sse_generator,
             media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
         )
     else:
         # Non-streaming mode - return full JSON
         logger.debug(f"Returning non-streaming web_search response (api_format={api_format})")
         summary = generate_search_summary(query, results)
-        
+
         # Count output tokens WITHOUT Claude correction (MCP API response)
         output_tokens = count_tokens(summary, apply_claude_correction=False)
-        
+
         if api_format == "openai":
             # OpenAI format: chat.completion
             from kiro.utils import generate_completion_id
+
             completion_id = generate_completion_id()
             created_time = int(time.time())
-            
+
             full_response = {
                 "id": completion_id,
                 "object": "chat.completion",
                 "created": created_time,
                 "model": request_data.model,
-                "choices": [{
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": summary
-                    },
-                    "finish_reason": "stop"
-                }],
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": summary}, "finish_reason": "stop"}
+                ],
                 "usage": {
                     "prompt_tokens": input_tokens,
                     "completion_tokens": output_tokens,
-                    "total_tokens": input_tokens + output_tokens
-                }
+                    "total_tokens": input_tokens + output_tokens,
+                },
             }
         else:  # anthropic
             # Anthropic format: message
             message_id = f"msg_{uuid.uuid4().hex[:24]}"
-            
+
             # Build search results content
             search_content = []
             for r in results.get("results", []):
-                search_content.append({
-                    "type": "web_search_result",
-                    "title": r.get("title", ""),
-                    "url": r.get("url", ""),
-                    "encrypted_content": r.get("snippet", ""),
-                    "page_age": None
-                })
-            
+                search_content.append(
+                    {
+                        "type": "web_search_result",
+                        "title": r.get("title", ""),
+                        "url": r.get("url", ""),
+                        "encrypted_content": r.get("snippet", ""),
+                        "page_age": None,
+                    }
+                )
+
             full_response = {
                 "id": message_id,
                 "type": "message",
                 "role": "assistant",
                 "content": [
-                    {
-                        "type": "server_tool_use",
-                        "id": tool_use_id,
-                        "name": "web_search",
-                        "input": {"query": query}
-                    },
-                    {
-                        "type": "web_search_tool_result",
-                        "tool_use_id": tool_use_id,
-                        "content": search_content
-                    },
-                    {
-                        "type": "text",
-                        "text": summary
-                    }
+                    {"type": "server_tool_use", "id": tool_use_id, "name": "web_search", "input": {"query": query}},
+                    {"type": "web_search_tool_result", "tool_use_id": tool_use_id, "content": search_content},
+                    {"type": "text", "text": summary},
                 ],
                 "model": request_data.model,
                 "stop_reason": "end_turn",
                 "stop_sequence": None,
-                "usage": {
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens
-                }
+                "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
             }
-        
+
         return JSONResponse(content=full_response)

--- a/kiro/model_resolver.py
+++ b/kiro/model_resolver.py
@@ -33,14 +33,14 @@ VALID_RUNTIME_MODEL_IDS: set = {model["modelId"] for model in FALLBACK_MODELS}
 def to_runtime_model_id(normalized: str) -> str:
     """
     Pass-through function for runtime.kiro.dev model ID.
-    
+
     Previously performed fallback to "auto" for unknown models, but this violated
     the "gateway, not gatekeeper" principle. Now returns model as-is and lets
     Kiro API decide if the model exists.
-    
+
     Args:
         normalized: Normalized model name
-    
+
     Returns:
         Model name as-is (no fallback)
     """
@@ -51,7 +51,7 @@ def to_runtime_model_id(normalized: str) -> str:
 class ModelResolution:
     """
     Result of model resolution.
-    
+
     Attributes:
         internal_id: ID to send to Kiro API
         source: Resolution source - "cache", "hidden", or "passthrough"
@@ -59,6 +59,7 @@ class ModelResolution:
         normalized: Model name after normalization
         is_verified: True if found in cache/hidden, False if passthrough
     """
+
     internal_id: str
     source: str
     original_request: str
@@ -69,7 +70,7 @@ class ModelResolution:
 def normalize_model_name(name: str) -> str:
     """
     Normalize client model name to Kiro format.
-    
+
     Transformations applied:
     1. claude-haiku-4-5 → claude-haiku-4.5 (dash to dot for minor version)
     2. claude-haiku-4-5-20251001 → claude-haiku-4.5 (strip date suffix)
@@ -78,13 +79,13 @@ def normalize_model_name(name: str) -> str:
     5. claude-3-7-sonnet → claude-3.7-sonnet (legacy format normalization)
     6. claude-3-7-sonnet-20250219 → claude-3.7-sonnet (legacy + strip date)
     7. claude-4.5-opus-high → claude-opus-4.5 (inverted format with suffix)
-    
+
     Args:
         name: External model name from client
-    
+
     Returns:
         Normalized model name in Kiro format
-    
+
     Examples:
         >>> normalize_model_name("claude-haiku-4-5-20251001")
         'claude-haiku-4.5'
@@ -111,62 +112,62 @@ def normalize_model_name(name: str) -> str:
         return name
 
     # Strip context window suffix (e.g., [1m], [200k]) — client-side indicator, not a model ID
-    name = re.sub(r'\[\d+[mk]\]$', '', name, flags=re.IGNORECASE)
+    name = re.sub(r"\[\d+[mk]\]$", "", name, flags=re.IGNORECASE)
 
     # Lowercase for consistent matching
     name_lower = name.lower()
-    
+
     # Pattern 1: Standard format - claude-{family}-{major}-{minor}(-{suffix})?
     # Matches: claude-haiku-4-5, claude-haiku-4-5-20251001, claude-haiku-4-5-latest
     # Groups: (claude-haiku-4), (5), optional suffix
     # IMPORTANT: Minor version is 1-2 digits only! 8-digit dates should NOT match here.
-    standard_pattern = r'^(claude-(?:haiku|sonnet|opus)-\d+)-(\d{1,2})(?:-(?:\d{8}|latest|\d+))?$'
+    standard_pattern = r"^(claude-(?:haiku|sonnet|opus)-\d+)-(\d{1,2})(?:-(?:\d{8}|latest|\d+))?$"
     match = re.match(standard_pattern, name_lower)
     if match:
         base = match.group(1)  # claude-haiku-4
         minor = match.group(2)  # 5
         return f"{base}.{minor}"  # claude-haiku-4.5
-    
+
     # Pattern 2: Standard format without minor - claude-{family}-{major}(-{date})?
     # Matches: claude-sonnet-4, claude-sonnet-4-20250514
     # Groups: (claude-sonnet-4), optional date
-    no_minor_pattern = r'^(claude-(?:haiku|sonnet|opus)-\d+)(?:-\d{8})?$'
+    no_minor_pattern = r"^(claude-(?:haiku|sonnet|opus)-\d+)(?:-\d{8})?$"
     match = re.match(no_minor_pattern, name_lower)
     if match:
         return match.group(1)  # claude-sonnet-4
-    
+
     # Pattern 3: Legacy format - claude-{major}-{minor}-{family}(-{suffix})?
     # Matches: claude-3-7-sonnet, claude-3-7-sonnet-20250219
     # Groups: (claude), (3), (7), (sonnet), optional suffix
-    legacy_pattern = r'^(claude)-(\d+)-(\d+)-(haiku|sonnet|opus)(?:-(?:\d{8}|latest|\d+))?$'
+    legacy_pattern = r"^(claude)-(\d+)-(\d+)-(haiku|sonnet|opus)(?:-(?:\d{8}|latest|\d+))?$"
     match = re.match(legacy_pattern, name_lower)
     if match:
         prefix = match.group(1)  # claude
-        major = match.group(2)   # 3
-        minor = match.group(3)   # 7
+        major = match.group(2)  # 3
+        minor = match.group(3)  # 7
         family = match.group(4)  # sonnet
         return f"{prefix}-{major}.{minor}-{family}"  # claude-3.7-sonnet
-    
+
     # Pattern 4: Already normalized with dot but has date suffix
     # Matches: claude-haiku-4.5-20251001, claude-3.7-sonnet-20250219
-    dot_with_date_pattern = r'^(claude-(?:\d+\.\d+-)?(?:haiku|sonnet|opus)(?:-\d+\.\d+)?)-\d{8}$'
+    dot_with_date_pattern = r"^(claude-(?:\d+\.\d+-)?(?:haiku|sonnet|opus)(?:-\d+\.\d+)?)-\d{8}$"
     match = re.match(dot_with_date_pattern, name_lower)
     if match:
         return match.group(1)
-    
+
     # Pattern 5: Inverted format with suffix - claude-{major}.{minor}-{family}-{suffix}
     # Matches: claude-4.5-opus-high, claude-4.5-sonnet-low, claude-4.5-opus-high-thinking
     # Convert to: claude-{family}-{major}.{minor}
     # Groups: (4), (5), (opus), any suffix
     # NOTE: This pattern REQUIRES a suffix to avoid matching already-normalized formats like claude-3.7-sonnet
-    inverted_with_suffix_pattern = r'^claude-(\d+)\.(\d+)-(haiku|sonnet|opus)-(.+)$'
+    inverted_with_suffix_pattern = r"^claude-(\d+)\.(\d+)-(haiku|sonnet|opus)-(.+)$"
     match = re.match(inverted_with_suffix_pattern, name_lower)
     if match:
-        major = match.group(1)   # 4
-        minor = match.group(2)   # 5
+        major = match.group(1)  # 4
+        minor = match.group(2)  # 5
         family = match.group(3)  # opus
         return f"claude-{family}-{major}.{minor}"  # claude-opus-4.5
-    
+
     # No transformation needed - return as-is (preserving original case for passthrough)
     return name
 
@@ -193,7 +194,7 @@ def get_model_id_for_kiro(
 
     Returns:
         Model ID to send to Kiro API
-    
+
     Examples:
         >>> get_model_id_for_kiro("claude-haiku-4-5-20251001", {})
         'claude-haiku-4.5'
@@ -215,13 +216,13 @@ def get_model_id_for_kiro(
 def extract_model_family(model_name: str) -> Optional[str]:
     """
     Extract model family from model name.
-    
+
     Args:
         model_name: Model name (normalized or not)
-    
+
     Returns:
         Family name ('haiku', 'sonnet', 'opus') or None if not a Claude model
-    
+
     Examples:
         >>> extract_model_family("claude-haiku-4.5")
         'haiku'
@@ -232,7 +233,7 @@ def extract_model_family(model_name: str) -> Optional[str]:
         >>> extract_model_family("gpt-4")
         None
     """
-    family_match = re.search(r'(haiku|sonnet|opus)', model_name, re.IGNORECASE)
+    family_match = re.search(r"(haiku|sonnet|opus)", model_name, re.IGNORECASE)
     if family_match:
         return family_match.group(1).lower()
     return None
@@ -241,23 +242,23 @@ def extract_model_family(model_name: str) -> Optional[str]:
 class ModelResolver:
     """
     Dynamic model resolver with normalization and optimistic pass-through.
-    
+
     Key principle: We are a gateway, not a gatekeeper.
     Kiro API is the final arbiter of what models exist.
-    
+
     Resolution layers:
     0. Resolve aliases (custom name mappings)
     1. Normalize name (dashes→dots, strip dates)
     2. Check dynamic cache (from /ListAvailableModels)
     3. Check hidden models (manual config)
     4. Pass-through (let Kiro decide)
-    
+
     Attributes:
         cache: ModelInfoCache instance for dynamic model lookup
         hidden_models: Dict mapping display names to internal Kiro IDs
         aliases: Dict mapping alias names to real model IDs
         hidden_from_list: Set of model IDs to hide from /v1/models endpoint
-    
+
     Example:
         >>> resolver = ModelResolver(cache, hidden_models, aliases={"auto-kiro": "auto"})
         >>> resolution = resolver.resolve("auto-kiro")
@@ -266,17 +267,17 @@ class ModelResolver:
         >>> resolution.source
         'cache'
     """
-    
+
     def __init__(
         self,
         cache: ModelInfoCache,
         hidden_models: Optional[Dict[str, str]] = None,
         aliases: Optional[Dict[str, str]] = None,
-        hidden_from_list: Optional[List[str]] = None
+        hidden_from_list: Optional[List[str]] = None,
     ):
         """
         Initialize the model resolver.
-        
+
         Args:
             cache: ModelInfoCache instance for dynamic model lookup
             hidden_models: Dict mapping display names to internal Kiro IDs.
@@ -290,35 +291,31 @@ class ModelResolver:
         self.hidden_models = hidden_models or {}
         self.aliases = aliases or {}
         self.hidden_from_list = set(hidden_from_list or [])
-    
+
     def resolve(self, external_model: str) -> ModelResolution:
         """
         Resolve external model name to internal Kiro ID.
-        
+
         NEVER raises - always returns a resolution.
         If model is not in cache/hidden, we pass it through to Kiro.
         Kiro will be the final judge.
-        
+
         Args:
             external_model: Model name from client request
-        
+
         Returns:
             ModelResolution with internal ID and metadata
         """
         # Layer 0: Resolve alias (if exists)
         resolved_model = self.aliases.get(external_model, external_model)
         if resolved_model != external_model:
-            logger.debug(
-                f"Alias resolved: '{external_model}' → '{resolved_model}'"
-            )
-        
+            logger.debug(f"Alias resolved: '{external_model}' → '{resolved_model}'")
+
         # Layer 1: Normalize name (dashes→dots, strip date)
         normalized = normalize_model_name(resolved_model)
-        
-        logger.debug(
-            f"Model resolution: '{external_model}' → normalized: '{normalized}'"
-        )
-        
+
+        logger.debug(f"Model resolution: '{external_model}' → normalized: '{normalized}'")
+
         # Layer 2: Check dynamic cache (from /ListAvailableModels)
         if self.cache.is_valid_model(normalized):
             logger.debug(f"Model '{normalized}' found in dynamic cache")
@@ -328,93 +325,90 @@ class ModelResolver:
                 source="cache",
                 original_request=external_model,
                 normalized=normalized,
-                is_verified=True
+                is_verified=True,
             )
 
         # Layer 3: Check hidden models
         if normalized in self.hidden_models:
             internal_id = self.hidden_models[normalized]
             runtime_id = to_runtime_model_id(internal_id)
-            logger.debug(
-                f"Model '{normalized}' found in hidden models → '{runtime_id}'"
-            )
+            logger.debug(f"Model '{normalized}' found in hidden models → '{runtime_id}'")
             return ModelResolution(
                 internal_id=runtime_id,
                 source="hidden",
                 original_request=external_model,
                 normalized=normalized,
-                is_verified=True
+                is_verified=True,
             )
 
         # Layer 4: Pass-through - validate for runtime endpoint
         runtime_id = to_runtime_model_id(normalized)
         logger.info(
-            f"Model '{external_model}' (normalized: '{normalized}') not in cache, "
-            f"mapped to runtime ID: '{runtime_id}'"
+            f"Model '{external_model}' (normalized: '{normalized}') not in cache, mapped to runtime ID: '{runtime_id}'"
         )
         return ModelResolution(
             internal_id=runtime_id,
             source="passthrough",
             original_request=external_model,
             normalized=normalized,
-            is_verified=False
+            is_verified=False,
         )
-    
+
     def get_available_models(self) -> List[str]:
         """
         Get list of all available model IDs for /v1/models endpoint.
-        
+
         Combines:
         - Models from dynamic cache (Kiro API)
         - Hidden models (manual config)
         - Alias names (custom mappings)
-        
+
         Excludes:
         - Models in hidden_from_list (e.g., "auto" when showing "auto-kiro")
-        
+
         Returns:
             List of model IDs in consistent format (with dots)
         """
         # Start with cache models
         models = set(self.cache.get_all_model_ids())
-        
+
         # Add hidden model display names (they use dot format)
         models.update(self.hidden_models.keys())
-        
+
         # Remove models that should be hidden from list
         models -= self.hidden_from_list
-        
+
         # Add alias keys (these are the names users will see and use)
         models.update(self.aliases.keys())
-        
+
         return sorted(models)
-    
+
     def get_models_by_family(self, family: str) -> List[str]:
         """
         Get available models filtered by family.
-        
+
         Used for error messages to suggest alternatives from the same family.
-        
+
         Args:
             family: Model family ('haiku', 'sonnet', 'opus')
-        
+
         Returns:
             List of model IDs from the specified family
         """
         all_models = self.get_available_models()
         return [m for m in all_models if family.lower() in m.lower()]
-    
+
     def get_suggestions_for_model(self, model_name: str) -> List[str]:
         """
         Get available models from the SAME family for error message.
-        
+
         IMPORTANT: Never suggests models from different family!
         Opus request → only Opus suggestions
         Sonnet request → only Sonnet suggestions
-        
+
         Args:
             model_name: The model that was requested but not found
-        
+
         Returns:
             List of available models from the same family, or all models
             if family cannot be determined
@@ -422,6 +416,6 @@ class ModelResolver:
         family = extract_model_family(model_name)
         if family:
             return self.get_models_by_family(family)
-        
+
         # If we can't determine family, return all models
         return self.get_available_models()

--- a/kiro/models_anthropic.py
+++ b/kiro/models_anthropic.py
@@ -8,10 +8,9 @@ Anthropic's Messages API specification.
 Reference: https://docs.anthropic.com/en/api/messages
 """
 
-import time
 from typing import Any, Dict, List, Literal, Optional, Union
-from pydantic import BaseModel, Field, model_validator
 
+from pydantic import BaseModel, Field, model_validator
 
 # ==================================================================================================
 # Content Block Models
@@ -84,9 +83,9 @@ class ToolResultContentBlock(BaseModel):
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
-    content: Optional[
-        Union[str, List[Union["TextContentBlock", "ImageContentBlock", "ToolReferenceContentBlock"]]]
-    ] = None
+    content: Optional[Union[str, List[Union["TextContentBlock", "ImageContentBlock", "ToolReferenceContentBlock"]]]] = (
+        None
+    )
     is_error: Optional[bool] = None
 
     model_config = {"extra": "allow"}
@@ -185,11 +184,11 @@ class AnthropicMessage(BaseModel):
 class AnthropicTool(BaseModel):
     """
     Tool definition in Anthropic format.
-    
+
     Supports both user-defined tools and server-side tools (Anthropic):
     - User-defined tools: require input_schema
     - Server-side tools: use type field (e.g., "web_search_20250305")
-    
+
     Attributes:
         type: Tool type for server-side tools (e.g., "web_search_20250305")
         name: Tool name (must match pattern ^[a-zA-Z0-9_-]{1,64}$)
@@ -200,35 +199,32 @@ class AnthropicTool(BaseModel):
         blocked_domains: Blocked domains for web_search (optional)
         user_location: User location for web_search (optional)
     """
-    
+
     # Server-side tool fields (Anthropic spec)
     type: Optional[str] = None
-    
+
     # Common fields
     name: str
     description: Optional[str] = None
     input_schema: Optional[Dict[str, Any]] = None  # Now optional for server-side tools
-    
+
     # Server-side tool parameters (Anthropic spec - accepted but not enforced)
     max_uses: Optional[int] = None
     allowed_domains: Optional[List[str]] = None
     blocked_domains: Optional[List[str]] = None
     user_location: Optional[Dict[str, Any]] = None
-    
+
     model_config = {"extra": "allow"}  # Forward compatibility
-    
+
     @model_validator(mode="after")
     def validate_tool_consistency(self):
         """Validate that user-defined tools have input_schema."""
         is_server_side = self.type is not None
-        
+
         if not is_server_side:
             # User-defined tool: input_schema is required
             if self.input_schema is None:
-                raise ValueError(
-                    "input_schema is required for user-defined tools "
-                    "(those without a 'type' field)"
-                )
+                raise ValueError("input_schema is required for user-defined tools (those without a 'type' field)")
         return self
 
 
@@ -331,24 +327,24 @@ class AnthropicMessagesRequest(BaseModel):
 class AnthropicCountTokensRequest(BaseModel):
     """
     Request to Anthropic Count Tokens API (/v1/messages/count_tokens).
-    
+
     Similar to AnthropicMessagesRequest but without generation parameters.
     Used to estimate token count before making actual request.
-    
+
     Attributes:
         model: Model ID (e.g., "claude-sonnet-4-5")
         messages: List of conversation messages
         system: System prompt (optional, string or list of content blocks)
         tools: List of available tools
     """
-    
+
     model: str
     messages: List[AnthropicMessage] = Field(min_length=1)
-    
+
     # Optional parameters - only those that affect token count
     system: Optional[SystemPrompt] = None
     tools: Optional[List[AnthropicTool]] = None
-    
+
     model_config = {"extra": "allow"}
 
 
@@ -396,9 +392,7 @@ class AnthropicMessagesResponse(BaseModel):
     role: Literal["assistant"] = "assistant"
     content: List[Union[ThinkingContentBlock, TextContentBlock, ToolUseContentBlock]]
     model: str
-    stop_reason: Optional[
-        Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]
-    ] = None
+    stop_reason: Optional[Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]] = None
     stop_sequence: Optional[str] = None
     usage: AnthropicUsage
 

--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -8,20 +8,22 @@ providing validation and serialization.
 
 import time
 from typing import Any, Dict, List, Literal, Optional, Union
-from typing_extensions import Annotated
-from pydantic import BaseModel, Field
 
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 # ==================================================================================================
 # Models for /v1/models endpoint
 # ==================================================================================================
 
+
 class OpenAIModel(BaseModel):
     """
     Data model for describing an AI model in OpenAI format.
-    
+
     Used in the /v1/models endpoint response.
     """
+
     id: str
     object: str = "model"
     created: int = Field(default_factory=lambda: int(time.time()))
@@ -32,9 +34,10 @@ class OpenAIModel(BaseModel):
 class ModelList(BaseModel):
     """
     List of models in OpenAI format.
-    
+
     Response of GET /v1/models endpoint.
     """
+
     object: str = "list"
     data: List[OpenAIModel]
 
@@ -43,13 +46,14 @@ class ModelList(BaseModel):
 # Models for /v1/chat/completions endpoint
 # ==================================================================================================
 
+
 class ChatMessage(BaseModel):
     """
     Chat message in OpenAI format.
-    
+
     Supports various roles (user, assistant, system, tool)
     and various content formats (string, list, object).
-    
+
     Attributes:
         role: Sender role (user, assistant, system, tool)
         content: Message content (can be string, list, or None)
@@ -57,6 +61,7 @@ class ChatMessage(BaseModel):
         tool_calls: List of tool calls (for assistant)
         tool_call_id: Tool call ID (for tool)
     """
+
     role: str
     content: Optional[Union[str, List[Any], Any]] = None
     name: Optional[str] = None
@@ -64,19 +69,20 @@ class ChatMessage(BaseModel):
     tool_call_id: Optional[str] = None
     reasoning: Optional[str] = None
     reasoning_content: Optional[str] = None
-    
+
     model_config = {"extra": "allow"}
 
 
 class ToolFunction(BaseModel):
     """
     Tool function description.
-    
+
     Attributes:
         name: Function name
         description: Function description
         parameters: JSON Schema of function parameters
     """
+
     name: str
     description: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = None
@@ -85,11 +91,11 @@ class ToolFunction(BaseModel):
 class Tool(BaseModel):
     """
     Tool in OpenAI format.
-    
+
     Supports two formats:
     1. Standard OpenAI format: {"type": "function", "function": {...}}
     2. Flat format (Cursor-style): {"name": "...", "description": "...", "input_schema": {...}}
-    
+
     Attributes:
         type: Tool type (usually "function")
         function: Function description (standard format)
@@ -97,28 +103,29 @@ class Tool(BaseModel):
         description: Function description (flat format)
         input_schema: Function parameters (flat format)
     """
+
     # Standard OpenAI format fields
     type: str = "function"
     function: Optional[ToolFunction] = None
-    
+
     # Flat format fields (Cursor-style)
     name: Optional[str] = None
     description: Optional[str] = None
     input_schema: Optional[Dict[str, Any]] = None
-    
+
     model_config = {"extra": "allow"}
 
 
 class ChatCompletionRequest(BaseModel):
     """
     Request for response generation in OpenAI Chat Completions API format.
-    
+
     Supports all standard OpenAI API fields, including:
     - Basic parameters (model, messages, stream)
     - Generation parameters (temperature, top_p, max_tokens)
     - Tools (function calling)
     - Additional parameters (ignored but accepted for compatibility)
-    
+
     Attributes:
         model: Model ID for generation
         messages: List of chat messages
@@ -134,10 +141,11 @@ class ChatCompletionRequest(BaseModel):
         tools: List of available tools
         tool_choice: Tool selection strategy
     """
+
     model: str
     messages: Annotated[List[ChatMessage], Field(min_length=1)]
     stream: bool = False
-    
+
     # Generation parameters
     temperature: Optional[float] = None
     top_p: Optional[float] = None
@@ -147,16 +155,16 @@ class ChatCompletionRequest(BaseModel):
     stop: Optional[Union[str, List[str]]] = None
     presence_penalty: Optional[float] = None
     frequency_penalty: Optional[float] = None
-    
+
     # Reasoning (OpenAI reasoning models)
     # Supports all official reasoning_effort levels from OpenAI API
     reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]] = None
     include_reasoning: bool = True
-    
+
     # Tools (function calling)
     tools: Optional[List[Tool]] = None
     tool_choice: Optional[Union[str, Dict]] = None
-    
+
     # Compatibility fields (ignored)
     stream_options: Optional[Dict[str, Any]] = None
     logit_bias: Optional[Dict[str, float]] = None
@@ -165,7 +173,7 @@ class ChatCompletionRequest(BaseModel):
     user: Optional[str] = None
     seed: Optional[int] = None
     parallel_tool_calls: Optional[bool] = None
-    
+
     model_config = {"extra": "allow"}
 
 
@@ -173,15 +181,17 @@ class ChatCompletionRequest(BaseModel):
 # Models for responses
 # ==================================================================================================
 
+
 class ChatCompletionChoice(BaseModel):
     """
     Single response variant in Chat Completion.
-    
+
     Attributes:
         index: Variant index
         message: Response message
         finish_reason: Completion reason (stop, tool_calls, length)
     """
+
     index: int = 0
     message: Dict[str, Any]
     finish_reason: Optional[str] = None
@@ -190,13 +200,14 @@ class ChatCompletionChoice(BaseModel):
 class ChatCompletionUsage(BaseModel):
     """
     Token usage information.
-    
+
     Attributes:
         prompt_tokens: Number of tokens in request
         completion_tokens: Number of tokens in response
         total_tokens: Total number of tokens
         credits_used: Credits used (Kiro-specific)
     """
+
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
@@ -206,7 +217,7 @@ class ChatCompletionUsage(BaseModel):
 class ChatCompletionResponse(BaseModel):
     """
     Full Chat Completion response (non-streaming).
-    
+
     Attributes:
         id: Unique response ID
         object: Object type ("chat.completion")
@@ -215,6 +226,7 @@ class ChatCompletionResponse(BaseModel):
         choices: List of response variants
         usage: Token usage information
     """
+
     id: str
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
@@ -226,12 +238,13 @@ class ChatCompletionResponse(BaseModel):
 class ChatCompletionChunkDelta(BaseModel):
     """
     Delta of changes in streaming chunk.
-    
+
     Attributes:
         role: Role (only in first chunk)
         content: New content
         tool_calls: New tool calls
     """
+
     role: Optional[str] = None
     content: Optional[str] = None
     tool_calls: Optional[List[Dict[str, Any]]] = None
@@ -240,12 +253,13 @@ class ChatCompletionChunkDelta(BaseModel):
 class ChatCompletionChunkChoice(BaseModel):
     """
     Single variant in streaming chunk.
-    
+
     Attributes:
         index: Variant index
         delta: Delta of changes
         finish_reason: Completion reason (only in last chunk)
     """
+
     index: int = 0
     delta: ChatCompletionChunkDelta
     finish_reason: Optional[str] = None
@@ -254,7 +268,7 @@ class ChatCompletionChunkChoice(BaseModel):
 class ChatCompletionChunk(BaseModel):
     """
     Streaming chunk in OpenAI format.
-    
+
     Attributes:
         id: Unique response ID
         object: Object type ("chat.completion.chunk")
@@ -263,6 +277,7 @@ class ChatCompletionChunk(BaseModel):
         choices: List of variants
         usage: Usage information (only in last chunk)
     """
+
     id: str
     object: str = "chat.completion.chunk"
     created: int = Field(default_factory=lambda: int(time.time()))

--- a/kiro/network_errors.py
+++ b/kiro/network_errors.py
@@ -15,19 +15,19 @@ Architecture:
 import socket
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List
 
 import httpx
-from loguru import logger
 
 
 class ErrorCategory(str, Enum):
     """
     Categories of network errors.
-    
+
     Each category represents a distinct type of network failure
     with specific troubleshooting steps.
     """
+
     DNS_RESOLUTION = "dns_resolution"
     CONNECTION_REFUSED = "connection_refused"
     CONNECTION_RESET = "connection_reset"
@@ -44,7 +44,7 @@ class ErrorCategory(str, Enum):
 class NetworkErrorInfo:
     """
     Structured information about a network error.
-    
+
     Attributes:
         category: Error category for classification
         user_message: Clear, non-technical message for end users
@@ -53,6 +53,7 @@ class NetworkErrorInfo:
         is_retryable: Whether retrying the request might succeed
         suggested_http_code: Appropriate HTTP status code (502, 504, etc.)
     """
+
     category: ErrorCategory
     user_message: str
     troubleshooting_steps: List[str]
@@ -64,17 +65,17 @@ class NetworkErrorInfo:
 def classify_network_error(error: Exception) -> NetworkErrorInfo:
     """
     Classifies a network error and returns structured information.
-    
+
     Analyzes the exception type, error message, and underlying cause
     to determine the specific type of network failure and provide
     appropriate user-facing messages and troubleshooting steps.
-    
+
     Args:
         error: The exception that occurred (typically httpx.RequestError)
-    
+
     Returns:
         NetworkErrorInfo with classification and user-friendly details
-    
+
     Example:
         >>> try:
         ...     response = await client.get("https://example.com")
@@ -84,18 +85,18 @@ def classify_network_error(error: Exception) -> NetworkErrorInfo:
     """
     error_type = type(error).__name__
     error_str = str(error)
-    
+
     # Extract technical details for logging
     technical_details = f"{error_type}: {error_str}"
-    
+
     # Analyze httpx.ConnectError (connection establishment failures)
     if isinstance(error, httpx.ConnectError):
         return _classify_connect_error(error, technical_details)
-    
+
     # Analyze httpx.TimeoutException (various timeout types)
     if isinstance(error, httpx.TimeoutException):
         return _classify_timeout_error(error, technical_details)
-    
+
     # Analyze httpx.TooManyRedirects
     if isinstance(error, httpx.TooManyRedirects):
         return NetworkErrorInfo(
@@ -104,13 +105,13 @@ def classify_network_error(error: Exception) -> NetworkErrorInfo:
             troubleshooting_steps=[
                 "This is likely a server-side configuration issue",
                 "Try accessing the service directly without the gateway",
-                "Contact the service provider if the issue persists"
+                "Contact the service provider if the issue persists",
             ],
             technical_details=technical_details,
             is_retryable=False,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Analyze httpx.ProxyError
     if isinstance(error, httpx.ProxyError):
         return NetworkErrorInfo(
@@ -120,13 +121,13 @@ def classify_network_error(error: Exception) -> NetworkErrorInfo:
                 "Check proxy configuration (HTTP_PROXY, HTTPS_PROXY environment variables)",
                 "Verify proxy server is accessible",
                 "Try disabling proxy temporarily",
-                "Check proxy authentication credentials if required"
+                "Check proxy authentication credentials if required",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Generic httpx.RequestError (catch-all)
     if isinstance(error, httpx.RequestError):
         return NetworkErrorInfo(
@@ -136,13 +137,13 @@ def classify_network_error(error: Exception) -> NetworkErrorInfo:
                 "Check your internet connection",
                 "Verify firewall/antivirus settings",
                 "Try again in a few moments",
-                "Check the debug logs for more details"
+                "Check the debug logs for more details",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Non-httpx errors (shouldn't happen, but handle gracefully)
     return NetworkErrorInfo(
         category=ErrorCategory.UNKNOWN,
@@ -150,38 +151,38 @@ def classify_network_error(error: Exception) -> NetworkErrorInfo:
         troubleshooting_steps=[
             "Check the debug logs for details",
             "Try again in a few moments",
-            "Report this issue if it persists"
+            "Report this issue if it persists",
         ],
         technical_details=technical_details,
         is_retryable=True,
-        suggested_http_code=500
+        suggested_http_code=500,
     )
 
 
 def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -> NetworkErrorInfo:
     """
     Classifies httpx.ConnectError into specific subcategories.
-    
+
     Args:
         error: The ConnectError exception
         technical_details: Technical error string for logging
-    
+
     Returns:
         NetworkErrorInfo with specific classification
     """
     error_str = str(error)
-    
+
     # Check underlying cause chain for more specific errors
     cause = error.__cause__
-    
+
     # Check for DNS errors (socket.gaierror)
     if cause and isinstance(cause, socket.gaierror):
         # DNS resolution failed
         # Common errno values:
         # - 11001 (Windows): WSAHOST_NOT_FOUND
         # - -2, -3, -5 (Unix): EAI_NONAME, EAI_AGAIN, EAI_NODATA
-        errno = getattr(cause, 'errno', None)
-        
+        errno = getattr(cause, "errno", None)
+
         return NetworkErrorInfo(
             category=ErrorCategory.DNS_RESOLUTION,
             user_message="DNS resolution failed - cannot resolve the provider's domain name.",
@@ -190,13 +191,13 @@ def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -
                 "Try changing DNS servers to Google DNS (8.8.8.8, 8.8.4.4) or Cloudflare (1.1.1.1, 1.0.0.1)",
                 "Temporarily disable VPN if you're using one",
                 "Check if firewall/antivirus is blocking DNS requests",
-                "Verify the domain name is correct and the service is operational"
+                "Verify the domain name is correct and the service is operational",
             ],
             technical_details=f"{technical_details} (errno: {errno})",
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Check for connection refused
     if "Connection refused" in error_str or "ECONNREFUSED" in error_str:
         return NetworkErrorInfo(
@@ -206,13 +207,13 @@ def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -
                 "The service may be temporarily down",
                 "Check if the service is running and accessible",
                 "Verify firewall is not blocking the connection",
-                "Try again in a few moments"
+                "Try again in a few moments",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Check for connection reset
     if "Connection reset" in error_str or "ECONNRESET" in error_str:
         return NetworkErrorInfo(
@@ -222,13 +223,13 @@ def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -
                 "This is usually a temporary server issue",
                 "Try again in a few moments",
                 "Check if VPN/proxy is interfering with the connection",
-                "Verify network stability"
+                "Verify network stability",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Check for network unreachable
     if "Network is unreachable" in error_str or "No route to host" in error_str or "ENETUNREACH" in error_str:
         return NetworkErrorInfo(
@@ -239,13 +240,13 @@ def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -
                 "Verify network adapter is enabled and working",
                 "Check routing table if using VPN",
                 "Try disabling VPN temporarily",
-                "Restart network adapter or router"
+                "Restart network adapter or router",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Check for SSL/TLS errors
     if "SSL" in error_str or "TLS" in error_str or "certificate" in error_str.lower():
         return NetworkErrorInfo(
@@ -255,13 +256,13 @@ def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -
                 "Check system date and time (incorrect time causes SSL errors)",
                 "Update SSL certificates on your system",
                 "Check if antivirus/firewall is intercepting HTTPS traffic",
-                "Verify the server's SSL certificate is valid"
+                "Verify the server's SSL certificate is valid",
             ],
             technical_details=technical_details,
             is_retryable=False,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-    
+
     # Generic connection error
     return NetworkErrorInfo(
         category=ErrorCategory.UNKNOWN,
@@ -270,22 +271,22 @@ def _classify_connect_error(error: httpx.ConnectError, technical_details: str) -
             "Check your internet connection",
             "Verify firewall/antivirus settings",
             "Try disabling VPN temporarily",
-            "Check if the service is accessible from other devices"
+            "Check if the service is accessible from other devices",
         ],
         technical_details=technical_details,
         is_retryable=True,
-        suggested_http_code=502
+        suggested_http_code=502,
     )
 
 
 def _classify_timeout_error(error: httpx.TimeoutException, technical_details: str) -> NetworkErrorInfo:
     """
     Classifies httpx.TimeoutException into specific subcategories.
-    
+
     Args:
         error: The TimeoutException
         technical_details: Technical error string for logging
-    
+
     Returns:
         NetworkErrorInfo with specific classification
     """
@@ -298,13 +299,13 @@ def _classify_timeout_error(error: httpx.TimeoutException, technical_details: st
                 "Check your internet connection speed",
                 "The server may be overloaded or slow to respond",
                 "Try again in a few moments",
-                "Check if firewall is delaying connections"
+                "Check if firewall is delaying connections",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=504
+            suggested_http_code=504,
         )
-    
+
     # ReadTimeout: Server stopped sending data
     if isinstance(error, httpx.ReadTimeout):
         return NetworkErrorInfo(
@@ -314,13 +315,13 @@ def _classify_timeout_error(error: httpx.TimeoutException, technical_details: st
                 "The server may be processing a complex request",
                 "Check your internet connection stability",
                 "Try again with a simpler request",
-                "The service may be experiencing high load"
+                "The service may be experiencing high load",
             ],
             technical_details=technical_details,
             is_retryable=True,
-            suggested_http_code=504
+            suggested_http_code=504,
         )
-    
+
     # Generic timeout
     return NetworkErrorInfo(
         category=ErrorCategory.TIMEOUT_READ,
@@ -328,33 +329,31 @@ def _classify_timeout_error(error: httpx.TimeoutException, technical_details: st
         troubleshooting_steps=[
             "Check your internet connection",
             "The server may be slow or overloaded",
-            "Try again in a few moments"
+            "Try again in a few moments",
         ],
         technical_details=technical_details,
         is_retryable=True,
-        suggested_http_code=504
+        suggested_http_code=504,
     )
 
 
 def format_error_for_user(
-    error_info: NetworkErrorInfo,
-    format_type: str = "openai",
-    include_troubleshooting: bool = True
+    error_info: NetworkErrorInfo, format_type: str = "openai", include_troubleshooting: bool = True
 ) -> Dict[str, Any]:
     """
     Formats NetworkErrorInfo for API response.
-    
+
     Converts structured error information into the appropriate format
     for OpenAI or Anthropic API responses.
-    
+
     Args:
         error_info: The classified error information
         format_type: "openai" or "anthropic" format
         include_troubleshooting: Whether to include troubleshooting steps
-    
+
     Returns:
         Dictionary formatted for API response
-    
+
     Example:
         >>> error_info = classify_network_error(exception)
         >>> response = format_error_for_user(error_info, format_type="openai")
@@ -362,12 +361,12 @@ def format_error_for_user(
     """
     # Build the message
     message = error_info.user_message
-    
+
     if include_troubleshooting and error_info.troubleshooting_steps:
         message += "\n\nTroubleshooting steps:\n"
         for i, step in enumerate(error_info.troubleshooting_steps, 1):
             message += f"{i}. {step}\n"
-    
+
     # Format for OpenAI API
     if format_type == "openai":
         return {
@@ -375,20 +374,14 @@ def format_error_for_user(
                 "message": message.strip(),
                 "type": "connectivity_error",
                 "code": error_info.category.value,
-                "param": None
+                "param": None,
             }
         }
-    
+
     # Format for Anthropic API
     elif format_type == "anthropic":
-        return {
-            "type": "error",
-            "error": {
-                "type": "connectivity_error",
-                "message": message.strip()
-            }
-        }
-    
+        return {"type": "error", "error": {"type": "connectivity_error", "message": message.strip()}}
+
     # Generic format (fallback)
     else:
         return {
@@ -396,7 +389,7 @@ def format_error_for_user(
                 "type": "connectivity_error",
                 "category": error_info.category.value,
                 "message": message.strip(),
-                "technical_details": error_info.technical_details
+                "technical_details": error_info.technical_details,
             }
         }
 
@@ -404,13 +397,13 @@ def format_error_for_user(
 def get_short_error_message(error_info: NetworkErrorInfo) -> str:
     """
     Returns a short, single-line error message for logging.
-    
+
     Args:
         error_info: The classified error information
-    
+
     Returns:
         Short error message suitable for log files
-    
+
     Example:
         >>> error_info = classify_network_error(exception)
         >>> logger.warning(get_short_error_message(error_info))

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -294,7 +294,7 @@ class AwsEventStreamParser:
                     earliest_pos = pos
                     earliest_type = event_type
 
-            if earliest_pos == -1:
+            if earliest_pos == -1 or earliest_type is None:
                 break
 
             # Find JSON end

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -26,69 +26,69 @@ class MalformedToolInputError(ValueError):
 def find_matching_brace(text: str, start_pos: int) -> int:
     """
     Finds the position of the closing brace considering nesting and strings.
-    
+
     Uses bracket counting for correct parsing of nested JSON.
     Accounts for quoted strings and escape sequences.
-    
+
     Args:
         text: Text to search
         start_pos: Position of opening brace '{'
-    
+
     Returns:
         Position of closing brace or -1 if not found
-    
+
     Example:
         >>> find_matching_brace('{"a": {"b": 1}}', 0)
         14
         >>> find_matching_brace('{"a": "{}"}', 0)
         10
     """
-    if start_pos >= len(text) or text[start_pos] != '{':
+    if start_pos >= len(text) or text[start_pos] != "{":
         return -1
-    
+
     brace_count = 0
     in_string = False
     escape_next = False
-    
+
     for i in range(start_pos, len(text)):
         char = text[i]
-        
+
         if escape_next:
             escape_next = False
             continue
-        
-        if char == '\\' and in_string:
+
+        if char == "\\" and in_string:
             escape_next = True
             continue
-        
+
         if char == '"' and not escape_next:
             in_string = not in_string
             continue
-        
+
         if not in_string:
-            if char == '{':
+            if char == "{":
                 brace_count += 1
-            elif char == '}':
+            elif char == "}":
                 brace_count -= 1
                 if brace_count == 0:
                     return i
-    
+
     return -1
 
 
 def parse_bracket_tool_calls(response_text: str) -> List[Dict[str, Any]]:
     """
     Parses tool calls in [Called func_name with args: {...}] format.
-    
+
     Some models return tool calls in text format instead of
     structured JSON. This function extracts them.
-    
+
     Args:
         response_text: Model response text
-    
+
     Returns:
         List of tool calls in OpenAI format
-    
+
     Example:
         >>> text = "[Called get_weather with args: {\"city\": \"London\"}]"
         >>> calls = parse_bracket_tool_calls(text)
@@ -97,56 +97,51 @@ def parse_bracket_tool_calls(response_text: str) -> List[Dict[str, Any]]:
     """
     if not response_text or "[Called" not in response_text:
         return []
-    
+
     tool_calls = []
-    pattern = r'\[Called\s+(\w+)\s+with\s+args:\s*'
-    
+    pattern = r"\[Called\s+(\w+)\s+with\s+args:\s*"
+
     for match in re.finditer(pattern, response_text, re.IGNORECASE):
         func_name = match.group(1)
         args_start = match.end()
-        
+
         # Find JSON start
-        json_start = response_text.find('{', args_start)
+        json_start = response_text.find("{", args_start)
         if json_start == -1:
             continue
-        
+
         # Find JSON end considering nesting
         json_end = find_matching_brace(response_text, json_start)
         if json_end == -1:
             continue
-        
-        json_str = response_text[json_start:json_end + 1]
-        
+
+        json_str = response_text[json_start : json_end + 1]
+
         try:
             args = json.loads(json_str)
             tool_call_id = generate_tool_call_id()
             # index will be added later when forming the final response
-            tool_calls.append({
-                "id": tool_call_id,
-                "type": "function",
-                "function": {
-                    "name": func_name,
-                    "arguments": json.dumps(args)
-                }
-            })
+            tool_calls.append(
+                {"id": tool_call_id, "type": "function", "function": {"name": func_name, "arguments": json.dumps(args)}}
+            )
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse tool call arguments: {json_str[:100]}")
-    
+
     return tool_calls
 
 
 def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Removes duplicate tool calls.
-    
+
     Deduplication occurs by two criteria:
     1. By id - if there are multiple tool calls with the same id, keep the one with
        more arguments (not empty "{}")
     2. By name+arguments - remove complete duplicates
-    
+
     Args:
         tool_calls: List of tool calls
-    
+
     Returns:
         List of unique tool calls
     """
@@ -157,7 +152,7 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
         if not tc_id:
             # Without id - add as is (will be deduplicated by name+args)
             continue
-        
+
         existing = by_id.get(tc_id)
         if existing is None:
             by_id[tc_id] = tc
@@ -165,19 +160,21 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
             # Duplicate by id exists - keep the one with more arguments
             existing_args = existing.get("function", {}).get("arguments", "{}")
             current_args = tc.get("function", {}).get("arguments", "{}")
-            
+
             # Prefer non-empty arguments
             if current_args != "{}" and (existing_args == "{}" or len(current_args) > len(existing_args)):
-                logger.debug(f"Replacing tool call {tc_id} with better arguments: {len(existing_args)} -> {len(current_args)}")
+                logger.debug(
+                    f"Replacing tool call {tc_id} with better arguments: {len(existing_args)} -> {len(current_args)}"
+                )
                 by_id[tc_id] = tc
-    
+
     # Collect tool calls: first those with id, then without id
     result_with_id = list(by_id.values())
     result_without_id = [tc for tc in tool_calls if not tc.get("id")]
-    
+
     seen = set()
     unique = list(result_with_id)
-    
+
     for tc in result_without_id:
         # Protection against None in function
         func = tc.get("function") or {}
@@ -187,20 +184,20 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
         if key not in seen:
             seen.add(key)
             unique.append(tc)
-    
+
     if len(tool_calls) != len(unique):
         logger.debug(f"Deduplicated tool calls: {len(tool_calls)} -> {len(unique)}")
-    
+
     return unique
 
 
 class AwsEventStreamParser:
     """
     Parser for AWS Event Stream format.
-    
+
     AWS returns events in binary format with :message-type...event delimiters.
     This class extracts JSON events from the stream and converts them to a convenient format.
-    
+
     Supported event types:
     - content: Text content of response
     - tool_start: Start of tool call (name, toolUseId)
@@ -208,12 +205,12 @@ class AwsEventStreamParser:
     - tool_stop: End of tool call
     - usage: Credit consumption information
     - context_usage: Context usage percentage
-    
+
     Attributes:
         buffer: Buffer for accumulating data
         current_tool_call: Current incomplete tool call
         tool_calls: List of completed tool calls
-    
+
     Example:
         >>> parser = AwsEventStreamParser()
         >>> events = parser.feed(chunk)
@@ -221,46 +218,44 @@ class AwsEventStreamParser:
         ...     if event["type"] == "content":
         ...         print(event["data"])
     """
-    
+
     # Patterns for finding JSON events
     EVENT_PATTERNS = [
-        ('{"content":', 'content'),
-        ('{"name":', 'tool_start'),
-        ('{"input":', 'tool_input'),
-        ('{"stop":', 'tool_stop'),
-        ('{"followupPrompt":', 'followup'),
-        ('{"usage":', 'usage'),
-        ('{"contextUsagePercentage":', 'context_usage'),
+        ('{"content":', "content"),
+        ('{"name":', "tool_start"),
+        ('{"input":', "tool_input"),
+        ('{"stop":', "tool_stop"),
+        ('{"followupPrompt":', "followup"),
+        ('{"usage":', "usage"),
+        ('{"contextUsagePercentage":', "context_usage"),
         # Upstream reports why generation ended in a metadata frame such as
         # {"stopReason":"END_TURN"}. Without it the gateway can only guess, and
         # truncation would be reported to clients as a clean finish.
-        ('{"stopReason":', 'stop_reason'),
+        ('{"stopReason":', "stop_reason"),
         # Kiro native adaptive-thinking stream frames. These are structured
         # upstream events, unlike the removed prompt-tag fake reasoning path.
-        ('{"text":', 'native_thinking'),
-        ('{"signature":', 'native_thinking_signature'),
+        ('{"text":', "native_thinking"),
+        ('{"signature":', "native_thinking_signature"),
     ]
-    
+
     def __init__(self):
         """Initializes the parser."""
         self.buffer = ""
         self._observation_buffer = ""
-        self._utf8_decoder = codecs.getincrementaldecoder("utf-8")(
-            errors="replace"
-        )
+        self._utf8_decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         self.current_tool_call: Optional[Dict[str, Any]] = None
         self.tool_calls: List[Dict[str, Any]] = []
         self._emitted_tool_call_count = 0
         self._observed_frames: List[Dict[str, Any]] = []
         self.native_thinking_started = False
-    
+
     def feed(self, chunk: bytes) -> List[Dict[str, Any]]:
         """
         Adds chunk to buffer and returns parsed events.
-        
+
         Args:
             chunk: Bytes of data from stream
-        
+
         Returns:
             List of events in {"type": str, "data": Any} format
         """
@@ -277,8 +272,8 @@ class AwsEventStreamParser:
             end = find_matching_brace(self._observation_buffer, 0)
             if end == -1:
                 break
-            candidate = self._observation_buffer[:end + 1]
-            self._observation_buffer = self._observation_buffer[end + 1:]
+            candidate = self._observation_buffer[: end + 1]
+            self._observation_buffer = self._observation_buffer[end + 1 :]
             try:
                 frame = json.loads(candidate)
             except json.JSONDecodeError:
@@ -287,30 +282,30 @@ class AwsEventStreamParser:
                 self._observed_frames.append(frame)
 
         events = []
-        
+
         while True:
             # Find nearest pattern
             earliest_pos = -1
             earliest_type = None
-            
+
             for pattern, event_type in self.EVENT_PATTERNS:
                 pos = self.buffer.find(pattern)
                 if pos != -1 and (earliest_pos == -1 or pos < earliest_pos):
                     earliest_pos = pos
                     earliest_type = event_type
-            
+
             if earliest_pos == -1:
                 break
-            
+
             # Find JSON end
             json_end = find_matching_brace(self.buffer, earliest_pos)
             if json_end == -1:
                 # JSON not complete, wait for more data
                 break
-            
-            json_str = self.buffer[earliest_pos:json_end + 1]
-            self.buffer = self.buffer[json_end + 1:]
-            
+
+            json_str = self.buffer[earliest_pos : json_end + 1]
+            self.buffer = self.buffer[json_end + 1 :]
+
             try:
                 data = json.loads(json_str)
                 event = self._process_event(data, earliest_type)
@@ -318,53 +313,45 @@ class AwsEventStreamParser:
                     events.append(event)
             except json.JSONDecodeError:
                 logger.warning(f"Failed to parse JSON: {json_str[:100]}")
-        
+
         return events
-    
+
     def _process_event(self, data: dict, event_type: str) -> Optional[Dict[str, Any]]:
         """
         Processes a parsed event.
-        
+
         Args:
             data: Parsed JSON
             event_type: Event type
-        
+
         Returns:
             Processed event or None
         """
-        current_id = (
-            self.current_tool_call.get("id")
-            if self.current_tool_call
-            else None
-        )
+        current_id = self.current_tool_call.get("id") if self.current_tool_call else None
         frame_tool_id = data.get("toolUseId")
-        if (
-            "input" in data
-            and self.current_tool_call
-            and (not frame_tool_id or frame_tool_id == current_id)
-        ):
+        if "input" in data and self.current_tool_call and (not frame_tool_id or frame_tool_id == current_id):
             self._process_tool_input_event(data)
             if data.get("stop"):
                 return self._process_tool_stop_event(data)
             return None
         if data.get("stop") and self.current_tool_call:
             return self._process_tool_stop_event(data)
-        if event_type == 'content':
+        if event_type == "content":
             return self._process_content_event(data)
-        elif event_type == 'tool_start':
+        elif event_type == "tool_start":
             return self._process_tool_start_event(data)
-        elif event_type == 'tool_input':
+        elif event_type == "tool_input":
             return self._process_tool_input_event(data)
-        elif event_type == 'tool_stop':
+        elif event_type == "tool_stop":
             return self._process_tool_stop_event(data)
-        elif event_type == 'usage':
-            return {"type": "usage", "data": data.get('usage', 0)}
-        elif event_type == 'context_usage':
-            return {"type": "context_usage", "data": data.get('contextUsagePercentage', 0)}
-        elif event_type == 'stop_reason':
-            reason = data.get('stopReason') or data.get('stop_reason')
+        elif event_type == "usage":
+            return {"type": "usage", "data": data.get("usage", 0)}
+        elif event_type == "context_usage":
+            return {"type": "context_usage", "data": data.get("contextUsagePercentage", 0)}
+        elif event_type == "stop_reason":
+            reason = data.get("stopReason") or data.get("stop_reason")
             return {"type": "stop_reason", "data": reason} if reason else None
-        elif event_type == 'native_thinking':
+        elif event_type == "native_thinking":
             event = {
                 "type": "native_thinking",
                 "data": data.get("text", ""),
@@ -372,12 +359,12 @@ class AwsEventStreamParser:
             }
             self.native_thinking_started = True
             return event
-        elif event_type == 'native_thinking_signature':
+        elif event_type == "native_thinking_signature":
             self.native_thinking_started = False
             return {"type": "native_thinking_signature", "data": data.get("signature", "")}
-        
+
         return None
-    
+
     def _process_content_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Process a content event.
 
@@ -386,14 +373,14 @@ class AwsEventStreamParser:
         to drop "replays" corrupts legitimately repeating output: a stream of
         ["666", "666", "666", "6"] must render as 6666666666, not 6666.
         """
-        content = data.get('content', '')
+        content = data.get("content", "")
 
         # Skip followupPrompt
-        if data.get('followupPrompt'):
+        if data.get("followupPrompt"):
             return None
 
         return {"type": "content", "data": content}
-    
+
     def _process_tool_start_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes tool call start."""
         # Finalize previous tool call if exists
@@ -402,58 +389,55 @@ class AwsEventStreamParser:
             self._finalize_tool_call()
             completed_tool_call = self.tool_calls[-1]
             self._emitted_tool_call_count += 1
-        
+
         # input can be string or object
-        input_data = data.get('input', '')
+        input_data = data.get("input", "")
         if isinstance(input_data, dict):
             if input_data:
                 # Non-empty dict: serialize it
                 input_str = json.dumps(input_data)
             else:
                 # Empty dict {}: fragments will follow, use empty string
-                input_str = ''
+                input_str = ""
         else:
-            input_str = str(input_data) if input_data else ''
-        
+            input_str = str(input_data) if input_data else ""
+
         self.current_tool_call = {
-            "id": data.get('toolUseId', generate_tool_call_id()),
+            "id": data.get("toolUseId", generate_tool_call_id()),
             "type": "function",
-            "function": {
-                "name": data.get('name', ''),
-                "arguments": input_str
-            }
+            "function": {"name": data.get("name", ""), "arguments": input_str},
         }
-        
-        if data.get('stop'):
+
+        if data.get("stop"):
             self._finalize_tool_call()
             self._emitted_tool_call_count += 1
             return {
                 "type": "tool_use",
                 "data": self.tool_calls[-1],
             }
-        
+
         if completed_tool_call is not None:
             return {"type": "tool_use", "data": completed_tool_call}
         return None
-    
+
     def _process_tool_input_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes input continuation for tool call."""
         if self.current_tool_call:
             # input can be string or object
-            input_data = data.get('input', '')
+            input_data = data.get("input", "")
             if isinstance(input_data, dict):
                 if input_data:
                     input_str = json.dumps(input_data)
                 else:
-                    input_str = ''
+                    input_str = ""
             else:
-                input_str = str(input_data) if input_data else ''
-            self.current_tool_call['function']['arguments'] += input_str
+                input_str = str(input_data) if input_data else ""
+            self.current_tool_call["function"]["arguments"] += input_str
         return None
-    
+
     def _process_tool_stop_event(self, data: dict) -> Optional[Dict[str, Any]]:
         """Processes tool call end."""
-        if self.current_tool_call and data.get('stop'):
+        if self.current_tool_call and data.get("stop"):
             self._finalize_tool_call()
             self._emitted_tool_call_count += 1
             return {
@@ -461,37 +445,39 @@ class AwsEventStreamParser:
                 "data": self.tool_calls[-1],
             }
         return None
-    
+
     def _finalize_tool_call(self) -> None:
         """Finalizes current tool call and adds to list."""
         if not self.current_tool_call:
             return
-        
+
         # Try to parse and normalize arguments as JSON
-        args = self.current_tool_call['function']['arguments']
-        tool_name = self.current_tool_call['function'].get('name', 'unknown')
-        
+        args = self.current_tool_call["function"]["arguments"]
+        tool_name = self.current_tool_call["function"].get("name", "unknown")
+
         logger.debug(f"Finalizing tool call '{tool_name}' with raw arguments: {repr(args)[:200]}")
-        
+
         if isinstance(args, str):
             if args.strip():
                 try:
                     parsed = json.loads(args)
                     # Ensure result is a JSON string
-                    self.current_tool_call['function']['arguments'] = json.dumps(parsed)
-                    logger.debug(f"Tool '{tool_name}' arguments parsed successfully: {list(parsed.keys()) if isinstance(parsed, dict) else type(parsed)}")
+                    self.current_tool_call["function"]["arguments"] = json.dumps(parsed)
+                    logger.debug(
+                        f"Tool '{tool_name}' arguments parsed successfully: {list(parsed.keys()) if isinstance(parsed, dict) else type(parsed)}"
+                    )
                 except json.JSONDecodeError as e:
                     # Analyze the failure to provide better diagnostics
                     truncation_info = self._diagnose_json_truncation(args)
-                    
+
                     if truncation_info["is_truncated"]:
                         # Mark for recovery system
-                        self.current_tool_call['_truncation_detected'] = True
-                        self.current_tool_call['_truncation_info'] = truncation_info
-                        
+                        self.current_tool_call["_truncation_detected"] = True
+                        self.current_tool_call["_truncation_info"] = truncation_info
+
                         # Check if recovery is enabled
-                        tool_id = self.current_tool_call.get('id', 'unknown')
-                        
+                        tool_id = self.current_tool_call.get("id", "unknown")
+
                         # Clear error message: this is Kiro API's fault, not ours
                         logger.error(
                             f"Tool call truncated by Kiro API: "
@@ -510,112 +496,98 @@ class AwsEventStreamParser:
                 # Empty string - use empty object
                 # This is normal behavior for duplicate tool calls from Kiro
                 logger.debug(f"Tool '{tool_name}' has empty arguments string (will be deduplicated)")
-                self.current_tool_call['function']['arguments'] = "{}"
+                self.current_tool_call["function"]["arguments"] = "{}"
         elif isinstance(args, dict):
             # If already an object - serialize to string
-            self.current_tool_call['function']['arguments'] = json.dumps(args)
+            self.current_tool_call["function"]["arguments"] = json.dumps(args)
             logger.debug(f"Tool '{tool_name}' arguments already dict with keys: {list(args.keys())}")
         else:
             # Unknown type - empty object
             logger.warning(f"Tool '{tool_name}' has unexpected arguments type: {type(args)}")
-            self.current_tool_call['function']['arguments'] = "{}"
-        
+            self.current_tool_call["function"]["arguments"] = "{}"
+
         self.tool_calls.append(self.current_tool_call)
         self.current_tool_call = None
-    
+
     def _diagnose_json_truncation(self, json_str: str) -> Dict[str, Any]:
         """
         Analyzes a malformed JSON string to determine if it was truncated.
-        
+
         This helps distinguish between upstream issues (Kiro API cutting off
         large tool call arguments) and actual malformed JSON from the model.
-        
+
         Args:
             json_str: The raw JSON string that failed to parse
-        
+
         Returns:
             Dictionary with diagnostic information:
             - is_truncated: True if the JSON appears to be cut off
             - reason: Human-readable explanation of why it's truncated
             - size_bytes: Size of the received data
         """
-        size_bytes = len(json_str.encode('utf-8'))
+        size_bytes = len(json_str.encode("utf-8"))
         stripped = json_str.strip()
-        
+
         # Check for obvious truncation signs
         if not stripped:
             return {"is_truncated": False, "reason": "empty string", "size_bytes": size_bytes}
-        
+
         # Count braces and brackets (simplified, doesn't account for strings perfectly)
-        open_braces = stripped.count('{')
-        close_braces = stripped.count('}')
-        open_brackets = stripped.count('[')
-        close_brackets = stripped.count(']')
-        
+        open_braces = stripped.count("{")
+        close_braces = stripped.count("}")
+        open_brackets = stripped.count("[")
+        close_brackets = stripped.count("]")
+
         # Check if JSON starts with { but doesn't end with }
-        if stripped.startswith('{') and not stripped.endswith('}'):
+        if stripped.startswith("{") and not stripped.endswith("}"):
             missing = open_braces - close_braces
-            return {
-                "is_truncated": True,
-                "reason": f"missing {missing} closing brace(s)",
-                "size_bytes": size_bytes
-            }
-        
+            return {"is_truncated": True, "reason": f"missing {missing} closing brace(s)", "size_bytes": size_bytes}
+
         # Check if JSON starts with [ but doesn't end with ]
-        if stripped.startswith('[') and not stripped.endswith(']'):
+        if stripped.startswith("[") and not stripped.endswith("]"):
             missing = open_brackets - close_brackets
-            return {
-                "is_truncated": True,
-                "reason": f"missing {missing} closing bracket(s)",
-                "size_bytes": size_bytes
-            }
-        
+            return {"is_truncated": True, "reason": f"missing {missing} closing bracket(s)", "size_bytes": size_bytes}
+
         # Check for unbalanced braces/brackets
         if open_braces != close_braces:
-            diff = open_braces - close_braces
             return {
                 "is_truncated": True,
                 "reason": f"unbalanced braces ({open_braces} open, {close_braces} close)",
-                "size_bytes": size_bytes
+                "size_bytes": size_bytes,
             }
-        
+
         if open_brackets != close_brackets:
-            diff = open_brackets - close_brackets
             return {
                 "is_truncated": True,
                 "reason": f"unbalanced brackets ({open_brackets} open, {close_brackets} close)",
-                "size_bytes": size_bytes
+                "size_bytes": size_bytes,
             }
-        
+
         # Check for unclosed string (ends with backslash or inside quotes)
         # This is a heuristic - count unescaped quotes
         quote_count = 0
         i = 0
         while i < len(stripped):
-            if stripped[i] == '\\' and i + 1 < len(stripped):
+            if stripped[i] == "\\" and i + 1 < len(stripped):
                 i += 2  # Skip escaped character
                 continue
             if stripped[i] == '"':
                 quote_count += 1
             i += 1
-        
+
         if quote_count % 2 != 0:
-            return {
-                "is_truncated": True,
-                "reason": "unclosed string literal",
-                "size_bytes": size_bytes
-            }
-        
+            return {"is_truncated": True, "reason": "unclosed string literal", "size_bytes": size_bytes}
+
         # Doesn't look truncated, probably just malformed
         return {"is_truncated": False, "reason": "malformed JSON", "size_bytes": size_bytes}
-    
+
     def get_tool_calls(self) -> List[Dict[str, Any]]:
         """
         Returns all collected tool calls.
-        
+
         Finalizes current tool call if not finished.
         Removes duplicates.
-        
+
         Returns:
             List of unique tool calls
         """
@@ -627,16 +599,14 @@ class AwsEventStreamParser:
         """Return tool calls not already emitted by completed native frames."""
         if self.current_tool_call:
             self._finalize_tool_call()
-        return deduplicate_tool_calls(
-            self.tool_calls[self._emitted_tool_call_count:]
-        )
+        return deduplicate_tool_calls(self.tool_calls[self._emitted_tool_call_count :])
 
     def drain_observed_frames(self) -> List[Dict[str, Any]]:
         """Return and clear decoded upstream frames for sanitized diagnostics."""
         frames = self._observed_frames
         self._observed_frames = []
         return frames
-    
+
     def reset(self) -> None:
         """Resets parser state."""
         self.buffer = ""

--- a/kiro/payload_guards.py
+++ b/kiro/payload_guards.py
@@ -18,6 +18,7 @@ from typing import Any, Dict
 @dataclass
 class PayloadTrimStats:
     """Statistics from a payload trim operation."""
+
     original_bytes: int
     final_bytes: int
     original_entries: int

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -8,7 +8,7 @@ Reference: https://docs.anthropic.com/en/api/messages
 """
 
 import json
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Security
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -33,11 +33,17 @@ from kiro.tokenizer import estimate_request_tokens
 from kiro.usage_tracking import current_api_key_id
 from kiro.utils import generate_conversation_id
 
+if TYPE_CHECKING:
+    from kiro.debug_logger import DebugLogger
+
 # Import debug_logger
+debug_logger: Optional["DebugLogger"]
 try:
-    from kiro.debug_logger import debug_logger
+    import kiro.debug_logger as debug_logger_module
 except ImportError:
     debug_logger = None
+else:
+    debug_logger = debug_logger_module.debug_logger
 
 
 # --- Security scheme ---
@@ -201,7 +207,7 @@ async def messages(
 
         last_error_message = None
         last_error_status = None
-        tried_accounts = set()  # Track tried accounts in current failover loop
+        tried_accounts: set[str] = set()  # Track tried accounts in current failover loop
 
         for attempt in range(MAX_ATTEMPTS):
             # Get next available account (excluding already tried)
@@ -279,6 +285,7 @@ async def messages(
             # Prepare data for token counting
             messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
             tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
+            system_for_tokenizer: str | list[dict[str, Any]] | None
             if isinstance(request_data.system, list):
                 system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
             else:
@@ -480,6 +487,7 @@ async def messages(
         if len(all_accounts) == 1:
             # Single account - return its original error
             # last_error_status and last_error_message are guaranteed to be set
+            assert last_error_status is not None
             return JSONResponse(
                 status_code=last_error_status,
                 content={"type": "error", "error": {"type": "api_error", "message": last_error_message}},
@@ -752,6 +760,7 @@ async def count_tokens_endpoint(
     tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
 
     # Handle system prompt (can be string or list of content blocks)
+    system_for_tokenizer: str | list[dict[str, Any]] | None
     if isinstance(request_data.system, list):
         system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
     else:

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -10,35 +10,28 @@ Reference: https://docs.anthropic.com/en/api/messages
 import json
 from typing import Optional
 
-import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request, Security, Header
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Security
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
 
-from kiro.config import PROXY_API_KEY, PROFILE_ARN
-from kiro.models_anthropic import (
-    AnthropicMessagesRequest,
-    AnthropicCountTokensRequest,
-    AnthropicMessagesResponse,
-    AnthropicErrorResponse,
-    AnthropicErrorDetail,
-)
-from kiro.auth import KiroAuthManager, AuthType
-from kiro.cache import ModelInfoCache
+from kiro.auth import AuthType
+from kiro.config import PROFILE_ARN, WEB_SEARCH_ENABLED
 from kiro.converters_anthropic import anthropic_to_kiro
+from kiro.dashboard import identify_data_api_key
+from kiro.http_client import KiroHttpClient
+from kiro.mcp_tools import handle_native_web_search
+from kiro.models_anthropic import (
+    AnthropicCountTokensRequest,
+    AnthropicMessagesRequest,
+)
 from kiro.streaming_anthropic import (
-    stream_kiro_to_anthropic,
     collect_anthropic_response,
     stream_with_first_token_retry_anthropic,
 )
-from kiro.http_client import KiroHttpClient
-from kiro.utils import generate_conversation_id
 from kiro.tokenizer import estimate_request_tokens
-from kiro.config import WEB_SEARCH_ENABLED
-from kiro.mcp_tools import handle_native_web_search
-from kiro.dashboard import identify_data_api_key
 from kiro.usage_tracking import current_api_key_id
+from kiro.utils import generate_conversation_id
 
 # Import debug_logger
 try:
@@ -55,28 +48,29 @@ auth_header = APIKeyHeader(name="Authorization", auto_error=False)
 
 
 async def verify_anthropic_api_key(
-    x_api_key: Optional[str] = Security(anthropic_api_key_header),
-    authorization: Optional[str] = Security(auth_header)
+    x_api_key: Optional[str] = Security(anthropic_api_key_header), authorization: Optional[str] = Security(auth_header)
 ) -> bool:
     """
     Verify API key for Anthropic API.
-    
+
     Supports two authentication methods:
     1. x-api-key header (Anthropic native)
     2. Authorization: Bearer header (for compatibility)
-    
+
     Args:
         x_api_key: Value from x-api-key header
         authorization: Value from Authorization header
-    
+
     Returns:
         True if key is valid
-    
+
     Raises:
         HTTPException: 401 if key is invalid or missing
     """
     # Check x-api-key first (Anthropic native), then Bearer compatibility.
-    candidate = x_api_key or (authorization.removeprefix("Bearer ") if authorization and authorization.startswith("Bearer ") else "")
+    candidate = x_api_key or (
+        authorization.removeprefix("Bearer ") if authorization and authorization.startswith("Bearer ") else ""
+    )
     if candidate:
         key_id = identify_data_api_key(candidate)
         if key_id is not None:
@@ -90,9 +84,9 @@ async def verify_anthropic_api_key(
             "type": "error",
             "error": {
                 "type": "authentication_error",
-                "message": "Invalid or missing API key. Use x-api-key header or Authorization: Bearer."
-            }
-        }
+                "message": "Invalid or missing API key. Use x-api-key header or Authorization: Bearer.",
+            },
+        },
     )
 
 
@@ -104,74 +98,70 @@ router = APIRouter(tags=["Anthropic API"])
 async def messages(
     request: Request,
     request_data: AnthropicMessagesRequest,
-    anthropic_version: Optional[str] = Header(None, alias="anthropic-version")
+    anthropic_version: Optional[str] = Header(None, alias="anthropic-version"),
 ):
     """
     Anthropic Messages API endpoint.
-    
+
     Compatible with Anthropic's /v1/messages endpoint.
     Accepts requests in Anthropic format and translates them to Kiro API.
-    
+
     Required headers:
     - x-api-key: Your API key (or Authorization: Bearer)
     - anthropic-version: API version (optional, for compatibility)
     - Content-Type: application/json
-    
+
     Args:
         request: FastAPI Request for accessing app.state
         request_data: Request in Anthropic MessagesRequest format
         anthropic_version: Anthropic API version header (optional)
-    
+
     Returns:
         StreamingResponse for streaming mode (SSE)
         JSONResponse for non-streaming mode
-    
+
     Raises:
         HTTPException: On validation or API errors
     """
     logger.info(f"Request to /v1/messages (model={request_data.model}, stream={request_data.stream})")
-    
+
     if anthropic_version:
         logger.debug(f"Anthropic-Version header: {anthropic_version}")
-    
+
     # Note: prepare_new_request() and log_request_body() are now called by DebugLoggerMiddleware
     # This ensures debug logging works even for requests that fail Pydantic validation (422 errors)
-    
+
     # ==============================================================================
     # WebSearch Support - Path B: Auto-Injection (MCP Tool Emulation)
     # ==============================================================================
-    
+
     # Auto-inject web_search tool if enabled (Path B - MCP emulation)
     if WEB_SEARCH_ENABLED:
         if request_data.tools is None:
             request_data.tools = []
-        
+
         # Check if web_search already exists (by name)
-        has_ws = any(
-            getattr(tool, "name", "") == "web_search"
-            for tool in request_data.tools
-        )
-        
+        has_ws = any(getattr(tool, "name", "") == "web_search" for tool in request_data.tools)
+
         if not has_ws:
             from kiro.models_anthropic import AnthropicTool
+
             web_search_tool = AnthropicTool(
                 name="web_search",
                 description="Search the web for current information. Use when you need up-to-date data from the internet.",
                 input_schema={
                     "type": "object",
-                    "properties": {
-                        "query": {"type": "string", "description": "Search query"}
-                    },
-                    "required": ["query"]
-                }
+                    "properties": {"query": {"type": "string", "description": "Search query"}},
+                    "required": ["query"],
+                },
             )
             request_data.tools.append(web_search_tool)
             logger.debug("Auto-injected web_search tool for MCP emulation (Path B)")
-    
+
     # ==============================================================================
     # WebSearch Support - Path A: Native Anthropic (Early Return)
     # ==============================================================================
-    
+
     # Check for native Anthropic server-side tool (Path A)
     # This works ALWAYS, regardless of WEB_SEARCH_ENABLED setting
     if request_data.tools:
@@ -187,42 +177,36 @@ async def messages(
                         status_code=503,
                         content={
                             "type": "error",
-                            "error": {
-                                "type": "api_error",
-                                "message": "No initialized accounts available"
-                            }
-                        }
+                            "error": {"type": "api_error", "message": "No initialized accounts available"},
+                        },
                     )
                 auth_manager = account.auth_manager
-                
+
                 logger.info("Detected native Anthropic web_search (Path A), routing to MCP API")
                 return await handle_native_web_search(request, request_data, auth_manager, api_format="anthropic")
-    
+
     # ==============================================================================
     # Account System: Account System Failover or Legacy Mode
     # ==============================================================================
-    
+
     if request.app.state.account_system:
         # ==============================================================================
         # ACCOUNT SYSTEM ENABLED: Failover Loop
         # ==============================================================================
-        from kiro.account_errors import classify_error, ErrorType
-        
+        from kiro.account_errors import ErrorType, classify_error
+
         account_manager = request.app.state.account_manager
         all_accounts = list(account_manager._accounts.keys())
         MAX_ATTEMPTS = len(all_accounts) * 2  # Full circle with margin
-        
+
         last_error_message = None
         last_error_status = None
         tried_accounts = set()  # Track tried accounts in current failover loop
-        
+
         for attempt in range(MAX_ATTEMPTS):
             # Get next available account (excluding already tried)
-            account = await account_manager.get_next_account(
-                request_data.model,
-                exclude_accounts=tried_accounts
-            )
-            
+            account = await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
+
             if account is None:
                 # All accounts unavailable
                 if len(all_accounts) == 1:
@@ -231,11 +215,8 @@ async def messages(
                         status_code=last_error_status or 503,
                         content={
                             "type": "error",
-                            "error": {
-                                "type": "api_error",
-                                "message": last_error_message or "Account unavailable"
-                            }
-                        }
+                            "error": {"type": "api_error", "message": last_error_message or "Account unavailable"},
+                        },
                     )
                 else:
                     # Multiple accounts - no account is currently selectable.
@@ -248,71 +229,53 @@ async def messages(
                     if last_error_message:
                         detail += f" Error from last account: {last_error_message}"
                     return JSONResponse(
-                        status_code=503,
-                        content={
-                            "type": "error",
-                            "error": {
-                                "type": "api_error",
-                                "message": detail
-                            }
-                        }
+                        status_code=503, content={"type": "error", "error": {"type": "api_error", "message": detail}}
                     )
-            
+
             # Mark account as tried in current failover loop
             tried_accounts.add(account.id)
-            
+
             # Use objects from account
             auth_manager = account.auth_manager
             model_cache = account.model_cache
-            model_resolver = account.model_resolver
-            
+
             # Generate conversation ID
             conversation_id = generate_conversation_id()
-            
+
             # Build payload for Kiro
             # A Builder ID account has no profile and must not be given one: the
             # global fallback would send a foreign ARN and fail the request.
             profile_arn_for_payload = auth_manager.profile_arn or (
                 "" if auth_manager.auth_type == AuthType.AWS_SSO_OIDC else PROFILE_ARN or ""
             )
-            
+
             try:
-                kiro_payload = anthropic_to_kiro(
-                    request_data,
-                    conversation_id,
-                    profile_arn_for_payload
-                )
+                kiro_payload = anthropic_to_kiro(request_data, conversation_id, profile_arn_for_payload)
             except ValueError as e:
                 logger.error(f"Conversion error: {e}")
                 return JSONResponse(
                     status_code=400,
-                    content={
-                        "type": "error",
-                        "error": {
-                            "type": "invalid_request_error",
-                            "message": str(e)
-                        }
-                    }
+                    content={"type": "error", "error": {"type": "invalid_request_error", "message": str(e)}},
                 )
-            
+
             # Log Kiro payload
             try:
-                kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
+                kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode("utf-8")
                 if debug_logger:
                     debug_logger.log_kiro_request_body(kiro_request_body)
             except Exception as e:
                 logger.warning(f"Failed to log Kiro request: {e}")
-            
+
             # Create HTTP client
             url = f"{auth_manager.api_host}/generateAssistantResponse"
             logger.debug(f"Kiro API URL: {url} (account: {account.id})")
-            
+
             if request_data.stream:
                 http_client = KiroHttpClient(auth_manager, shared_client=None)
             else:
                 shared_client = request.app.state.http_client
                 http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
-            
+
             # Prepare data for token counting
             messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
             tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
@@ -320,32 +283,29 @@ async def messages(
                 system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
             else:
                 system_for_tokenizer = request_data.system
-            
+
             try:
                 # Make request to Kiro API
                 response = await http_client.request_with_retry(
-                    "POST",
-                    url,
-                    kiro_payload,
-                    stream=True,
-                    retry_rate_limits=False
+                    "POST", url, kiro_payload, stream=True, retry_rate_limits=False
                 )
-                
+
                 if response.status_code == 200:
                     # SUCCESS - report and return
                     await account_manager.report_success(account.id, request_data.model)
-                    
+
                     if request_data.stream:
                         # Streaming mode
                         async def stream_wrapper():
                             streaming_error = None
                             client_disconnected = False
                             try:
+
                                 async def make_retry_request():
                                     return await http_client.request_with_retry(
                                         "POST", url, kiro_payload, stream=True, retry_rate_limits=False
                                     )
-                                
+
                                 async for chunk in stream_with_first_token_retry_anthropic(
                                     make_request=make_retry_request,
                                     model=request_data.model,
@@ -363,7 +323,7 @@ async def messages(
                             except Exception as e:
                                 streaming_error = e
                                 try:
-                                    error_event = f'event: error\ndata: {json.dumps({"type": "error", "error": {"type": "api_error", "message": str(e)}})}\n\n'
+                                    error_event = f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'type': 'api_error', 'message': str(e)}})}\n\n"
                                     yield error_event
                                 except Exception:
                                     pass
@@ -372,27 +332,29 @@ async def messages(
                                 if streaming_error:
                                     error_type = type(streaming_error).__name__
                                     error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
-                                    logger.error(f"HTTP 500 - POST /v1/messages (streaming) - [{error_type}] {error_msg[:100]}")
+                                    logger.error(
+                                        f"HTTP 500 - POST /v1/messages (streaming) - [{error_type}] {error_msg[:100]}"
+                                    )
                                 elif client_disconnected:
-                                    logger.info(f"HTTP 200 - POST /v1/messages (streaming) - client disconnected")
+                                    logger.info("HTTP 200 - POST /v1/messages (streaming) - client disconnected")
                                 else:
-                                    logger.info(f"HTTP 200 - POST /v1/messages (streaming) - completed")
-                                
+                                    logger.info("HTTP 200 - POST /v1/messages (streaming) - completed")
+
                                 if debug_logger:
                                     if streaming_error:
                                         debug_logger.flush_on_error(500, str(streaming_error))
                                     else:
                                         debug_logger.discard_buffers()
-                        
+
                         return StreamingResponse(
                             stream_wrapper(),
                             media_type="text/event-stream",
                             headers={
                                 "Cache-Control": "no-cache",
                                 "Connection": "keep-alive",
-                            }
+                            },
                         )
-                    
+
                     else:
                         # Non-streaming mode
                         anthropic_response = await collect_anthropic_response(
@@ -404,101 +366,95 @@ async def messages(
                             request_tools=tools_for_tokenizer,
                             request_system=system_for_tokenizer,
                         )
-                        
+
                         await http_client.close()
-                        logger.info(f"HTTP 200 - POST /v1/messages (non-streaming) - completed")
-                        
+                        logger.info("HTTP 200 - POST /v1/messages (non-streaming) - completed")
+
                         if debug_logger:
                             debug_logger.discard_buffers()
-                        
+
                         return JSONResponse(content=anthropic_response)
-                
+
                 else:
                     # ERROR - classify and decide
                     try:
                         error_content = await response.aread()
                     except Exception:
                         error_content = b"Unknown error"
-                    
+
                     await http_client.close()
-                    error_text = error_content.decode('utf-8', errors='replace')
-                    
+                    error_text = error_content.decode("utf-8", errors="replace")
+
                     # Extract error reason and save for final return
                     error_reason = None
                     try:
                         error_json = json.loads(error_text)
                         from kiro.kiro_errors import enhance_kiro_error
+
                         error_info = enhance_kiro_error(error_json)
                         error_reason = error_info.reason
                         last_error_message = error_info.user_message
                         last_error_status = response.status_code
-                        logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
+                        logger.debug(
+                            f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})"
+                        )
                     except (json.JSONDecodeError, KeyError):
                         last_error_message = error_text
                         last_error_status = response.status_code
-                    
+
                     # Classify error
                     error_type = classify_error(response.status_code, error_reason)
-                    
+
                     if error_type == ErrorType.FATAL:
                         # FATAL - return to client immediately
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type,
-                            response.status_code, error_reason
+                            account.id, request_data.model, error_type, response.status_code, error_reason
                         )
-                        
+
                         logger.warning(f"HTTP {response.status_code} - POST /v1/messages - {last_error_message[:100]}")
-                        
+
                         if debug_logger:
                             debug_logger.flush_on_error(response.status_code, last_error_message)
-                        
+
                         return JSONResponse(
                             status_code=response.status_code,
-                            content={
-                                "type": "error",
-                                "error": {
-                                    "type": "api_error",
-                                    "message": last_error_message
-                                }
-                            }
+                            content={"type": "error", "error": {"type": "api_error", "message": last_error_message}},
                         )
-                    
+
                     else:  # ErrorType.RECOVERABLE
                         # RECOVERABLE - try next account
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type,
-                            response.status_code, error_reason
+                            account.id, request_data.model, error_type, response.status_code, error_reason
                         )
-                        
+
                         # Single account - no point in failover, break immediately
                         if len(all_accounts) == 1:
                             break
-                        
+
                         continue  # Next iteration
-            
+
             except HTTPException as e:
                 await http_client.close()
-                
+
                 # Network errors (502/504 from request_with_retry) = RECOVERABLE
                 # These are thrown ONLY for network-level issues (timeouts, connection errors)
                 # NOT for HTTP-level errors (which are returned as response objects)
                 if e.status_code in (502, 504):
                     # Network error → try next account
                     await account_manager.report_failure(
-                        account.id, request_data.model, ErrorType.RECOVERABLE,
-                        e.status_code, None
+                        account.id, request_data.model, ErrorType.RECOVERABLE, e.status_code, None
                     )
-                    
+
                     last_error_message = str(e.detail)
                     last_error_status = e.status_code
-                    
+
                     # Single account - no point in failover, break immediately
                     if len(all_accounts) == 1:
                         break
-                    
+
                     logger.warning(f"Network error on account {account.id}, trying next account")
                     continue  # Try next account
-                
+
                 # All other HTTPException (400, 500, etc.) = application errors
                 # These come from build_kiro_payload() or other places → re-raise immediately
                 logger.error(f"HTTP {e.status_code} - POST /v1/messages - {e.detail}")
@@ -511,31 +467,22 @@ async def messages(
                 logger.error(f"HTTP 500 - POST /v1/messages - {str(e)[:100]}")
                 if debug_logger:
                     debug_logger.flush_on_error(500, str(e))
-                
+
                 return JSONResponse(
                     status_code=500,
                     content={
                         "type": "error",
-                        "error": {
-                            "type": "api_error",
-                            "message": f"Internal Server Error: {str(e)}"
-                        }
-                    }
+                        "error": {"type": "api_error", "message": f"Internal Server Error: {str(e)}"},
+                    },
                 )
-        
+
         # All attempts exhausted
         if len(all_accounts) == 1:
             # Single account - return its original error
             # last_error_status and last_error_message are guaranteed to be set
             return JSONResponse(
                 status_code=last_error_status,
-                content={
-                    "type": "error",
-                    "error": {
-                        "type": "api_error",
-                        "message": last_error_message
-                    }
-                }
+                content={"type": "error", "error": {"type": "api_error", "message": last_error_message}},
             )
         else:
             # Multiple accounts - every account was tried and failed
@@ -546,16 +493,9 @@ async def messages(
             if last_error_message:
                 detail += f" Error from last account: {last_error_message}"
             return JSONResponse(
-                status_code=503,
-                content={
-                    "type": "error",
-                    "error": {
-                        "type": "api_error",
-                        "message": detail
-                    }
-                }
+                status_code=503, content={"type": "error", "error": {"type": "api_error", "message": detail}}
             )
-    
+
     else:
         # ==============================================================================
         # LEGACY MODE: Single Account (no failover)
@@ -567,63 +507,48 @@ async def messages(
                 status_code=503,
                 content={
                     "type": "error",
-                    "error": {
-                        "type": "api_error",
-                        "message": "No initialized accounts available"
-                    }
-                }
+                    "error": {"type": "api_error", "message": "No initialized accounts available"},
+                },
             )
         auth_manager = account.auth_manager
         model_cache = account.model_cache
-        model_resolver = account.model_resolver
-    
+
     # ==============================================================================
     # Normal Flow (Path B will be intercepted in streaming, or no web_search)
     # ==============================================================================
-    
+
     # Generate conversation ID for Kiro API (random UUID, not used for tracking)
     conversation_id = generate_conversation_id()
-    
+
     # Build payload for Kiro
     # A Builder ID account has no profile and must not be given one: the global
     # fallback would send a foreign ARN and fail the request.
     profile_arn_for_payload = auth_manager.profile_arn or (
         "" if auth_manager.auth_type == AuthType.AWS_SSO_OIDC else PROFILE_ARN or ""
     )
-    
+
     try:
-        kiro_payload = anthropic_to_kiro(
-            request_data,
-            conversation_id,
-            profile_arn_for_payload
-        )
+        kiro_payload = anthropic_to_kiro(request_data, conversation_id, profile_arn_for_payload)
     except ValueError as e:
         logger.error(f"Conversion error: {e}")
         return JSONResponse(
-            status_code=400,
-            content={
-                "type": "error",
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": str(e)
-                }
-            }
+            status_code=400, content={"type": "error", "error": {"type": "invalid_request_error", "message": str(e)}}
         )
-    
+
     # Log Kiro payload
     try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
+        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode("utf-8")
         if debug_logger:
             debug_logger.log_kiro_request_body(kiro_request_body)
     except Exception as e:
         logger.warning(f"Failed to log Kiro request: {e}")
-    
+
     # Create HTTP client with retry logic
     # For streaming: use per-request client to avoid CLOSE_WAIT leak on VPN disconnect (issue #54)
     # For non-streaming: use shared client for connection pooling
     url = f"{auth_manager.api_host}/generateAssistantResponse"
     logger.debug(f"Kiro API URL: {url}")
-    
+
     if request_data.stream:
         # Streaming mode: per-request client prevents orphaned connections
         # when network interface changes (VPN disconnect/reconnect)
@@ -632,7 +557,7 @@ async def messages(
         # Non-streaming mode: shared client for efficient connection reuse
         shared_client = request.app.state.http_client
         http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
-    
+
     # Prepare data for token counting
     # Convert Pydantic models to dicts for tokenizer
     messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
@@ -642,62 +567,49 @@ async def messages(
         system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
     else:
         system_for_tokenizer = request_data.system
-    
+
     try:
         # Make request to Kiro API (for both streaming and non-streaming modes)
         # Important: we wait for Kiro response BEFORE returning StreamingResponse,
         # so that we can return proper HTTP error codes if Kiro fails
-        response = await http_client.request_with_retry(
-            "POST",
-            url,
-            kiro_payload,
-            stream=True,
-            retry_rate_limits=False
-        )
-        
+        response = await http_client.request_with_retry("POST", url, kiro_payload, stream=True, retry_rate_limits=False)
+
         if response.status_code != 200:
             try:
                 error_content = await response.aread()
             except Exception:
                 error_content = b"Unknown error"
-            
+
             await http_client.close()
-            error_text = error_content.decode('utf-8', errors='replace')
-            
+            error_text = error_content.decode("utf-8", errors="replace")
+
             # Try to parse JSON response from Kiro to extract error message
             error_message = error_text
             try:
                 error_json = json.loads(error_text)
                 # Enhance Kiro API errors with user-friendly messages
                 from kiro.kiro_errors import enhance_kiro_error
+
                 error_info = enhance_kiro_error(error_json)
                 error_message = error_info.user_message
                 # Log original error for debugging
                 logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
             except (json.JSONDecodeError, KeyError):
                 pass
-            
+
             # Log access log for error (before flush, so it gets into app_logs)
-            logger.warning(
-                f"HTTP {response.status_code} - POST /v1/messages - {error_message[:100]}"
-            )
-            
+            logger.warning(f"HTTP {response.status_code} - POST /v1/messages - {error_message[:100]}")
+
             # Flush debug logs on error
             if debug_logger:
                 debug_logger.flush_on_error(response.status_code, error_message)
-            
+
             # Return error in Anthropic format
             return JSONResponse(
                 status_code=response.status_code,
-                content={
-                    "type": "error",
-                    "error": {
-                        "type": "api_error",
-                        "message": error_message
-                    }
-                }
+                content={"type": "error", "error": {"type": "api_error", "message": error_message}},
             )
-        
+
         if request_data.stream:
             # Streaming mode with first token retry
             async def stream_wrapper():
@@ -709,7 +621,7 @@ async def messages(
                         return await http_client.request_with_retry(
                             "POST", url, kiro_payload, stream=True, retry_rate_limits=False
                         )
-                    
+
                     # Use retry wrapper with initial response
                     async for chunk in stream_with_first_token_retry_anthropic(
                         make_request=make_retry_request,
@@ -729,7 +641,7 @@ async def messages(
                     streaming_error = e
                     # Send error event to client, then gracefully end the stream
                     try:
-                        error_event = f'event: error\ndata: {json.dumps({"type": "error", "error": {"type": "api_error", "message": str(e)}})}\n\n'
+                        error_event = f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'type': 'api_error', 'message': str(e)}})}\n\n"
                         yield error_event
                     except Exception:
                         pass
@@ -740,25 +652,25 @@ async def messages(
                         error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
                         logger.error(f"HTTP 500 - POST /v1/messages (streaming) - [{error_type}] {error_msg[:100]}")
                     elif client_disconnected:
-                        logger.info(f"HTTP 200 - POST /v1/messages (streaming) - client disconnected")
+                        logger.info("HTTP 200 - POST /v1/messages (streaming) - client disconnected")
                     else:
-                        logger.info(f"HTTP 200 - POST /v1/messages (streaming) - completed")
-                    
+                        logger.info("HTTP 200 - POST /v1/messages (streaming) - completed")
+
                     if debug_logger:
                         if streaming_error:
                             debug_logger.flush_on_error(500, str(streaming_error))
                         else:
                             debug_logger.discard_buffers()
-            
+
             return StreamingResponse(
                 stream_wrapper(),
                 media_type="text/event-stream",
                 headers={
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
-                }
+                },
             )
-        
+
         else:
             # Non-streaming mode - collect entire response
             anthropic_response = await collect_anthropic_response(
@@ -770,24 +682,24 @@ async def messages(
                 request_tools=tools_for_tokenizer,
                 request_system=system_for_tokenizer,
             )
-            
+
             await http_client.close()
-            
-            logger.info(f"HTTP 200 - POST /v1/messages (non-streaming) - completed")
-            
+
+            logger.info("HTTP 200 - POST /v1/messages (non-streaming) - completed")
+
             if debug_logger:
                 debug_logger.discard_buffers()
-            
+
             return JSONResponse(content=anthropic_response)
-    
+
     except HTTPException as e:
         await http_client.close()
-        
+
         # Network errors (502/504 from request_with_retry) = RECOVERABLE
         # In legacy mode, we still log them but re-raise (no failover available)
         if e.status_code in (502, 504):
-            logger.warning(f"Network error (legacy mode, no failover available)")
-        
+            logger.warning("Network error (legacy mode, no failover available)")
+
         logger.error(f"HTTP {e.status_code} - POST /v1/messages - {e.detail}")
         if debug_logger:
             debug_logger.flush_on_error(e.status_code, str(e.detail))
@@ -798,16 +710,10 @@ async def messages(
         logger.error(f"HTTP 500 - POST /v1/messages - {str(e)[:100]}")
         if debug_logger:
             debug_logger.flush_on_error(500, str(e))
-        
+
         return JSONResponse(
             status_code=500,
-            content={
-                "type": "error",
-                "error": {
-                    "type": "api_error",
-                    "message": f"Internal Server Error: {str(e)}"
-                }
-            }
+            content={"type": "error", "error": {"type": "api_error", "message": f"Internal Server Error: {str(e)}"}},
         )
 
 
@@ -818,47 +724,49 @@ async def count_tokens_endpoint(
 ):
     """
     Anthropic Count Tokens API endpoint.
-    
+
     Returns estimated token count for the given request payload.
     Used by Claude Code to decide when to trigger conversation compaction.
-    
+
     Uses the same fallback estimation as Anthropic streaming (message_start event),
     since Kiro API only provides accurate token counts after request completion.
     This endpoint is called BEFORE the actual request, so we cannot use Kiro's
     contextUsagePercentage (which is only available after generation completes).
-    
+
     Args:
         request: FastAPI Request for accessing app.state
         request_data: Request in Anthropic MessagesRequest format
-    
+
     Returns:
         JSONResponse with {"input_tokens": int}
-    
+
     Raises:
         HTTPException: 401 if authentication fails (handled by dependency)
     """
-    logger.info(f"Request to /v1/messages/count_tokens (model={request_data.model}, messages={len(request_data.messages)})")
-    
+    logger.info(
+        f"Request to /v1/messages/count_tokens (model={request_data.model}, messages={len(request_data.messages)})"
+    )
+
     # Prepare data for tokenizer (same format as streaming message_start)
     messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
     tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
-    
+
     # Handle system prompt (can be string or list of content blocks)
     if isinstance(request_data.system, list):
         system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
     else:
         system_for_tokenizer = request_data.system
-    
+
     # Use the SAME estimation logic as Anthropic streaming message_start
     request_token_stats = estimate_request_tokens(
         messages=messages_for_tokenizer,
         tools=tools_for_tokenizer,
         system_prompt=system_for_tokenizer,
-        apply_claude_correction=True  # CRITICAL: Enable correction for Claude models
+        apply_claude_correction=True,  # CRITICAL: Enable correction for Claude models
     )
-    
+
     input_tokens = request_token_stats["total_tokens"]
-    
+
     logger.info(f"Token count estimate: {input_tokens} tokens")
-    
+
     return JSONResponse(content={"input_tokens": input_tokens})

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -11,32 +11,28 @@ Contains all API endpoints:
 import json
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, Security
+from fastapi import APIRouter, Depends, HTTPException, Request, Security
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
 
+from kiro.auth import AuthType
 from kiro.config import (
-    PROXY_API_KEY,
     APP_VERSION,
     PROFILE_ARN,
+    WEB_SEARCH_ENABLED,
 )
-from kiro.models_openai import (
-    OpenAIModel,
-    ModelList,
-    ChatCompletionRequest,
-)
-from kiro.auth import KiroAuthManager, AuthType
-from kiro.cache import ModelInfoCache
-from kiro.model_resolver import ModelResolver
 from kiro.converters_openai import build_kiro_payload
-from kiro.streaming_openai import stream_kiro_to_openai, collect_stream_response, stream_with_first_token_retry
-from kiro.http_client import KiroHttpClient
-from kiro.utils import generate_conversation_id
-from kiro.config import WEB_SEARCH_ENABLED
-from kiro.mcp_tools import handle_native_web_search
 from kiro.dashboard import identify_data_api_key
+from kiro.http_client import KiroHttpClient
+from kiro.models_openai import (
+    ChatCompletionRequest,
+    ModelList,
+    OpenAIModel,
+)
+from kiro.streaming_openai import collect_stream_response, stream_with_first_token_retry
 from kiro.usage_tracking import current_api_key_id
+from kiro.utils import generate_conversation_id
 
 # Import debug_logger
 try:
@@ -52,15 +48,15 @@ api_key_header = APIKeyHeader(name="Authorization", auto_error=False)
 async def verify_api_key(auth_header: str = Security(api_key_header)) -> bool:
     """
     Verify API key in Authorization header.
-    
+
     Expects format: "Bearer {PROXY_API_KEY}"
-    
+
     Args:
         auth_header: Authorization header value
-    
+
     Returns:
         True if key is valid
-    
+
     Raises:
         HTTPException: 401 if key is invalid or missing
     """
@@ -83,47 +79,40 @@ router = APIRouter()
 async def root():
     """
     Health check endpoint.
-    
+
     Returns:
         Status and application version
     """
-    return {
-        "status": "ok",
-        "message": "kiro-lb is running",
-        "version": APP_VERSION
-    }
+    return {"status": "ok", "message": "kiro-lb is running", "version": APP_VERSION}
 
 
 @router.get("/health")
 async def health():
     """
     Detailed health check.
-    
+
     Returns:
         Status, timestamp and version
     """
-    return {
-        "status": "healthy",
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "version": APP_VERSION
-    }
+    return {"status": "healthy", "timestamp": datetime.now(timezone.utc).isoformat(), "version": APP_VERSION}
+
 
 @router.get("/v1/models", response_model=ModelList, dependencies=[Depends(verify_api_key)])
 async def get_models(request: Request):
     """
     Return list of available models.
-    
+
     Models are loaded at startup (blocking) and cached.
     This endpoint returns the cached list.
-    
+
     Args:
         request: FastAPI Request for accessing app.state
-    
+
     Returns:
         ModelList with available models in consistent format (with dots)
     """
     logger.info("Request to /v1/models")
-    
+
     # Get available models based on mode
     if request.app.state.account_system:
         # Account system: collect models from all initialized accounts
@@ -132,17 +121,13 @@ async def get_models(request: Request):
         # Legacy: use resolver from first account
         account = request.app.state.account_manager.get_first_account()
         available_model_ids = account.model_resolver.get_available_models()
-    
+
     # Build OpenAI-compatible model list
     openai_models = [
-        OpenAIModel(
-            id=model_id,
-            owned_by="anthropic",
-            description="Claude model via Kiro API"
-        )
+        OpenAIModel(id=model_id, owned_by="anthropic", description="Claude model via Kiro API")
         for model_id in available_model_ids
     ]
-    
+
     return ModelList(data=openai_models)
 
 
@@ -150,44 +135,45 @@ async def get_models(request: Request):
 async def chat_completions(request: Request, request_data: ChatCompletionRequest):
     """
     Chat completions endpoint - compatible with OpenAI API.
-    
+
     Accepts requests in OpenAI format and translates them to Kiro API.
     Supports streaming and non-streaming modes.
-    
+
     Args:
         request: FastAPI Request for accessing app.state
         request_data: Request in OpenAI ChatCompletionRequest format
-    
+
     Returns:
         StreamingResponse for streaming mode
         JSONResponse for non-streaming mode
-    
+
     Raises:
         HTTPException: On validation or API errors
     """
     logger.info(f"Request to /v1/chat/completions (model={request_data.model}, stream={request_data.stream})")
-    
+
     # Note: prepare_new_request() and log_request_body() are now called by DebugLoggerMiddleware
     # This ensures debug logging works even for requests that fail Pydantic validation (422 errors)
-    
+
     # ==============================================================================
     # WebSearch Support - Path B: Auto-Injection (MCP Tool Emulation)
     # ==============================================================================
-    
+
     # Auto-inject web_search tool if enabled (Path B - MCP emulation)
     if WEB_SEARCH_ENABLED:
         if request_data.tools is None:
             request_data.tools = []
-        
+
         # Check if web_search already exists
         has_ws = any(
-            getattr(tool, "type", None) == "function" and
-            getattr(getattr(tool, "function", None), "name", None) == "web_search"
+            getattr(tool, "type", None) == "function"
+            and getattr(getattr(tool, "function", None), "name", None) == "web_search"
             for tool in request_data.tools
         )
-        
+
         if not has_ws:
             from kiro.models_openai import Tool, ToolFunction
+
             web_search_tool = Tool(
                 type="function",
                 function=ToolFunction(
@@ -195,51 +181,42 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                     description="Search the web for current information. Use when you need up-to-date data from the internet.",
                     parameters={
                         "type": "object",
-                        "properties": {
-                            "query": {
-                                "type": "string",
-                                "description": "Search query"
-                            }
-                        },
-                        "required": ["query"]
-                    }
-                )
+                        "properties": {"query": {"type": "string", "description": "Search query"}},
+                        "required": ["query"],
+                    },
+                ),
             )
             request_data.tools.append(web_search_tool)
             logger.debug("Auto-injected web_search tool for MCP emulation (Path B)")
-    
+
     # ==============================================================================
     # Account System: Account System Failover or Legacy Mode
     # ==============================================================================
-    
+
     if request.app.state.account_system:
         # ==============================================================================
         # ACCOUNT SYSTEM ENABLED: Failover Loop
         # ==============================================================================
-        from kiro.account_errors import classify_error, ErrorType
-        
+        from kiro.account_errors import ErrorType, classify_error
+
         account_manager = request.app.state.account_manager
         all_accounts = list(account_manager._accounts.keys())
         MAX_ATTEMPTS = len(all_accounts) * 2  # Full circle with margin
-        
+
         last_error_message = None
         last_error_status = None
         tried_accounts = set()  # Track tried accounts in current failover loop
-        
+
         for attempt in range(MAX_ATTEMPTS):
             # Get next available account (excluding already tried)
-            account = await account_manager.get_next_account(
-                request_data.model,
-                exclude_accounts=tried_accounts
-            )
-            
+            account = await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
+
             if account is None:
                 # All accounts unavailable
                 if len(all_accounts) == 1:
                     # Single account - return original error with original status code
                     raise HTTPException(
-                        status_code=last_error_status or 503,
-                        detail=last_error_message or "Account unavailable"
+                        status_code=last_error_status or 503, detail=last_error_message or "Account unavailable"
                     )
                 else:
                     # Multiple accounts - no account is currently selectable.
@@ -252,81 +229,75 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                     if last_error_message:
                         detail += f" Error from last account: {last_error_message}"
                     raise HTTPException(status_code=503, detail=detail)
-            
+
             # Mark account as tried in current failover loop
             tried_accounts.add(account.id)
-            
+
             # Use objects from account
             auth_manager = account.auth_manager
             model_cache = account.model_cache
-            model_resolver = account.model_resolver
-            
+
             # Generate conversation ID
             conversation_id = generate_conversation_id()
-            
+
             # Build payload for Kiro
             # A Builder ID account has no profile and must not be given one: the
             # global fallback would send a foreign ARN and fail the request.
             profile_arn_for_payload = auth_manager.profile_arn or (
                 "" if auth_manager.auth_type == AuthType.AWS_SSO_OIDC else PROFILE_ARN or ""
             )
-            
+
             try:
-                kiro_payload = build_kiro_payload(
-                    request_data,
-                    conversation_id,
-                    profile_arn_for_payload
-                )
+                kiro_payload = build_kiro_payload(request_data, conversation_id, profile_arn_for_payload)
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
-            
+
             # Log Kiro payload
             try:
-                kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
+                kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode("utf-8")
                 if debug_logger:
                     debug_logger.log_kiro_request_body(kiro_request_body)
             except Exception as e:
                 logger.warning(f"Failed to log Kiro request: {e}")
-            
+
             # Create HTTP client
             url = f"{auth_manager.api_host}/generateAssistantResponse"
             logger.debug(f"Kiro API URL: {url} (account: {account.id})")
-            
+
             if request_data.stream:
                 http_client = KiroHttpClient(auth_manager, shared_client=None)
             else:
                 shared_client = request.app.state.http_client
                 http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
-            
+
             try:
                 # Make request to Kiro API
                 response = await http_client.request_with_retry(
-                    "POST",
-                    url,
-                    kiro_payload,
-                    stream=True,
-                    retry_rate_limits=False
+                    "POST", url, kiro_payload, stream=True, retry_rate_limits=False
                 )
-                
+
                 if response.status_code == 200:
                     # SUCCESS - report and return
                     await account_manager.report_success(account.id, request_data.model)
-                    
+
                     # Prepare data for token counting
                     messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
-                    tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
-                    
+                    tools_for_tokenizer = (
+                        [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
+                    )
+
                     if request_data.stream:
                         # Streaming mode
                         async def stream_wrapper():
                             streaming_error = None
                             client_disconnected = False
                             try:
+
                                 async def make_retry_request():
                                     return await http_client.request_with_retry(
                                         "POST", url, kiro_payload, stream=True, retry_rate_limits=False
                                     )
-                                
+
                                 async for chunk in stream_with_first_token_retry(
                                     make_request=make_retry_request,
                                     client=http_client.client,
@@ -355,19 +326,23 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                                 if streaming_error:
                                     error_type = type(streaming_error).__name__
                                     error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
-                                    logger.error(f"HTTP 500 - POST /v1/chat/completions (streaming) - [{error_type}] {error_msg[:100]}")
+                                    logger.error(
+                                        f"HTTP 500 - POST /v1/chat/completions (streaming) - [{error_type}] {error_msg[:100]}"
+                                    )
                                 elif client_disconnected:
-                                    logger.info(f"HTTP 200 - POST /v1/chat/completions (streaming) - client disconnected")
+                                    logger.info(
+                                        "HTTP 200 - POST /v1/chat/completions (streaming) - client disconnected"
+                                    )
                                 else:
-                                    logger.info(f"HTTP 200 - POST /v1/chat/completions (streaming) - completed")
+                                    logger.info("HTTP 200 - POST /v1/chat/completions (streaming) - completed")
                                 if debug_logger:
                                     if streaming_error:
                                         debug_logger.flush_on_error(500, str(streaming_error))
                                     else:
                                         debug_logger.discard_buffers()
-                        
+
                         return StreamingResponse(stream_wrapper(), media_type="text/event-stream")
-                    
+
                     else:
                         # Non-streaming mode
                         openai_response = await collect_stream_response(
@@ -381,101 +356,103 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                             include_reasoning=request_data.include_reasoning,
                             parallel_tool_calls=request_data.parallel_tool_calls is not False,
                         )
-                        
+
                         await http_client.close()
-                        logger.info(f"HTTP 200 - POST /v1/chat/completions (non-streaming) - completed")
-                        
+                        logger.info("HTTP 200 - POST /v1/chat/completions (non-streaming) - completed")
+
                         if debug_logger:
                             debug_logger.discard_buffers()
-                        
+
                         return JSONResponse(content=openai_response)
-                
+
                 else:
                     # ERROR - classify and decide
                     try:
                         error_content = await response.aread()
                     except Exception:
                         error_content = b"Unknown error"
-                    
+
                     await http_client.close()
-                    error_text = error_content.decode('utf-8', errors='replace')
-                    
+                    error_text = error_content.decode("utf-8", errors="replace")
+
                     # Extract error reason and save for final return
                     error_reason = None
                     try:
                         error_json = json.loads(error_text)
                         from kiro.kiro_errors import enhance_kiro_error
+
                         error_info = enhance_kiro_error(error_json)
                         error_reason = error_info.reason
                         last_error_message = error_info.user_message
                         last_error_status = response.status_code
-                        logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
+                        logger.debug(
+                            f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})"
+                        )
                     except (json.JSONDecodeError, KeyError):
                         last_error_message = error_text
                         last_error_status = response.status_code
-                    
+
                     # Classify error
                     error_type = classify_error(response.status_code, error_reason)
-                    
+
                     if error_type == ErrorType.FATAL:
                         # FATAL - return to client immediately
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type,
-                            response.status_code, error_reason
+                            account.id, request_data.model, error_type, response.status_code, error_reason
                         )
-                        
-                        logger.warning(f"HTTP {response.status_code} - POST /v1/chat/completions - {last_error_message[:100]}")
-                        
+
+                        logger.warning(
+                            f"HTTP {response.status_code} - POST /v1/chat/completions - {last_error_message[:100]}"
+                        )
+
                         if debug_logger:
                             debug_logger.flush_on_error(response.status_code, last_error_message)
-                        
+
                         return JSONResponse(
                             status_code=response.status_code,
                             content={
                                 "error": {
                                     "message": last_error_message,
                                     "type": "kiro_api_error",
-                                    "code": response.status_code
+                                    "code": response.status_code,
                                 }
-                            }
+                            },
                         )
-                    
+
                     else:  # ErrorType.RECOVERABLE
                         # RECOVERABLE - try next account
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type,
-                            response.status_code, error_reason
+                            account.id, request_data.model, error_type, response.status_code, error_reason
                         )
-                        
+
                         # Single account - no point in failover, break immediately
                         if len(all_accounts) == 1:
                             break
-                        
+
                         continue  # Next iteration
-            
+
             except HTTPException as e:
                 await http_client.close()
-                
+
                 # Network errors (502/504 from request_with_retry) = RECOVERABLE
                 # These are thrown ONLY for network-level issues (timeouts, connection errors)
                 # NOT for HTTP-level errors (which are returned as response objects)
                 if e.status_code in (502, 504):
                     # Network error → try next account
                     await account_manager.report_failure(
-                        account.id, request_data.model, ErrorType.RECOVERABLE,
-                        e.status_code, None
+                        account.id, request_data.model, ErrorType.RECOVERABLE, e.status_code, None
                     )
-                    
+
                     last_error_message = str(e.detail)
                     last_error_status = e.status_code
-                    
+
                     # Single account - no point in failover, break immediately
                     if len(all_accounts) == 1:
                         break
-                    
+
                     logger.warning(f"Network error on account {account.id}, trying next account")
                     continue  # Try next account
-                
+
                 # All other HTTPException (400, 500, etc.) = application errors
                 # These come from build_kiro_payload() or other places → re-raise immediately
                 logger.error(f"HTTP {e.status_code} - POST /v1/chat/completions - {e.detail}")
@@ -489,15 +466,12 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                 if debug_logger:
                     debug_logger.flush_on_error(500, str(e))
                 raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")
-        
+
         # All attempts exhausted
         if len(all_accounts) == 1:
             # Single account - return its original error
             # last_error_status and last_error_message are guaranteed to be set
-            raise HTTPException(
-                status_code=last_error_status,
-                detail=last_error_message
-            )
+            raise HTTPException(status_code=last_error_status, detail=last_error_message)
         else:
             # Multiple accounts - every account was tried and failed
             detail = (
@@ -507,7 +481,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             if last_error_message:
                 detail += f" Error from last account: {last_error_message}"
             raise HTTPException(status_code=503, detail=detail)
-    
+
     else:
         # ==============================================================================
         # LEGACY MODE: Single Account (no failover)
@@ -518,41 +492,36 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             raise HTTPException(503, "No initialized accounts available")
         auth_manager = account.auth_manager
         model_cache = account.model_cache
-        model_resolver = account.model_resolver
-    
+
     # Generate conversation ID for Kiro API (random UUID, not used for tracking)
     conversation_id = generate_conversation_id()
-    
+
     # Build payload for Kiro
     # A Builder ID account has no profile and must not be given one: the global
     # fallback would send a foreign ARN and fail the request.
     profile_arn_for_payload = auth_manager.profile_arn or (
         "" if auth_manager.auth_type == AuthType.AWS_SSO_OIDC else PROFILE_ARN or ""
     )
-    
+
     try:
-        kiro_payload = build_kiro_payload(
-            request_data,
-            conversation_id,
-            profile_arn_for_payload
-        )
+        kiro_payload = build_kiro_payload(request_data, conversation_id, profile_arn_for_payload)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    
+
     # Log Kiro payload
     try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode('utf-8')
+        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode("utf-8")
         if debug_logger:
             debug_logger.log_kiro_request_body(kiro_request_body)
     except Exception as e:
         logger.warning(f"Failed to log Kiro request: {e}")
-    
+
     # Create HTTP client with retry logic
     # For streaming: use per-request client to avoid CLOSE_WAIT leak on VPN disconnect (issue #54)
     # For non-streaming: use shared client for connection pooling
     url = f"{auth_manager.api_host}/generateAssistantResponse"
     logger.debug(f"Kiro API URL: {url}")
-    
+
     if request_data.stream:
         # Streaming mode: per-request client prevents orphaned connections
         # when network interface changes (VPN disconnect/reconnect)
@@ -565,62 +534,49 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
         # Make request to Kiro API (for both streaming and non-streaming modes)
         # Important: we wait for Kiro response BEFORE returning StreamingResponse,
         # so that 200 OK means Kiro accepted the request and started responding
-        response = await http_client.request_with_retry(
-            "POST",
-            url,
-            kiro_payload,
-            stream=True,
-            retry_rate_limits=False
-        )
-        
+        response = await http_client.request_with_retry("POST", url, kiro_payload, stream=True, retry_rate_limits=False)
+
         if response.status_code != 200:
             try:
                 error_content = await response.aread()
             except Exception:
                 error_content = b"Unknown error"
-            
+
             await http_client.close()
-            error_text = error_content.decode('utf-8', errors='replace')
-            
+            error_text = error_content.decode("utf-8", errors="replace")
+
             # Try to parse JSON response from Kiro to extract error message
             error_message = error_text
             try:
                 error_json = json.loads(error_text)
                 # Enhance Kiro API errors with user-friendly messages
                 from kiro.kiro_errors import enhance_kiro_error
+
                 error_info = enhance_kiro_error(error_json)
                 error_message = error_info.user_message
                 # Log original error for debugging
                 logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
             except (json.JSONDecodeError, KeyError):
                 pass
-            
+
             # Log access log for error (before flush, so it gets into app_logs)
-            logger.warning(
-                f"HTTP {response.status_code} - POST /v1/chat/completions - {error_message[:100]}"
-            )
-            
+            logger.warning(f"HTTP {response.status_code} - POST /v1/chat/completions - {error_message[:100]}")
+
             # Flush debug logs on error ("errors" mode)
             if debug_logger:
                 debug_logger.flush_on_error(response.status_code, error_message)
-            
+
             # Return error in OpenAI API format
             return JSONResponse(
                 status_code=response.status_code,
-                content={
-                    "error": {
-                        "message": error_message,
-                        "type": "kiro_api_error",
-                        "code": response.status_code
-                    }
-                }
+                content={"error": {"message": error_message, "type": "kiro_api_error", "code": response.status_code}},
             )
-        
+
         # Prepare data for fallback token counting
         # Convert Pydantic models to dicts for tokenizer
         messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
         tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
-        
+
         if request_data.stream:
             # Streaming mode with first token retry
             async def stream_wrapper():
@@ -632,7 +588,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                         return await http_client.request_with_retry(
                             "POST", url, kiro_payload, stream=True, retry_rate_limits=False
                         )
-                    
+
                     # Use retry wrapper with initial response
                     async for chunk in stream_with_first_token_retry(
                         make_request=make_retry_request,
@@ -666,22 +622,23 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                     if streaming_error:
                         error_type = type(streaming_error).__name__
                         error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
-                        logger.error(f"HTTP 500 - POST /v1/chat/completions (streaming) - [{error_type}] {error_msg[:100]}")
+                        logger.error(
+                            f"HTTP 500 - POST /v1/chat/completions (streaming) - [{error_type}] {error_msg[:100]}"
+                        )
                     elif client_disconnected:
-                        logger.info(f"HTTP 200 - POST /v1/chat/completions (streaming) - client disconnected")
+                        logger.info("HTTP 200 - POST /v1/chat/completions (streaming) - client disconnected")
                     else:
-                        logger.info(f"HTTP 200 - POST /v1/chat/completions (streaming) - completed")
+                        logger.info("HTTP 200 - POST /v1/chat/completions (streaming) - completed")
                     # Write debug logs AFTER streaming completes
                     if debug_logger:
                         if streaming_error:
                             debug_logger.flush_on_error(500, str(streaming_error))
                         else:
                             debug_logger.discard_buffers()
-            
+
             return StreamingResponse(stream_wrapper(), media_type="text/event-stream")
-        
+
         else:
-            
             # Non-streaming mode - collect entire response
             openai_response = await collect_stream_response(
                 http_client.client,
@@ -694,26 +651,26 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                 include_reasoning=request_data.include_reasoning,
                 parallel_tool_calls=request_data.parallel_tool_calls is not False,
             )
-            
+
             await http_client.close()
-            
+
             # Log access log for non-streaming success
-            logger.info(f"HTTP 200 - POST /v1/chat/completions (non-streaming) - completed")
-            
+            logger.info("HTTP 200 - POST /v1/chat/completions (non-streaming) - completed")
+
             # Write debug logs after non-streaming request completes
             if debug_logger:
                 debug_logger.discard_buffers()
-            
+
             return JSONResponse(content=openai_response)
-    
+
     except HTTPException as e:
         await http_client.close()
-        
+
         # Network errors (502/504 from request_with_retry) = RECOVERABLE
         # In legacy mode, we still log them but re-raise (no failover available)
         if e.status_code in (502, 504):
-            logger.warning(f"Network error (legacy mode, no failover available)")
-        
+            logger.warning("Network error (legacy mode, no failover available)")
+
         # Log access log for HTTP error
         logger.error(f"HTTP {e.status_code} - POST /v1/chat/completions - {e.detail}")
         # Flush debug logs on HTTP error ("errors" mode)

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -10,6 +10,7 @@ Contains all API endpoints:
 
 import json
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -34,11 +35,17 @@ from kiro.streaming_openai import collect_stream_response, stream_with_first_tok
 from kiro.usage_tracking import current_api_key_id
 from kiro.utils import generate_conversation_id
 
+if TYPE_CHECKING:
+    from kiro.debug_logger import DebugLogger
+
 # Import debug_logger
+debug_logger: Optional["DebugLogger"]
 try:
-    from kiro.debug_logger import debug_logger
+    import kiro.debug_logger as debug_logger_module
 except ImportError:
     debug_logger = None
+else:
+    debug_logger = debug_logger_module.debug_logger
 
 
 # --- Security scheme ---
@@ -205,7 +212,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
 
         last_error_message = None
         last_error_status = None
-        tried_accounts = set()  # Track tried accounts in current failover loop
+        tried_accounts: set[str] = set()  # Track tried accounts in current failover loop
 
         for attempt in range(MAX_ATTEMPTS):
             # Get next available account (excluding already tried)
@@ -345,8 +352,10 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
 
                     else:
                         # Non-streaming mode
+                        client = http_client.client
+                        assert client is not None
                         openai_response = await collect_stream_response(
-                            http_client.client,
+                            client,
                             response,
                             request_data.model,
                             model_cache,
@@ -471,6 +480,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
         if len(all_accounts) == 1:
             # Single account - return its original error
             # last_error_status and last_error_message are guaranteed to be set
+            assert last_error_status is not None
             raise HTTPException(status_code=last_error_status, detail=last_error_message)
         else:
             # Multiple accounts - every account was tried and failed
@@ -640,8 +650,10 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
 
         else:
             # Non-streaming mode - collect entire response
+            client = http_client.client
+            assert client is not None
             openai_response = await collect_stream_response(
-                http_client.client,
+                client,
                 response,
                 request_data.model,
                 model_cache,

--- a/kiro/sse_validation.py
+++ b/kiro/sse_validation.py
@@ -42,11 +42,7 @@ class AnthropicSSEValidator:
             self._fail()
         if event_type == "content_block_start":
             index = data.get("index")
-            if (
-                self.active_index is not None
-                or not isinstance(index, int)
-                or index != self.last_index + 1
-            ):
+            if self.active_index is not None or not isinstance(index, int) or index != self.last_index + 1:
                 self._fail()
             assert isinstance(index, int)
             self.active_index = index
@@ -116,15 +112,11 @@ class OpenAIStreamValidator:
             for tool_call in delta.get("tool_calls") or []:
                 index = tool_call.get("index")
                 if not isinstance(index, int):
-                    raise StreamProtocolError(
-                        "Invalid assistant content event order"
-                    )
+                    raise StreamProtocolError("Invalid assistant content event order")
                 self.tool_indices.add(index)
             if choice.get("finish_reason") is not None:
                 if self.terminal_seen:
-                    raise StreamProtocolError(
-                        "Invalid assistant content event order"
-                    )
+                    raise StreamProtocolError("Invalid assistant content event order")
                 self.terminal_seen = True
 
     def finish(self) -> None:

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -42,8 +42,10 @@ from kiro.usage_tracking import record_token_usage
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
     from kiro.cache import ModelInfoCache
+    from kiro.debug_logger import DebugLogger
 
 # Import debug_logger for logging
+debug_logger: Optional["DebugLogger"]
 try:
     from kiro.debug_logger import debug_logger
 except ImportError:

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -14,32 +14,30 @@ Reference: https://docs.anthropic.com/en/api/messages-streaming
 """
 
 import json
-import time
 import uuid
-from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Any
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional
 
 import httpx
 from loguru import logger
 
-from kiro.streaming_core import (
-    parse_kiro_stream,
-    collect_stream_to_result,
-    FirstTokenTimeoutError,
-    KiroEvent,
-    calculate_tokens_from_context_usage,
-    stream_with_first_token_retry,
-)
-from kiro.tokenizer import count_tokens, estimate_request_tokens
-from kiro.usage_tracking import record_token_usage
-from kiro.parsers import parse_bracket_tool_calls, deduplicate_tool_calls
-from kiro.config import FIRST_TOKEN_TIMEOUT, FIRST_TOKEN_MAX_RETRIES
-from kiro.stop_reasons import is_truncated, to_anthropic_stop_reason
+from kiro.config import FIRST_TOKEN_MAX_RETRIES, FIRST_TOKEN_TIMEOUT
+from kiro.parsers import parse_bracket_tool_calls
 from kiro.sse_validation import (
     StreamProtocolError,
     begin_anthropic_stream,
     end_anthropic_stream,
     validate_live_anthropic_event,
 )
+from kiro.stop_reasons import is_truncated, to_anthropic_stop_reason
+from kiro.streaming_core import (
+    FirstTokenTimeoutError,
+    calculate_tokens_from_context_usage,
+    collect_stream_to_result,
+    parse_kiro_stream,
+    stream_with_first_token_retry,
+)
+from kiro.tokenizer import count_tokens, estimate_request_tokens
+from kiro.usage_tracking import record_token_usage
 
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
@@ -60,22 +58,19 @@ def generate_message_id() -> str:
 def format_sse_event(event_type: str, data: Dict[str, Any]) -> str:
     """
     Format data as Anthropic SSE event.
-    
+
     Anthropic SSE format:
     event: {event_type}
     data: {json_data}
-    
+
     Args:
         event_type: Event type (message_start, content_block_delta, etc.)
         data: Event data dictionary
-    
+
     Returns:
         Formatted SSE string
     """
-    formatted = (
-        f"event: {event_type}\n"
-        f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
-    )
+    formatted = f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
     if debug_logger:
         debug_logger.log_modified_chunk(formatted.encode("utf-8"))
     try:
@@ -85,8 +80,6 @@ def format_sse_event(event_type: str, data: Dict[str, Any]) -> str:
             debug_logger.flush_on_error(500, str(exc))
         raise
     return formatted
-
-
 
 
 def _extract_cache_usage_fields(usage: Optional[Dict[str, Any]]) -> Dict[str, int]:
@@ -126,14 +119,14 @@ async def stream_kiro_to_anthropic(
     request_messages: Optional[list] = None,
     request_tools: Optional[list] = None,
     request_system: Optional[Any] = None,
-    conversation_id: Optional[str] = None
+    conversation_id: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generator for converting Kiro stream to Anthropic SSE format.
-    
+
     Parses Kiro AWS SSE stream and converts events to Anthropic format.
     Emits only content blocks produced by the upstream stream.
-    
+
     Args:
         response: HTTP response with data stream
         model: Model name to include in response
@@ -144,10 +137,10 @@ async def stream_kiro_to_anthropic(
         request_tools: Original request tools (for token counting)
         request_system: Original system prompt (for token counting)
         conversation_id: Stable conversation ID for truncation recovery (optional)
-    
+
     Yields:
         Strings in Anthropic SSE format
-    
+
     Raises:
         FirstTokenTimeoutError: If first token not received within timeout
     """
@@ -156,23 +149,23 @@ async def stream_kiro_to_anthropic(
     output_tokens = 0
     full_content = ""
     full_thinking_content = ""
-    
+
     # NOTE: Anthropic streaming spec requires input_tokens in message_start (beginning),
     # but Kiro API provides accurate context_usage at the end of stream.
     # This creates a fundamental limitation: we must use fallback estimation in message_start.
     # Accuracy: ~85-90% (acceptable trade-off for maintaining streaming capability).
     # See: https://docs.anthropic.com/en/api/messages-streaming
-    
+
     # Fallback estimation must cover messages/tools/system to avoid significant undercount
     if request_messages or request_tools or request_system:
         request_token_stats = estimate_request_tokens(
             messages=request_messages or [],
             tools=request_tools,
             system_prompt=request_system,
-            apply_claude_correction=False
+            apply_claude_correction=False,
         )
         input_tokens = request_token_stats["total_tokens"]
-    
+
     # Track content blocks - thinking block is index 0, text block is index 1 (when thinking enabled)
     current_block_index = 0
     thinking_block_started = False
@@ -181,15 +174,14 @@ async def stream_kiro_to_anthropic(
     text_block_index: Optional[int] = None
     pending_content: List[str] = []
     tool_blocks: List[Dict[str, Any]] = []
-    tool_input_buffers: Dict[int, str] = {}  # index -> accumulated JSON
     upstream_stop_reason: Optional[str] = None
-    
+
     # Native reasoning blocks carry their own upstream signature events, so no
     # placeholder signature is generated here.
     # Track context usage for token calculation
     context_usage_percentage: Optional[float] = None
     upstream_cache_usage: Dict[str, int] = {}
-    
+
     # Track truncated tool calls for recovery
     truncated_tools: List[Dict[str, Any]] = []
 
@@ -200,41 +192,40 @@ async def stream_kiro_to_anthropic(
         nonlocal text_block_started
 
         chunks: List[str] = []
-        if (
-            close_thinking
-            and thinking_block_started
-            and thinking_block_index is not None
-        ):
-            chunks.append(format_sse_event("content_block_stop", {
-                "type": "content_block_stop",
-                "index": thinking_block_index
-            }))
+        if close_thinking and thinking_block_started and thinking_block_index is not None:
+            chunks.append(
+                format_sse_event("content_block_stop", {"type": "content_block_stop", "index": thinking_block_index})
+            )
             thinking_block_started = False
             current_block_index += 1
         if pending_content and not text_block_started:
             text_block_index = current_block_index
-            chunks.append(format_sse_event("content_block_start", {
-                "type": "content_block_start",
-                "index": text_block_index,
-                "content_block": {
-                    "type": "text",
-                    "text": ""
-                }
-            }))
+            chunks.append(
+                format_sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": text_block_index,
+                        "content_block": {"type": "text", "text": ""},
+                    },
+                )
+            )
             text_block_started = True
         if pending_content and text_block_index is not None:
             for pending_text in pending_content:
-                chunks.append(format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": text_block_index,
-                    "delta": {
-                        "type": "text_delta",
-                        "text": pending_text
-                    }
-                }))
+                chunks.append(
+                    format_sse_event(
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": text_block_index,
+                            "delta": {"type": "text_delta", "text": pending_text},
+                        },
+                    )
+                )
             pending_content.clear()
         return chunks
-    
+
     message_started = False
     message_start_data = {
         "type": "message_start",
@@ -246,11 +237,8 @@ async def stream_kiro_to_anthropic(
             "model": model,
             "stop_reason": None,
             "stop_sequence": None,
-            "usage": {
-                "input_tokens": input_tokens,
-                "output_tokens": 0
-            }
-        }
+            "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+        },
     }
 
     begin_anthropic_stream()
@@ -259,10 +247,7 @@ async def stream_kiro_to_anthropic(
             if not message_started:
                 yield format_sse_event("message_start", message_start_data)
                 message_started = True
-            if (
-                pending_content
-                and event.type not in {"content", "thinking_signature"}
-            ):
+            if pending_content and event.type not in {"content", "thinking_signature"}:
                 for pending_chunk in flush_pending_content(True):
                     yield pending_chunk
 
@@ -275,27 +260,32 @@ async def stream_kiro_to_anthropic(
                 full_thinking_content += thinking_delta
 
                 if text_block_started and text_block_index is not None:
-                    yield format_sse_event("content_block_stop", {
-                        "type": "content_block_stop",
-                        "index": text_block_index
-                    })
+                    yield format_sse_event(
+                        "content_block_stop", {"type": "content_block_stop", "index": text_block_index}
+                    )
                     text_block_started = False
                     current_block_index += 1
 
                 if not thinking_block_started:
                     thinking_block_index = current_block_index
-                    yield format_sse_event("content_block_start", {
-                        "type": "content_block_start",
-                        "index": thinking_block_index,
-                        "content_block": {"type": "thinking", "thinking": "", "signature": ""},
-                    })
+                    yield format_sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": thinking_block_index,
+                            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+                        },
+                    )
                     thinking_block_started = True
 
-                yield format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": thinking_block_index,
-                    "delta": {"type": "thinking_delta", "thinking": thinking_delta},
-                })
+                yield format_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": thinking_block_index,
+                        "delta": {"type": "thinking_delta", "thinking": thinking_delta},
+                    },
+                )
 
             elif event.type == "thinking_signature":
                 thinking_signature = event.thinking_signature or ""
@@ -303,35 +293,31 @@ async def stream_kiro_to_anthropic(
                     continue
 
                 if text_block_started and text_block_index is not None:
-                    raise StreamProtocolError(
-                        "Invalid assistant content event order"
-                    )
+                    raise StreamProtocolError("Invalid assistant content event order")
 
                 if not thinking_block_started:
                     thinking_block_index = current_block_index
-                    yield format_sse_event("content_block_start", {
-                        "type": "content_block_start",
-                        "index": thinking_block_index,
-                        "content_block": {
-                            "type": "thinking",
-                            "thinking": "",
-                            "signature": ""
-                        }
-                    })
+                    yield format_sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": thinking_block_index,
+                            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+                        },
+                    )
                     thinking_block_started = True
 
-                yield format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": thinking_block_index,
-                    "delta": {
-                        "type": "signature_delta",
-                        "signature": thinking_signature
-                    }
-                })
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": thinking_block_index
-                })
+                yield format_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": thinking_block_index,
+                        "delta": {"type": "signature_delta", "signature": thinking_signature},
+                    },
+                )
+                yield format_sse_event(
+                    "content_block_stop", {"type": "content_block_stop", "index": thinking_block_index}
+                )
                 thinking_block_started = False
                 current_block_index += 1
 
@@ -347,226 +333,226 @@ async def stream_kiro_to_anthropic(
                 if thinking_block_started:
                     pending_content.append(content)
                     continue
-                
+
                 # Start text block if not started
                 if not text_block_started:
                     text_block_index = current_block_index
-                    yield format_sse_event("content_block_start", {
-                        "type": "content_block_start",
-                        "index": text_block_index,
-                        "content_block": {
-                            "type": "text",
-                            "text": ""
-                        }
-                    })
+                    yield format_sse_event(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": text_block_index,
+                            "content_block": {"type": "text", "text": ""},
+                        },
+                    )
                     text_block_started = True
-                
+
                 # Send content delta
                 if content:
-                    yield format_sse_event("content_block_delta", {
-                        "type": "content_block_delta",
-                        "index": text_block_index,
-                        "delta": {
-                            "type": "text_delta",
-                            "text": content
-                        }
-                    })
-            
+                    yield format_sse_event(
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": text_block_index,
+                            "delta": {"type": "text_delta", "text": content},
+                        },
+                    )
+
             elif event.type == "tool_use" and event.tool_use:
                 # Close thinking block if open
                 if thinking_block_started and thinking_block_index is not None:
-                    yield format_sse_event("content_block_stop", {
-                        "type": "content_block_stop",
-                        "index": thinking_block_index
-                    })
+                    yield format_sse_event(
+                        "content_block_stop", {"type": "content_block_stop", "index": thinking_block_index}
+                    )
                     thinking_block_started = False
                     current_block_index += 1
-                
+
                 # Close text block if open
                 if text_block_started and text_block_index is not None:
-                    yield format_sse_event("content_block_stop", {
-                        "type": "content_block_stop",
-                        "index": text_block_index
-                    })
+                    yield format_sse_event(
+                        "content_block_stop", {"type": "content_block_stop", "index": text_block_index}
+                    )
                     text_block_started = False
                     current_block_index += 1
-                
+
                 tool = event.tool_use
                 tool_id = tool.get("id") or f"toolu_{uuid.uuid4().hex[:24]}"
                 tool_name = tool.get("function", {}).get("name", "") or tool.get("name", "")
                 tool_input = tool.get("function", {}).get("arguments", {}) or tool.get("input", {})
-                
+
                 # ==============================================================================
                 # WebSearch Support - Path B: MCP Tool Emulation (Streaming Interception)
                 # ==============================================================================
-                
+
                 # INTERCEPT web_search tool calls (Path B - MCP emulation)
                 if tool_name == "web_search":
                     from kiro.mcp_tools import call_kiro_mcp_api, generate_search_summary
-                    
+
                     logger.info("Intercepted web_search tool call (Path B - MCP emulation)")
-                    
+
                     # Parse tool_input if string
                     if isinstance(tool_input, str):
                         try:
                             tool_input = json.loads(tool_input)
                         except json.JSONDecodeError:
                             tool_input = {}
-                    
+
                     # Extract query
                     query = tool_input.get("query", "")
                     if not query:
                         logger.warning("web_search called without query, skipping MCP call")
                         continue
-                    
+
                     logger.debug(f"WebSearch query (Path B): {query}")
-                    
+
                     # Call MCP API
                     mcp_tool_use_id, results = await call_kiro_mcp_api(query, auth_manager)
-                    
+
                     if results is None:
                         logger.error("MCP API call failed for web_search")
                         # Continue with normal tool_use processing (will show error to user)
                     else:
                         # Emit server_tool_use + web_search_tool_result + text summary
                         # (full SSE sequence as in mcp_tools.py)
-                        
+
                         # Event: content_block_start (server_tool_use)
-                        yield format_sse_event("content_block_start", {
-                            "type": "content_block_start",
-                            "index": current_block_index,
-                            "content_block": {
-                                "id": mcp_tool_use_id,
-                                "type": "server_tool_use",
-                                "name": "web_search",
-                                "input": {}
-                            }
-                        })
-                        
+                        yield format_sse_event(
+                            "content_block_start",
+                            {
+                                "type": "content_block_start",
+                                "index": current_block_index,
+                                "content_block": {
+                                    "id": mcp_tool_use_id,
+                                    "type": "server_tool_use",
+                                    "name": "web_search",
+                                    "input": {},
+                                },
+                            },
+                        )
+
                         # Event: content_block_delta (input_json_delta)
-                        yield format_sse_event("content_block_delta", {
-                            "type": "content_block_delta",
-                            "index": current_block_index,
-                            "delta": {
-                                "type": "input_json_delta",
-                                "partial_json": json.dumps({"query": query})
-                            }
-                        })
-                        
+                        yield format_sse_event(
+                            "content_block_delta",
+                            {
+                                "type": "content_block_delta",
+                                "index": current_block_index,
+                                "delta": {"type": "input_json_delta", "partial_json": json.dumps({"query": query})},
+                            },
+                        )
+
                         # Event: content_block_stop (server_tool_use)
-                        yield format_sse_event("content_block_stop", {
-                            "type": "content_block_stop",
-                            "index": current_block_index
-                        })
+                        yield format_sse_event(
+                            "content_block_stop", {"type": "content_block_stop", "index": current_block_index}
+                        )
                         current_block_index += 1
-                        
+
                         # Event: content_block_start (web_search_tool_result)
                         search_content = []
                         for r in results.get("results", []):
-                            search_content.append({
-                                "type": "web_search_result",
-                                "title": r.get("title", ""),
-                                "url": r.get("url", ""),
-                                "encrypted_content": r.get("snippet", ""),
-                                "page_age": None
-                            })
-                        
-                        yield format_sse_event("content_block_start", {
-                            "type": "content_block_start",
-                            "index": current_block_index,
-                            "content_block": {
-                                "type": "web_search_tool_result",
-                                "tool_use_id": mcp_tool_use_id,
-                                "content": search_content
-                            }
-                        })
-                        
+                            search_content.append(
+                                {
+                                    "type": "web_search_result",
+                                    "title": r.get("title", ""),
+                                    "url": r.get("url", ""),
+                                    "encrypted_content": r.get("snippet", ""),
+                                    "page_age": None,
+                                }
+                            )
+
+                        yield format_sse_event(
+                            "content_block_start",
+                            {
+                                "type": "content_block_start",
+                                "index": current_block_index,
+                                "content_block": {
+                                    "type": "web_search_tool_result",
+                                    "tool_use_id": mcp_tool_use_id,
+                                    "content": search_content,
+                                },
+                            },
+                        )
+
                         # Event: content_block_stop (web_search_tool_result)
-                        yield format_sse_event("content_block_stop", {
-                            "type": "content_block_stop",
-                            "index": current_block_index
-                        })
+                        yield format_sse_event(
+                            "content_block_stop", {"type": "content_block_stop", "index": current_block_index}
+                        )
                         current_block_index += 1
-                        
+
                         # Event: content_block_start (text)
-                        yield format_sse_event("content_block_start", {
-                            "type": "content_block_start",
-                            "index": current_block_index,
-                            "content_block": {"type": "text", "text": ""}
-                        })
-                        
+                        yield format_sse_event(
+                            "content_block_start",
+                            {
+                                "type": "content_block_start",
+                                "index": current_block_index,
+                                "content_block": {"type": "text", "text": ""},
+                            },
+                        )
+
                         # Events: content_block_delta (text_delta) - stream summary
                         summary = generate_search_summary(query, results)
                         chunk_size = 100
                         for i in range(0, len(summary), chunk_size):
-                            chunk = summary[i:i + chunk_size]
-                            yield format_sse_event("content_block_delta", {
-                                "type": "content_block_delta",
-                                "index": current_block_index,
-                                "delta": {"type": "text_delta", "text": chunk}
-                            })
-                        
+                            chunk = summary[i : i + chunk_size]
+                            yield format_sse_event(
+                                "content_block_delta",
+                                {
+                                    "type": "content_block_delta",
+                                    "index": current_block_index,
+                                    "delta": {"type": "text_delta", "text": chunk},
+                                },
+                            )
+
                         # Event: content_block_stop (text)
-                        yield format_sse_event("content_block_stop", {
-                            "type": "content_block_stop",
-                            "index": current_block_index
-                        })
+                        yield format_sse_event(
+                            "content_block_stop", {"type": "content_block_stop", "index": current_block_index}
+                        )
                         current_block_index += 1
-                        
+
                         # Skip normal tool_use processing
                         continue
-                
+
                 # Check if this tool was truncated
-                if tool.get('_truncation_detected'):
-                    truncated_tools.append({
-                        "id": tool_id,
-                        "name": tool_name,
-                        "truncation_info": tool.get('_truncation_info', {})
-                    })
-                
+                if tool.get("_truncation_detected"):
+                    truncated_tools.append(
+                        {"id": tool_id, "name": tool_name, "truncation_info": tool.get("_truncation_info", {})}
+                    )
+
                 # Parse arguments if string
                 if isinstance(tool_input, str):
                     try:
                         tool_input = json.loads(tool_input)
                     except json.JSONDecodeError:
                         tool_input = {}
-                
+
                 # Send tool_use block start
-                yield format_sse_event("content_block_start", {
-                    "type": "content_block_start",
-                    "index": current_block_index,
-                    "content_block": {
-                        "type": "tool_use",
-                        "id": tool_id,
-                        "name": tool_name,
-                        "input": {}
-                    }
-                })
-                
+                yield format_sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": current_block_index,
+                        "content_block": {"type": "tool_use", "id": tool_id, "name": tool_name, "input": {}},
+                    },
+                )
+
                 # Send tool input as delta
                 input_json = json.dumps(tool_input, ensure_ascii=False)
-                yield format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": current_block_index,
-                    "delta": {
-                        "type": "input_json_delta",
-                        "partial_json": input_json
-                    }
-                })
-                
+                yield format_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": current_block_index,
+                        "delta": {"type": "input_json_delta", "partial_json": input_json},
+                    },
+                )
+
                 # Close tool block
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": current_block_index
-                })
-                
-                tool_blocks.append({
-                    "id": tool_id,
-                    "name": tool_name,
-                    "input": tool_input
-                })
+                yield format_sse_event(
+                    "content_block_stop", {"type": "content_block_stop", "index": current_block_index}
+                )
+
+                tool_blocks.append({"id": tool_id, "name": tool_name, "input": tool_input})
                 current_block_index += 1
-            
+
             elif event.type == "context_usage" and event.context_usage_percentage is not None:
                 context_usage_percentage = event.context_usage_percentage
             elif event.type == "usage" and event.usage:
@@ -574,10 +560,10 @@ async def stream_kiro_to_anthropic(
 
             elif event.type == "stop_reason" and event.stop_reason:
                 upstream_stop_reason = event.stop_reason
-        
+
         # Track completion signals for truncation detection
         stream_completed_normally = context_usage_percentage is not None
-        
+
         if not message_started:
             yield format_sse_event("message_start", message_start_data)
             message_started = True
@@ -587,101 +573,84 @@ async def stream_kiro_to_anthropic(
         if bracket_tool_calls:
             # Close thinking block if open
             if thinking_block_started and thinking_block_index is not None:
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": thinking_block_index
-                })
+                yield format_sse_event(
+                    "content_block_stop", {"type": "content_block_stop", "index": thinking_block_index}
+                )
                 thinking_block_started = False
                 current_block_index += 1
-            
+
             # Close text block if open
             if text_block_started and text_block_index is not None:
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": text_block_index
-                })
+                yield format_sse_event("content_block_stop", {"type": "content_block_stop", "index": text_block_index})
                 text_block_started = False
                 current_block_index += 1
-            
+
             for tc in bracket_tool_calls:
                 tool_id = tc.get("id") or f"toolu_{uuid.uuid4().hex[:24]}"
                 tool_name = tc.get("function", {}).get("name", "")
                 tool_input = tc.get("function", {}).get("arguments", {})
-                
+
                 if isinstance(tool_input, str):
                     try:
                         tool_input = json.loads(tool_input)
                     except json.JSONDecodeError:
                         tool_input = {}
-                
-                yield format_sse_event("content_block_start", {
-                    "type": "content_block_start",
-                    "index": current_block_index,
-                    "content_block": {
-                        "type": "tool_use",
-                        "id": tool_id,
-                        "name": tool_name,
-                        "input": {}
-                    }
-                })
-                
+
+                yield format_sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": current_block_index,
+                        "content_block": {"type": "tool_use", "id": tool_id, "name": tool_name, "input": {}},
+                    },
+                )
+
                 input_json = json.dumps(tool_input, ensure_ascii=False)
-                yield format_sse_event("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": current_block_index,
-                    "delta": {
-                        "type": "input_json_delta",
-                        "partial_json": input_json
-                    }
-                })
-                
-                yield format_sse_event("content_block_stop", {
-                    "type": "content_block_stop",
-                    "index": current_block_index
-                })
-                
-                tool_blocks.append({
-                    "id": tool_id,
-                    "name": tool_name,
-                    "input": tool_input
-                })
+                yield format_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": current_block_index,
+                        "delta": {"type": "input_json_delta", "partial_json": input_json},
+                    },
+                )
+
+                yield format_sse_event(
+                    "content_block_stop", {"type": "content_block_stop", "index": current_block_index}
+                )
+
+                tool_blocks.append({"id": tool_id, "name": tool_name, "input": tool_input})
                 current_block_index += 1
-        
+
         if pending_content:
             for pending_chunk in flush_pending_content(True):
                 yield pending_chunk
 
         # Close thinking block if still open
         if thinking_block_started and thinking_block_index is not None:
-            yield format_sse_event("content_block_stop", {
-                "type": "content_block_stop",
-                "index": thinking_block_index
-            })
+            yield format_sse_event("content_block_stop", {"type": "content_block_stop", "index": thinking_block_index})
             current_block_index += 1
-        
+
         # Close text block if still open
         if text_block_started and text_block_index is not None:
-            yield format_sse_event("content_block_stop", {
-                "type": "content_block_stop",
-                "index": text_block_index
-            })
-        
+            yield format_sse_event("content_block_stop", {"type": "content_block_stop", "index": text_block_index})
+
         # Detect content truncation (missing completion signals)
         content_was_truncated = (
-            not stream_completed_normally and
-            len(full_content) > 0 and
-            not tool_blocks  # Don't confuse with tool call truncation
+            not stream_completed_normally
+            and len(full_content) > 0
+            and not tool_blocks  # Don't confuse with tool call truncation
         )
-        
+
         if content_was_truncated:
             logger.error(
                 f"Content truncated by Kiro API: stream ended without completion signals, "
                 f"length={len(full_content)} chars. "
             )
-        
+
         # Calculate output tokens
         output_tokens = count_tokens(full_content + full_thinking_content)
-        
+
         # Calculate total tokens from context usage if available
         if context_usage_percentage is not None:
             prompt_tokens, _, prompt_source, _ = calculate_tokens_from_context_usage(
@@ -691,7 +660,7 @@ async def stream_kiro_to_anthropic(
             # Only override local estimate when upstream context usage is available
             if prompt_source != "unknown":
                 input_tokens = prompt_tokens
-        
+
         # Prefer the reason the upstream actually reported; Anthropic clients
         # use stop_reason to decide whether the turn completed.
         upstream_mapped = to_anthropic_stop_reason(upstream_stop_reason)
@@ -703,27 +672,23 @@ async def stream_kiro_to_anthropic(
             stop_reason = upstream_mapped
         else:
             stop_reason = "end_turn"
-        
+
         # Send message_delta with stop_reason and usage
-        usage_payload = {
-            "output_tokens": output_tokens
-        }
+        usage_payload = {"output_tokens": output_tokens}
         usage_payload.update(upstream_cache_usage)
 
-        yield format_sse_event("message_delta", {
-            "type": "message_delta",
-            "delta": {
-                "stop_reason": stop_reason,
-                "stop_sequence": None
+        yield format_sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": usage_payload,
             },
-            "usage": usage_payload
-        })
-        
+        )
+
         # Send message_stop
-        yield format_sse_event("message_stop", {
-            "type": "message_stop"
-        })
-        
+        yield format_sse_event("message_stop", {"type": "message_stop"})
+
         logger.debug(
             f"[Anthropic Streaming] Completed: "
             f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
@@ -741,15 +706,11 @@ async def stream_kiro_to_anthropic(
         error_type = type(e).__name__
         error_msg = str(e) if str(e) else "(empty message)"
         logger.error(f"Error during Anthropic streaming: [{error_type}] {error_msg}", exc_info=True)
-        
+
         # Send error event
-        yield format_sse_event("error", {
-            "type": "error",
-            "error": {
-                "type": "api_error",
-                "message": f"Internal error: {error_msg}"
-            }
-        })
+        yield format_sse_event(
+            "error", {"type": "error", "error": {"type": "api_error", "message": f"Internal error: {error_msg}"}}
+        )
         raise
     finally:
         end_anthropic_stream()
@@ -766,13 +727,13 @@ async def collect_anthropic_response(
     auth_manager: "KiroAuthManager",
     request_messages: Optional[list] = None,
     request_tools: Optional[list] = None,
-    request_system: Optional[Any] = None
+    request_system: Optional[Any] = None,
 ) -> dict:
     """
     Collect full response from Kiro stream in Anthropic format.
-    
+
     Used for non-streaming mode.
-    
+
     Args:
         response: HTTP response with stream
         model: Model name
@@ -781,12 +742,12 @@ async def collect_anthropic_response(
         request_messages: Original request messages (for token counting)
         request_tools: Original request tools (for token counting)
         request_system: Original system prompt (for token counting)
-    
+
     Returns:
         Dictionary with full response in Anthropic Messages format
     """
     message_id = generate_message_id()
-    
+
     # Non-streaming uses the same full-request estimation as streaming
     input_tokens = 0
     if request_messages or request_tools or request_system:
@@ -794,73 +755,74 @@ async def collect_anthropic_response(
             messages=request_messages or [],
             tools=request_tools,
             system_prompt=request_system,
-            apply_claude_correction=False
+            apply_claude_correction=False,
         )
         input_tokens = request_token_stats["total_tokens"]
-    
+
     # Collect stream result
     result = await collect_stream_to_result(response)
     upstream_cache_usage = _extract_cache_usage_fields(result.usage)
-    
+
     native_blocks = list(result.content_blocks)
     if not native_blocks:
         if result.thinking_content:
-            native_blocks.append({
-                "type": "thinking",
-                "thinking": result.thinking_content,
-                "signature": result.thinking_signature,
-            })
+            native_blocks.append(
+                {
+                    "type": "thinking",
+                    "thinking": result.thinking_content,
+                    "signature": result.thinking_signature,
+                }
+            )
         if result.content:
-            native_blocks.append({
-                "type": "text",
-                "text": result.content,
-            })
-        native_blocks.extend(
-            {"type": "tool_use", "tool": tool_call}
-            for tool_call in result.tool_calls
-        )
+            native_blocks.append(
+                {
+                    "type": "text",
+                    "text": result.content,
+                }
+            )
+        native_blocks.extend({"type": "tool_use", "tool": tool_call} for tool_call in result.tool_calls)
 
     content_blocks = []
     for native_block in native_blocks:
         if native_block["type"] == "thinking":
-            content_blocks.append({
-                "type": "thinking",
-                "thinking": native_block["thinking"],
-                "signature": native_block["signature"],
-            })
+            content_blocks.append(
+                {
+                    "type": "thinking",
+                    "thinking": native_block["thinking"],
+                    "signature": native_block["signature"],
+                }
+            )
             continue
         if native_block["type"] == "text":
-            content_blocks.append({
-                "type": "text",
-                "text": native_block["text"],
-            })
+            content_blocks.append(
+                {
+                    "type": "text",
+                    "text": native_block["text"],
+                }
+            )
             continue
 
         tool_call = native_block["tool"]
         tool_id = tool_call.get("id") or f"toolu_{uuid.uuid4().hex[:24]}"
-        tool_name = (
-            tool_call.get("function", {}).get("name", "")
-            or tool_call.get("name", "")
-        )
-        tool_input = (
-            tool_call.get("function", {}).get("arguments", {})
-            or tool_call.get("input", {})
-        )
+        tool_name = tool_call.get("function", {}).get("name", "") or tool_call.get("name", "")
+        tool_input = tool_call.get("function", {}).get("arguments", {}) or tool_call.get("input", {})
         if isinstance(tool_input, str):
             try:
                 tool_input = json.loads(tool_input)
             except json.JSONDecodeError:
                 raise StreamProtocolError("Malformed upstream tool input")
-        content_blocks.append({
-            "type": "tool_use",
-            "id": tool_id,
-            "name": tool_name,
-            "input": tool_input,
-        })
-    
+        content_blocks.append(
+            {
+                "type": "tool_use",
+                "id": tool_id,
+                "name": tool_name,
+                "input": tool_input,
+            }
+        )
+
     # Calculate output tokens
     output_tokens = count_tokens(result.content + result.thinking_content)
-    
+
     # Calculate from context usage if available
     if result.context_usage_percentage is not None:
         prompt_tokens, _, prompt_source, _ = calculate_tokens_from_context_usage(
@@ -869,21 +831,21 @@ async def collect_anthropic_response(
         # Don't override fallback when context_usage=0% (returns source="unknown")
         if prompt_source != "unknown":
             input_tokens = prompt_tokens
-    
+
     # Detect content truncation (missing completion signals)
     stream_completed_normally = result.context_usage_percentage is not None
     content_was_truncated = (
-        not stream_completed_normally and
-        len(result.content) > 0 and
-        not result.tool_calls  # Don't confuse with tool call truncation
+        not stream_completed_normally
+        and len(result.content) > 0
+        and not result.tool_calls  # Don't confuse with tool call truncation
     )
-    
+
     if content_was_truncated:
         logger.error(
             f"Content truncated by Kiro API (non-streaming): stream ended without completion signals, "
             f"length={len(result.content)} chars. "
         )
-    
+
     # Prefer the reason the upstream actually reported.
     upstream_mapped = to_anthropic_stop_reason(result.stop_reason)
     if content_was_truncated or is_truncated(result.stop_reason):
@@ -894,7 +856,7 @@ async def collect_anthropic_response(
         stop_reason = upstream_mapped
     else:
         stop_reason = "end_turn"
-    
+
     logger.debug(
         f"[Anthropic Non-Streaming] Completed: "
         f"input_tokens={input_tokens}, output_tokens={output_tokens}, "
@@ -902,11 +864,8 @@ async def collect_anthropic_response(
     )
 
     record_token_usage(model, input_tokens, output_tokens)
-    
-    usage_payload: Dict[str, Any] = {
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens
-    }
+
+    usage_payload: Dict[str, Any] = {"input_tokens": input_tokens, "output_tokens": output_tokens}
     usage_payload.update(upstream_cache_usage)
 
     return {
@@ -917,7 +876,7 @@ async def collect_anthropic_response(
         "model": model,
         "stop_reason": stop_reason,
         "stop_sequence": None,
-        "usage": usage_payload
+        "usage": usage_payload,
     }
 
 
@@ -931,17 +890,17 @@ async def stream_with_first_token_retry_anthropic(
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
     request_messages: Optional[list] = None,
     request_tools: Optional[list] = None,
-    request_system: Optional[Any] = None
+    request_system: Optional[Any] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout for Anthropic API.
-    
+
     If model doesn't respond within first_token_timeout seconds,
     request is cancelled and a new one is made. Maximum max_retries attempts.
-    
+
     This is seamless for user - they just see a delay,
     but eventually get a response (or error after all attempts).
-    
+
     Args:
         make_request: Function to create new HTTP request
         model: Model name
@@ -954,33 +913,36 @@ async def stream_with_first_token_retry_anthropic(
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
         request_system: Original system prompt (for fallback token counting)
-    
+
     Yields:
         Strings in Anthropic SSE format
-    
+
     Raises:
         Exception with Anthropic error format after exhausting all attempts
     """
+
     def create_http_error(status_code: int, error_text: str) -> Exception:
         """Create exception for HTTP errors in Anthropic format."""
-        return Exception(json.dumps({
-            "type": "error",
-            "error": {
-                "type": "api_error",
-                "message": f"Upstream API error: {error_text}"
-            }
-        }))
-    
+        return Exception(
+            json.dumps(
+                {"type": "error", "error": {"type": "api_error", "message": f"Upstream API error: {error_text}"}}
+            )
+        )
+
     def create_timeout_error(retries: int, timeout: float) -> Exception:
         """Create exception for timeout errors in Anthropic format."""
-        return Exception(json.dumps({
-            "type": "error",
-            "error": {
-                "type": "timeout_error",
-                "message": f"Model did not respond within {timeout}s after {retries} attempts. Please try again."
-            }
-        }))
-    
+        return Exception(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "timeout_error",
+                        "message": f"Model did not respond within {timeout}s after {retries} attempts. Please try again.",
+                    },
+                }
+            )
+        )
+
     async def stream_processor(response: httpx.Response) -> AsyncGenerator[str, None]:
         """Process response and yield Anthropic SSE chunks."""
         async for chunk in stream_kiro_to_anthropic(
@@ -994,7 +956,7 @@ async def stream_with_first_token_retry_anthropic(
             request_system=request_system,
         ):
             yield chunk
-    
+
     async for chunk in stream_with_first_token_retry(
         make_request=make_request,
         stream_processor=stream_processor,

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -32,8 +32,10 @@ from kiro.parsers import (
 
 if TYPE_CHECKING:
     from kiro.cache import ModelInfoCache
+    from kiro.debug_logger import DebugLogger
 
 # Import debug_logger for logging
+debug_logger: Optional["DebugLogger"]
 try:
     from kiro.debug_logger import debug_logger
 except ImportError:

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -14,20 +14,20 @@ to convert Kiro events to their respective SSE formats.
 
 import asyncio
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Awaitable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional, Tuple
 
 import httpx
 from loguru import logger
 
+from kiro.config import (
+    FIRST_TOKEN_MAX_RETRIES,
+    FIRST_TOKEN_TIMEOUT,
+)
 from kiro.parsers import (
     AwsEventStreamParser,
     MalformedToolInputError,
     deduplicate_tool_calls,
     parse_bracket_tool_calls,
-)
-from kiro.config import (
-    FIRST_TOKEN_TIMEOUT,
-    FIRST_TOKEN_MAX_RETRIES,
 )
 
 if TYPE_CHECKING:
@@ -44,13 +44,14 @@ except ImportError:
 # Data Classes
 # ==================================================================================================
 
+
 @dataclass
 class KiroEvent:
     """
     Unified event from Kiro API stream.
-    
+
     This format is API-agnostic and can be converted to both OpenAI and Anthropic formats.
-    
+
     Attributes:
         type: Event type (content, thinking, tool_use, usage, context_usage, error)
         content: Text content (for content events)
@@ -63,6 +64,7 @@ class KiroEvent:
         is_last_thinking_chunk: Whether this is the last thinking chunk
         stop_reason: Upstream stop reason (for stop_reason events)
     """
+
     type: str
     content: Optional[str] = None
     thinking_content: Optional[str] = None
@@ -79,7 +81,7 @@ class KiroEvent:
 class StreamResult:
     """
     Result of collecting a complete stream response.
-    
+
     Attributes:
         content: Full text content
         thinking_content: Full thinking/reasoning content
@@ -90,6 +92,7 @@ class StreamResult:
         context_usage_percentage: Context usage percentage from Kiro API
         stop_reason: Upstream stop reason, when the stream reported one
     """
+
     content: str = ""
     thinking_content: str = ""
     thinking_signature: str = ""
@@ -102,12 +105,14 @@ class StreamResult:
 
 class FirstTokenTimeoutError(Exception):
     """Exception raised when first token timeout occurs."""
+
     pass
 
 
 # ==================================================================================================
 # Kiro Stream Parsing
 # ==================================================================================================
+
 
 async def parse_kiro_stream(
     response: httpx.Response,
@@ -136,10 +141,12 @@ async def parse_kiro_stream(
             yield event
         if debug_logger:
             for frame in parser.drain_observed_frames():
-                debug_logger.log_parsed_event({
-                    "type": "raw_upstream_frame",
-                    "frame": frame,
-                })
+                debug_logger.log_parsed_event(
+                    {
+                        "type": "raw_upstream_frame",
+                        "frame": frame,
+                    }
+                )
         async for chunk in byte_iterator:
             if debug_logger:
                 debug_logger.log_raw_chunk(chunk)
@@ -149,15 +156,15 @@ async def parse_kiro_stream(
                 yield event
             if debug_logger:
                 for frame in parser.drain_observed_frames():
-                    debug_logger.log_parsed_event({
-                        "type": "raw_upstream_frame",
-                        "frame": frame,
-                    })
+                    debug_logger.log_parsed_event(
+                        {
+                            "type": "raw_upstream_frame",
+                            "frame": frame,
+                        }
+                    )
         for tool_call in parser.get_unemitted_tool_calls():
             if tool_call.get("_parse_error"):
-                raise MalformedToolInputError(
-                    "Malformed upstream tool input"
-                )
+                raise MalformedToolInputError("Malformed upstream tool input")
             event = KiroEvent(type="tool_use", tool_use=tool_call)
             if debug_logger:
                 debug_logger.log_parsed_event(asdict(event))
@@ -171,9 +178,7 @@ async def parse_kiro_stream(
         raise
 
 
-async def _process_chunk(
-    parser: AwsEventStreamParser, chunk: bytes
-) -> AsyncGenerator[KiroEvent, None]:
+async def _process_chunk(parser: AwsEventStreamParser, chunk: bytes) -> AsyncGenerator[KiroEvent, None]:
     """Translate Kiro upstream stream frames without text-level interpretation."""
     for event in parser.feed(chunk):
         if event["type"] == "content":
@@ -199,9 +204,7 @@ async def _process_chunk(
             )
         elif event["type"] == "tool_use":
             if event["data"].get("_parse_error"):
-                raise MalformedToolInputError(
-                    "Malformed upstream tool input"
-                )
+                raise MalformedToolInputError("Malformed upstream tool input")
             yield KiroEvent(type="tool_use", tool_use=event["data"])
 
 
@@ -209,16 +212,17 @@ async def _process_chunk(
 # Full Response Collection
 # ==================================================================================================
 
+
 async def collect_stream_to_result(
     response: httpx.Response,
     first_token_timeout: float = FIRST_TOKEN_TIMEOUT,
 ) -> StreamResult:
     """
     Collects full response from Kiro stream.
-    
+
     This function consumes the entire stream and returns a StreamResult
     with all accumulated data.
-    
+
     Args:
         response: HTTP response with stream
         first_token_timeout: First token wait timeout
@@ -228,35 +232,33 @@ async def collect_stream_to_result(
     """
     result = StreamResult()
     full_content_for_bracket_tools = ""
-    
+
     async for event in parse_kiro_stream(response, first_token_timeout):
         if event.type == "content" and event.content:
             result.content += event.content
             full_content_for_bracket_tools += event.content
-            if (
-                result.content_blocks
-                and result.content_blocks[-1]["type"] == "text"
-            ):
+            if result.content_blocks and result.content_blocks[-1]["type"] == "text":
                 result.content_blocks[-1]["text"] += event.content
             else:
-                result.content_blocks.append({
-                    "type": "text",
-                    "text": event.content,
-                })
+                result.content_blocks.append(
+                    {
+                        "type": "text",
+                        "text": event.content,
+                    }
+                )
         elif event.type == "thinking" and event.thinking_content:
             result.thinking_content += event.thinking_content
             full_content_for_bracket_tools += event.thinking_content
-            if (
-                result.content_blocks
-                and result.content_blocks[-1]["type"] == "thinking"
-            ):
+            if result.content_blocks and result.content_blocks[-1]["type"] == "thinking":
                 result.content_blocks[-1]["thinking"] += event.thinking_content
             else:
-                result.content_blocks.append({
-                    "type": "thinking",
-                    "thinking": event.thinking_content,
-                    "signature": "",
-                })
+                result.content_blocks.append(
+                    {
+                        "type": "thinking",
+                        "thinking": event.thinking_content,
+                        "signature": "",
+                    }
+                )
         elif event.type == "thinking_signature" and event.thinking_signature:
             result.thinking_signature = event.thinking_signature
             for block in reversed(result.content_blocks):
@@ -265,33 +267,33 @@ async def collect_stream_to_result(
                     break
         elif event.type == "tool_use" and event.tool_use:
             result.tool_calls.append(event.tool_use)
-            result.content_blocks.append({
-                "type": "tool_use",
-                "tool": event.tool_use,
-            })
+            result.content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "tool": event.tool_use,
+                }
+            )
         elif event.type == "usage" and event.usage:
             result.usage = event.usage
         elif event.type == "context_usage" and event.context_usage_percentage is not None:
             result.context_usage_percentage = event.context_usage_percentage
         elif event.type == "stop_reason" and event.stop_reason:
             result.stop_reason = event.stop_reason
-    
+
     # Check for bracket-style tool calls in full content
     bracket_tool_calls = parse_bracket_tool_calls(full_content_for_bracket_tools)
     if bracket_tool_calls:
         result.tool_calls = deduplicate_tool_calls(result.tool_calls + bracket_tool_calls)
-        timeline_tool_ids = {
-            block["tool"].get("id")
-            for block in result.content_blocks
-            if block["type"] == "tool_use"
-        }
+        timeline_tool_ids = {block["tool"].get("id") for block in result.content_blocks if block["type"] == "tool_use"}
         for tool_call in bracket_tool_calls:
             if tool_call.get("id") not in timeline_tool_ids:
-                result.content_blocks.append({
-                    "type": "tool_use",
-                    "tool": tool_call,
-                })
-    
+                result.content_blocks.append(
+                    {
+                        "type": "tool_use",
+                        "tool": tool_call,
+                    }
+                )
+
     return result
 
 
@@ -299,21 +301,19 @@ async def collect_stream_to_result(
 # Token Counting Utilities
 # ==================================================================================================
 
+
 def calculate_tokens_from_context_usage(
-    context_usage_percentage: Optional[float],
-    completion_tokens: int,
-    model_cache: "ModelInfoCache",
-    model: str
+    context_usage_percentage: Optional[float], completion_tokens: int, model_cache: "ModelInfoCache", model: str
 ) -> Tuple[int, int, str, str]:
     """
     Calculate token counts from Kiro's context usage percentage.
-    
+
     Args:
         context_usage_percentage: Context usage percentage from Kiro API
         completion_tokens: Number of completion tokens (counted via tiktoken)
         model_cache: Model cache for getting max input tokens
         model: Model name
-    
+
     Returns:
         Tuple of (prompt_tokens, total_tokens, prompt_source, total_source)
     """
@@ -322,7 +322,7 @@ def calculate_tokens_from_context_usage(
         total_tokens = int((context_usage_percentage / 100) * max_input_tokens)
         prompt_tokens = max(0, total_tokens - completion_tokens)
         return prompt_tokens, total_tokens, "subtraction", "API Kiro"
-    
+
     # Fallback: no context usage data
     return 0, completion_tokens, "unknown", "tiktoken"
 
@@ -330,6 +330,7 @@ def calculate_tokens_from_context_usage(
 # ==================================================================================================
 # First Token Retry Logic
 # ==================================================================================================
+
 
 async def stream_with_first_token_retry(
     make_request: Callable[[], Awaitable[httpx.Response]],
@@ -342,13 +343,13 @@ async def stream_with_first_token_retry(
 ) -> AsyncGenerator[str, None]:
     """
     Generic streaming with automatic retry on first token timeout.
-    
+
     If model doesn't respond within first_token_timeout seconds,
     request is cancelled and a new one is made. Maximum max_retries attempts.
-    
+
     This is seamless for user - they just see a delay,
     but eventually get a response (or error after all attempts).
-    
+
     Args:
         make_request: Function to create new HTTP request (returns httpx.Response)
         stream_processor: Function that processes response and yields SSE strings.
@@ -364,13 +365,13 @@ async def stream_with_first_token_retry(
         on_all_retries_failed: Optional callback to create exception when all retries fail.
                               Receives (max_retries, timeout), returns Exception.
                               If None, raises generic Exception.
-    
+
     Yields:
         Strings in SSE format (format depends on stream_processor)
-    
+
     Raises:
         Exception from on_http_error or on_all_retries_failed callbacks
-    
+
     Example:
         >>> async def make_req():
         ...     return await http_client.request_with_retry("POST", url, payload, stream=True)
@@ -382,66 +383,63 @@ async def stream_with_first_token_retry(
         >>> async for chunk in stream_with_first_token_retry(make_req, process, initial_response=response):
         ...     print(chunk)
     """
-    last_error: Optional[Exception] = None
-    
     for attempt in range(max_retries):
         response: Optional[httpx.Response] = None
         try:
             # Make request
             if attempt > 0:
                 logger.warning(f"Retry attempt {attempt + 1}/{max_retries} after first token timeout")
-            
+
             # On first attempt, reuse initial_response if provided
             if attempt == 0 and initial_response is not None:
                 response = initial_response
                 logger.debug("Reusing initial response for first attempt")
             else:
                 response = await make_request()
-            
+
             if response.status_code != 200:
                 # Error from API - close response and raise exception
                 try:
                     error_content = await response.aread()
-                    error_text = error_content.decode('utf-8', errors='replace')
+                    error_text = error_content.decode("utf-8", errors="replace")
                 except Exception:
                     error_text = "Unknown error"
-                
+
                 try:
                     await response.aclose()
                 except Exception:
                     pass
-                
+
                 logger.error(f"Error from Kiro API: {response.status_code} - {error_text}")
-                
+
                 if on_http_error:
                     raise on_http_error(response.status_code, error_text)
                 else:
                     raise Exception(f"Upstream API error ({response.status_code}): {error_text}")
-            
+
             # Try to stream with first token timeout
             async for chunk in stream_processor(response):
                 yield chunk
-            
+
             # Successfully completed - exit
             return
-            
-        except FirstTokenTimeoutError as e:
-            last_error = e
+
+        except FirstTokenTimeoutError:
             logger.warning(
                 f"[FirstTokenTimeout] Attempt {attempt + 1}/{max_retries} failed - "
                 f"model did not respond within {first_token_timeout}s"
             )
-            
+
             # Close current response if open
             if response:
                 try:
                     await response.aclose()
                 except Exception:
                     pass
-            
+
             # Continue to next attempt
             continue
-            
+
         except Exception as e:
             # Other errors - no retry, propagate
             # Use positional argument to avoid loguru interpreting curly braces in error message as format placeholders
@@ -454,17 +452,16 @@ async def stream_with_first_token_retry(
                 except Exception:
                     pass
             raise
-    
+
     # All attempts exhausted - raise error
     logger.error(
         f"[FirstTokenTimeout] All {max_retries} attempts exhausted - "
         f"model never responded within {first_token_timeout}s per attempt"
     )
-    
+
     if on_all_retries_failed:
         raise on_all_retries_failed(max_retries, first_token_timeout)
     else:
         raise Exception(
-            f"Model did not respond within {first_token_timeout}s after {max_retries} attempts. "
-            "Please try again."
+            f"Model did not respond within {first_token_timeout}s after {max_retries} attempts. Please try again."
         )

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -12,36 +12,37 @@ Uses streaming_core.py for parsing Kiro stream into unified KiroEvent objects.
 
 import json
 import time
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Awaitable, Optional
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Optional
 
 import httpx
 from fastapi import HTTPException
 from loguru import logger
 
-from kiro.parsers import parse_bracket_tool_calls, deduplicate_tool_calls
-from kiro.utils import generate_completion_id
 from kiro.config import (
-    FIRST_TOKEN_TIMEOUT,
     FIRST_TOKEN_MAX_RETRIES,
+    FIRST_TOKEN_TIMEOUT,
 )
-from kiro.tokenizer import count_tokens, count_message_tokens, count_tools_tokens
-from kiro.usage_tracking import record_token_usage
-from kiro.stop_reasons import is_truncated, to_openai_finish_reason
+from kiro.parsers import deduplicate_tool_calls, parse_bracket_tool_calls
 from kiro.sse_validation import (
     StreamProtocolError,
     begin_openai_stream,
     end_openai_stream,
     validate_live_openai_payload,
 )
+from kiro.stop_reasons import is_truncated, to_openai_finish_reason
 
 # Import from streaming_core - reuse shared parsing logic
 from kiro.streaming_core import (
-    parse_kiro_stream,
     FirstTokenTimeoutError,
-    KiroEvent,
     calculate_tokens_from_context_usage,
+    parse_kiro_stream,
+)
+from kiro.streaming_core import (
     stream_with_first_token_retry as stream_with_first_token_retry_core,
 )
+from kiro.tokenizer import count_message_tokens, count_tokens, count_tools_tokens
+from kiro.usage_tracking import record_token_usage
+from kiro.utils import generate_completion_id
 
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
@@ -55,7 +56,12 @@ except ImportError:
 
 
 # Re-export FirstTokenTimeoutError for backward compatibility
-__all__ = ['FirstTokenTimeoutError', 'stream_kiro_to_openai', 'stream_with_first_token_retry', 'collect_stream_response']
+__all__ = [
+    "FirstTokenTimeoutError",
+    "stream_kiro_to_openai",
+    "stream_with_first_token_retry",
+    "collect_stream_response",
+]
 
 
 def _openai_sse(payload: dict[str, Any]) -> str:
@@ -99,13 +105,13 @@ async def stream_kiro_to_openai_internal(
 ) -> AsyncGenerator[str, None]:
     """
     Internal generator for converting Kiro stream to OpenAI format.
-    
+
     Parses AWS SSE stream and converts events to OpenAI chat.completion.chunk.
     Supports tool calls and usage calculation.
-    
+
     IMPORTANT: This function raises FirstTokenTimeoutError if first token
     is not received within first_token_timeout seconds.
-    
+
     Args:
         client: HTTP client (for connection management)
         response: HTTP response with data stream
@@ -117,24 +123,24 @@ async def stream_kiro_to_openai_internal(
         request_tools: Original request tools (for fallback token counting)
         conversation_id: Stable conversation ID for truncation recovery (optional)
         conversation_id: Stable conversation ID for truncation recovery (optional)
-    
+
     Yields:
         Strings in SSE format: "data: {...}\\n\\n" or "data: [DONE]\\n\\n"
-    
+
     Raises:
         FirstTokenTimeoutError: If first token not received within timeout
-    
+
     Example:
         >>> async for chunk in stream_kiro_to_openai_internal(client, response, "claude-sonnet-4", cache, auth):
         ...     print(chunk)
         data: {"id":"chatcmpl-...","object":"chat.completion.chunk",...}
-        
+
         data: [DONE]
     """
     completion_id = generate_completion_id()
     created_time = int(time.time())
     first_chunk = False
-    
+
     metering_data = None
     context_usage_percentage = None
     full_content = ""
@@ -142,20 +148,24 @@ async def stream_kiro_to_openai_internal(
     upstream_stop_reason = None
     streaming_error_occurred = False
     tool_calls_from_stream = []
-    
+
     begin_openai_stream()
     try:
-        yield _openai_sse({
-            "id": completion_id,
-            "object": "chat.completion.chunk",
-            "created": created_time,
-            "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {"role": "assistant", "content": ""},
-                "finish_reason": None,
-            }],
-        })
+        yield _openai_sse(
+            {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created_time,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
 
         # Use streaming_core.parse_kiro_stream for unified event parsing
         # This handles AWS SSE parsing, first token timeout, and thinking parser
@@ -163,21 +173,21 @@ async def stream_kiro_to_openai_internal(
             if event.type == "content" and event.content:
                 # Accumulate content for bracket tool call detection
                 full_content += event.content
-                
+
                 # Format as OpenAI chunk
                 delta = {"content": event.content}
                 if first_chunk:
                     delta["role"] = "assistant"
                     first_chunk = False
-                
+
                 openai_chunk = {
                     "id": completion_id,
                     "object": "chat.completion.chunk",
                     "created": created_time,
                     "model": model,
-                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}]
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
                 }
-                
+
                 yield _openai_sse(openai_chunk)
 
             elif event.type == "thinking" and event.thinking_content:
@@ -196,25 +206,25 @@ async def stream_kiro_to_openai_internal(
                     "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
                 }
                 yield _openai_sse(openai_chunk)
-            
+
             elif event.type == "tool_use" and event.tool_use:
                 tool = event.tool_use
-                
+
                 # Extract tool name safely (handle None/missing fields)
                 tool_name = ""
                 if tool:
                     tool_name = (tool.get("function") or {}).get("name", "") or tool.get("name", "")
-                
+
                 # ==============================================================================
                 # WebSearch Support - Path B: MCP Tool Emulation (Streaming Interception)
                 # ==============================================================================
-                
+
                 # INTERCEPT web_search tool calls (Path B - MCP emulation)
                 if tool_name == "web_search":
                     from kiro.mcp_tools import call_kiro_mcp_api, generate_search_summary
-                    
+
                     logger.info("Intercepted web_search tool call (Path B - MCP emulation)")
-                    
+
                     # Parse tool_input
                     tool_input = tool.get("function", {}).get("arguments", {}) or tool.get("input", {})
                     if isinstance(tool_input, str):
@@ -222,7 +232,7 @@ async def stream_kiro_to_openai_internal(
                             tool_input = json.loads(tool_input)
                         except json.JSONDecodeError:
                             tool_input = {}
-                    
+
                     # Extract query
                     query = tool_input.get("query", "")
                     if not query:
@@ -230,84 +240,81 @@ async def stream_kiro_to_openai_internal(
                         # Continue with normal tool_use processing
                     else:
                         logger.debug(f"WebSearch query (Path B): {query}")
-                        
+
                         # Call MCP API
                         mcp_tool_use_id, results = await call_kiro_mcp_api(query, auth_manager)
-                        
+
                         if results is None:
                             logger.error("MCP API call failed for web_search")
                             # Continue with normal tool_use processing (will show error to user)
                         else:
                             # Emit summary as content chunks (OpenAI format)
                             summary = generate_search_summary(query, results)
-                            
+
                             # Send content chunks
                             chunk_size = 100
                             for i in range(0, len(summary), chunk_size):
-                                content_chunk = summary[i:i + chunk_size]
-                                
+                                content_chunk = summary[i : i + chunk_size]
+
                                 delta = {"content": content_chunk}
                                 if first_chunk:
                                     delta["role"] = "assistant"
                                     first_chunk = False
-                                
+
                                 openai_chunk = {
                                     "id": completion_id,
                                     "object": "chat.completion.chunk",
                                     "created": created_time,
                                     "model": model,
-                                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}]
+                                    "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
                                 }
-                                
+
                                 yield _openai_sse(openai_chunk)
-                            
+
                             # Accumulate for token counting
                             full_content += summary
-                            
+
                             # Skip normal tool_use processing
                             continue
-                
+
                 # Collect tool calls from stream (normal tools, not web_search)
                 tool_calls_from_stream.append(event.tool_use)
-            
+
             elif event.type == "usage" and event.usage:
                 metering_data = event.usage
-            
+
             elif event.type == "context_usage" and event.context_usage_percentage is not None:
                 context_usage_percentage = event.context_usage_percentage
 
             elif event.type == "stop_reason" and event.stop_reason:
                 upstream_stop_reason = event.stop_reason
-        
+
         # Track completion signals for truncation detection
         received_usage = metering_data is not None
         received_context_usage = context_usage_percentage is not None
         stream_completed_normally = received_usage or received_context_usage
-        
+
         # Check bracket-style tool calls in full content
         bracket_tool_calls = parse_bracket_tool_calls(full_content)
         all_tool_calls = tool_calls_from_stream + bracket_tool_calls
         all_tool_calls = deduplicate_tool_calls(all_tool_calls)
         if not parallel_tool_calls and len(all_tool_calls) > 1:
-            logger.info(
-                "parallel_tool_calls=false: forwarding the first of "
-                f"{len(all_tool_calls)} calls"
-            )
+            logger.info(f"parallel_tool_calls=false: forwarding the first of {len(all_tool_calls)} calls")
             all_tool_calls = all_tool_calls[:1]
-        
+
         # Detect content truncation (missing completion signals)
         content_was_truncated = (
-            not stream_completed_normally and
-            len(full_content) > 0 and
-            not all_tool_calls  # Don't confuse with tool call truncation
+            not stream_completed_normally
+            and len(full_content) > 0
+            and not all_tool_calls  # Don't confuse with tool call truncation
         )
-        
+
         if content_was_truncated:
             logger.error(
                 f"Content truncated by Kiro API: stream ended without completion signals, "
                 f"length={len(full_content)} chars. "
             )
-        
+
         # Prefer the reason the upstream actually reported; only fall back to
         # local inference when Kiro sent no stop reason for this stream.
         upstream_finish_reason = to_openai_finish_reason(upstream_stop_reason)
@@ -319,16 +326,16 @@ async def stream_kiro_to_openai_internal(
             finish_reason = upstream_finish_reason
         else:
             finish_reason = "stop"
-        
+
         # Count completion_tokens (output) using tiktoken
         completion_tokens = count_tokens(full_content + full_thinking_content)
-        
+
         # Calculate total_tokens based on context_usage_percentage from Kiro API
         # context_usage shows TOTAL percentage of context usage (input + output)
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, model_cache, model
         )
-        
+
         # Fallback: Kiro API didn't return context_usage, use tiktoken
         # Count prompt_tokens from original messages
         # IMPORTANT: Don't apply correction coefficient for prompt_tokens,
@@ -340,11 +347,11 @@ async def stream_kiro_to_openai_internal(
             total_tokens = prompt_tokens + completion_tokens
             prompt_source = "tiktoken"
             total_source = "tiktoken"
-        
+
         # Send tool calls if present
         if all_tool_calls:
             logger.debug(f"Processing {len(all_tool_calls)} tool calls for streaming response")
-            
+
             # Add required index field to each tool_call
             # according to OpenAI API specification for streaming
             indexed_tool_calls = []
@@ -354,33 +361,26 @@ async def stream_kiro_to_openai_internal(
                 # Use "or" for protection against explicit None in values
                 tool_name = func.get("name") or ""
                 tool_args = func.get("arguments") or "{}"
-                
+
                 logger.debug(f"Tool call [{idx}] '{tool_name}': id={tc.get('id')}, args_length={len(tool_args)}")
-                
+
                 indexed_tc = {
                     "index": idx,
                     "id": tc.get("id"),
                     "type": tc.get("type", "function"),
-                    "function": {
-                        "name": tool_name,
-                        "arguments": tool_args
-                    }
+                    "function": {"name": tool_name, "arguments": tool_args},
                 }
                 indexed_tool_calls.append(indexed_tc)
-            
+
             tool_calls_chunk = {
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": created_time,
                 "model": model,
-                "choices": [{
-                    "index": 0,
-                    "delta": {"tool_calls": indexed_tool_calls},
-                    "finish_reason": None
-                }]
+                "choices": [{"index": 0, "delta": {"tool_calls": indexed_tool_calls}, "finish_reason": None}],
             }
             yield _openai_sse(tool_calls_chunk)
-        
+
         # Final chunk with usage
         final_chunk = {
             "id": completion_id,
@@ -392,7 +392,7 @@ async def stream_kiro_to_openai_internal(
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
                 "total_tokens": total_tokens,
-            }
+            },
         }
 
         if metering_data:
@@ -423,10 +423,7 @@ async def stream_kiro_to_openai_internal(
         # Log exception type and message for better diagnostics
         error_type = type(e).__name__
         error_msg = str(e) if str(e) else "(empty message)"
-        logger.error(
-            f"Error during streaming: [{error_type}] {error_msg}",
-            exc_info=True
-        )
+        logger.error(f"Error during streaming: [{error_type}] {error_msg}", exc_info=True)
         # Propagate error up for proper handling in routes_openai.py
         raise
     finally:
@@ -436,7 +433,7 @@ async def stream_kiro_to_openai_internal(
             await response.aclose()
         except Exception as close_error:
             logger.debug(f"Error closing response: {close_error}")
-        
+
         if streaming_error_occurred:
             logger.debug("Streaming completed with error")
         else:
@@ -456,10 +453,10 @@ async def stream_kiro_to_openai(
 ) -> AsyncGenerator[str, None]:
     """
     Generator for converting Kiro stream to OpenAI format.
-    
+
     This is a wrapper over stream_kiro_to_openai_internal that does NOT retry.
     Retry logic is implemented in stream_with_first_token_retry.
-    
+
     Args:
         client: HTTP client (for connection management)
         response: HTTP response with data stream
@@ -468,12 +465,16 @@ async def stream_kiro_to_openai(
         auth_manager: Authentication manager
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Yields:
         Strings in SSE format: "data: {...}\\n\\n" or "data: [DONE]\\n\\n"
     """
     async for chunk in stream_kiro_to_openai_internal(
-        client, response, model, model_cache, auth_manager,
+        client,
+        response,
+        model,
+        model_cache,
+        auth_manager,
         request_messages=request_messages,
         request_tools=request_tools,
         include_reasoning=include_reasoning,
@@ -498,15 +499,15 @@ async def stream_with_first_token_retry(
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout.
-    
+
     If model doesn't respond within first_token_timeout seconds,
     request is cancelled and a new one is made. Maximum max_retries attempts.
-    
+
     This is seamless for user - they just see a delay,
     but eventually get a response (or error after all attempts).
-    
+
     Uses generic stream_with_first_token_retry from streaming_core.py.
-    
+
     Args:
         make_request: Function to create new HTTP request
         client: HTTP client
@@ -519,13 +520,13 @@ async def stream_with_first_token_retry(
         first_token_timeout: First token wait timeout (seconds)
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Yields:
         Strings in SSE format
-    
+
     Raises:
         HTTPException: After exhausting all attempts
-    
+
     Example:
         >>> async def make_req():
         ...     return await http_client.request_with_retry("POST", url, payload, stream=True)
@@ -535,20 +536,18 @@ async def stream_with_first_token_retry(
         ... ):
         ...     print(chunk)
     """
+
     def create_http_error(status_code: int, error_text: str) -> HTTPException:
         """Create HTTPException for HTTP errors."""
-        return HTTPException(
-            status_code=status_code,
-            detail=f"Upstream API error: {error_text}"
-        )
-    
+        return HTTPException(status_code=status_code, detail=f"Upstream API error: {error_text}")
+
     def create_timeout_error(retries: int, timeout: float) -> HTTPException:
         """Create HTTPException for timeout errors."""
         return HTTPException(
             status_code=504,
-            detail=f"Model did not respond within {timeout}s after {retries} attempts. Please try again."
+            detail=f"Model did not respond within {timeout}s after {retries} attempts. Please try again.",
         )
-    
+
     async def stream_processor(response: httpx.Response) -> AsyncGenerator[str, None]:
         """Process response and yield OpenAI SSE chunks."""
         async for chunk in stream_kiro_to_openai_internal(
@@ -564,7 +563,7 @@ async def stream_with_first_token_retry(
             parallel_tool_calls=parallel_tool_calls,
         ):
             yield chunk
-    
+
     async for chunk in stream_with_first_token_retry_core(
         make_request=make_request,
         stream_processor=stream_processor,
@@ -590,10 +589,10 @@ async def collect_stream_response(
 ) -> dict:
     """
     Collect full response from streaming stream.
-    
+
     Used for non-streaming mode - collects all chunks
     and forms a single response.
-    
+
     Args:
         client: HTTP client
         response: HTTP response with stream
@@ -602,7 +601,7 @@ async def collect_stream_response(
         auth_manager: Authentication manager
         request_messages: Original request messages (for fallback token counting)
         request_tools: Original request tools (for fallback token counting)
-    
+
     Returns:
         Dictionary with full response in OpenAI chat.completion format
     """
@@ -612,7 +611,7 @@ async def collect_stream_response(
     tool_calls = []
     finish_reason = "stop"  # Default fallback
     completion_id = generate_completion_id()
-    
+
     async for chunk_str in stream_kiro_to_openai(
         client,
         response,
@@ -626,14 +625,14 @@ async def collect_stream_response(
     ):
         if not chunk_str.startswith("data:"):
             continue
-        
-        data_str = chunk_str[len("data:"):].strip()
+
+        data_str = chunk_str[len("data:") :].strip()
         if not data_str or data_str == "[DONE]":
             continue
-        
+
         try:
             chunk_data = json.loads(data_str)
-            
+
             # Extract data from chunk
             delta = chunk_data.get("choices", [{}])[0].get("delta", {})
             if "content" in delta:
@@ -642,19 +641,19 @@ async def collect_stream_response(
                 full_reasoning_content += delta["reasoning"]
             if "tool_calls" in delta:
                 tool_calls.extend(delta["tool_calls"])
-            
+
             # Extract finish_reason from chunk (streaming already calculated it correctly)
             finish_reason_from_chunk = chunk_data.get("choices", [{}])[0].get("finish_reason")
             if finish_reason_from_chunk:
                 finish_reason = finish_reason_from_chunk
-            
+
             # Save usage from last chunk
             if "usage" in chunk_data:
                 final_usage = chunk_data["usage"]
-                
+
         except (json.JSONDecodeError, IndexError):
             continue
-    
+
     # Form final response
     message = {"role": "assistant", "content": full_content}
     if full_reasoning_content:
@@ -669,28 +668,21 @@ async def collect_stream_response(
             cleaned_tc = {
                 "id": tc.get("id"),
                 "type": tc.get("type", "function"),
-                "function": {
-                    "name": func.get("name", ""),
-                    "arguments": func.get("arguments", "{}")
-                }
+                "function": {"name": func.get("name", ""), "arguments": func.get("arguments", "{}")},
             }
             cleaned_tool_calls.append(cleaned_tc)
         message["tool_calls"] = cleaned_tool_calls
-    
+
     # Form usage for response
     usage = final_usage or {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-    
+
     # Log token info for debugging (non-streaming uses same logs from streaming)
-    
+
     return {
         "id": completion_id,
         "object": "chat.completion",
         "created": int(time.time()),
         "model": model,
-        "choices": [{
-            "index": 0,
-            "message": message,
-            "finish_reason": finish_reason
-        }],
-        "usage": usage
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": usage,
     }

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -47,8 +47,10 @@ from kiro.utils import generate_completion_id
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
     from kiro.cache import ModelInfoCache
+    from kiro.debug_logger import DebugLogger
 
 # Import debug_logger for logging
+debug_logger: Optional["DebugLogger"]
 try:
     from kiro.debug_logger import debug_logger
 except ImportError:
@@ -382,7 +384,7 @@ async def stream_kiro_to_openai_internal(
             yield _openai_sse(tool_calls_chunk)
 
         # Final chunk with usage
-        final_chunk = {
+        final_chunk: dict[str, Any] = {
             "id": completion_id,
             "object": "chat.completion.chunk",
             "created": created_time,
@@ -655,7 +657,7 @@ async def collect_stream_response(
             continue
 
     # Form final response
-    message = {"role": "assistant", "content": full_content}
+    message: dict[str, Any] = {"role": "assistant", "content": full_content}
     if full_reasoning_content:
         message["reasoning"] = full_reasoning_content
     if tool_calls:

--- a/kiro/tokenizer.py
+++ b/kiro/tokenizer.py
@@ -15,7 +15,8 @@ more than GPT-4 (cl100k_base). This is due to differences in BPE vocabularies.
 """
 
 import json
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
 from loguru import logger
 
 # Lazy loading of tiktoken to speed up import
@@ -30,10 +31,10 @@ CLAUDE_CORRECTION_FACTOR = 1.15
 def _get_encoding():
     """
     Lazy initialization of tokenizer.
-    
+
     Uses cl100k_base - encoding for GPT-4/ChatGPT,
     which is close enough to Claude tokenization.
-    
+
     Returns:
         tiktoken.Encoding or None if tiktoken is unavailable
     """
@@ -41,6 +42,7 @@ def _get_encoding():
     if _encoding is None:
         try:
             import tiktoken
+
             _encoding = tiktoken.get_encoding("cl100k_base")
             logger.debug("[Tokenizer] Initialized tiktoken with cl100k_base encoding")
         except ImportError:
@@ -59,17 +61,17 @@ def _get_encoding():
 def count_tokens(text: str, apply_claude_correction: bool = True) -> int:
     """
     Counts the number of tokens in text.
-    
+
     Args:
         text: Text to count tokens for
         apply_claude_correction: Apply correction coefficient for Claude (default True)
-    
+
     Returns:
         Number of tokens (approximate, with Claude correction)
     """
     if not text:
         return 0
-    
+
     encoding = _get_encoding()
     if encoding:
         try:
@@ -79,7 +81,7 @@ def count_tokens(text: str, apply_claude_correction: bool = True) -> int:
             return base_tokens
         except Exception as e:
             logger.warning(f"[Tokenizer] Error encoding text: {e}")
-    
+
     # Fallback: rough estimate ~4 characters per token for English,
     # ~2-3 characters for other languages (taking average ~3.5)
     # For Claude we add correction
@@ -92,32 +94,32 @@ def count_tokens(text: str, apply_claude_correction: bool = True) -> int:
 def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction: bool = True) -> int:
     """
     Counts tokens in a list of chat messages.
-    
+
     Accounts for OpenAI/Claude message structure:
     - role: ~1 token
     - content: text tokens
     - Service tokens between messages: ~3-4 tokens
-    
+
     Args:
         messages: List of messages in OpenAI format
         apply_claude_correction: Apply correction coefficient for Claude
-    
+
     Returns:
         Approximate number of tokens (with Claude correction)
     """
     if not messages:
         return 0
-    
+
     total_tokens = 0
-    
+
     for message in messages:
         # Base tokens per message (role, delimiters)
         total_tokens += 4  # ~4 tokens for service information
-        
+
         # Role tokens (without correction, these are short strings)
         role = message.get("role", "")
         total_tokens += count_tokens(role, apply_claude_correction=False)
-        
+
         # Content tokens
         content = message.get("content")
         if content:
@@ -152,8 +154,7 @@ def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction
                                         result_type = result_block.get("type")
                                         if result_type == "text":
                                             total_tokens += count_tokens(
-                                                result_block.get("text", ""),
-                                                apply_claude_correction=False
+                                                result_block.get("text", ""), apply_claude_correction=False
                                             )
                                         elif result_type in {"image_url", "image"}:
                                             total_tokens += 100
@@ -164,12 +165,11 @@ def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction
                         else:
                             # Unknown block fallback: estimate via JSON to avoid undercount
                             total_tokens += count_tokens(
-                                json.dumps(item, ensure_ascii=False),
-                                apply_claude_correction=False
+                                json.dumps(item, ensure_ascii=False), apply_claude_correction=False
                             )
                     else:
                         total_tokens += count_tokens(str(item), apply_claude_correction=False)
-        
+
         # tool_calls tokens (if present)
         tool_calls = message.get("tool_calls")
         if tool_calls:
@@ -178,14 +178,14 @@ def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction
                 func = tc.get("function", {})
                 total_tokens += count_tokens(func.get("name", ""), apply_claude_correction=False)
                 total_tokens += count_tokens(func.get("arguments", ""), apply_claude_correction=False)
-        
+
         # tool_call_id tokens (for tool responses)
         if message.get("tool_call_id"):
             total_tokens += count_tokens(message["tool_call_id"], apply_claude_correction=False)
-    
+
     # Final service tokens
     total_tokens += 3
-    
+
     # Apply correction to total count
     if apply_claude_correction:
         return int(total_tokens * CLAUDE_CORRECTION_FACTOR)
@@ -195,19 +195,19 @@ def count_message_tokens(messages: List[Dict[str, Any]], apply_claude_correction
 def count_tools_tokens(tools: Optional[List[Dict[str, Any]]], apply_claude_correction: bool = True) -> int:
     """
     Counts tokens in tool definitions.
-    
+
     Args:
         tools: List of tools in OpenAI format
         apply_claude_correction: Apply correction coefficient for Claude
-    
+
     Returns:
         Approximate number of tokens (with Claude correction)
     """
     if not tools:
         return 0
-    
+
     total_tokens = 0
-    
+
     for tool in tools:
         total_tokens += 4  # Service tokens
 
@@ -228,7 +228,7 @@ def count_tools_tokens(tools: Optional[List[Dict[str, Any]]], apply_claude_corre
         if params is not None:
             params_str = json.dumps(params, ensure_ascii=False)
             total_tokens += count_tokens(params_str, apply_claude_correction=False)
-    
+
     # Apply correction to total count
     if apply_claude_correction:
         return int(total_tokens * CLAUDE_CORRECTION_FACTOR)
@@ -262,8 +262,7 @@ def count_system_tokens(system_prompt: Optional[Any], apply_claude_correction: b
                 total_tokens += count_tokens(block.get("text", ""), apply_claude_correction=False)
                 if block.get("cache_control") is not None:
                     total_tokens += count_tokens(
-                        json.dumps(block.get("cache_control"), ensure_ascii=False),
-                        apply_claude_correction=False
+                        json.dumps(block.get("cache_control"), ensure_ascii=False), apply_claude_correction=False
                     )
             else:
                 total_tokens += count_tokens(str(block), apply_claude_correction=False)
@@ -279,17 +278,17 @@ def estimate_request_tokens(
     messages: List[Dict[str, Any]],
     tools: Optional[List[Dict[str, Any]]] = None,
     system_prompt: Optional[Any] = None,
-    apply_claude_correction: bool = True
+    apply_claude_correction: bool = True,
 ) -> Dict[str, int]:
     """
     Estimates total number of tokens in request.
-    
+
     Args:
         messages: List of messages
         tools: List of tools (optional)
         system_prompt: System prompt (optional, string or Anthropic content blocks)
         apply_claude_correction: Apply correction coefficient for Claude
-    
+
     Returns:
         Dictionary with token breakdown:
         - messages_tokens: message tokens
@@ -300,10 +299,10 @@ def estimate_request_tokens(
     messages_tokens = count_message_tokens(messages, apply_claude_correction=apply_claude_correction)
     tools_tokens = count_tools_tokens(tools, apply_claude_correction=apply_claude_correction)
     system_tokens = count_system_tokens(system_prompt, apply_claude_correction=apply_claude_correction)
-    
+
     return {
         "messages_tokens": messages_tokens,
         "tools_tokens": tools_tokens,
         "system_tokens": system_tokens,
-        "total_tokens": messages_tokens + tools_tokens + system_tokens
+        "total_tokens": messages_tokens + tools_tokens + system_tokens,
     }

--- a/kiro/usage.py
+++ b/kiro/usage.py
@@ -24,6 +24,7 @@ def _usage_region(account: Account) -> str:
     The profile ARN is authoritative. Otherwise derive the region from the
     resolved API host, which already accounts for per-account overrides.
     """
+    assert account.auth_manager is not None
     profile_arn = account.auth_manager.profile_arn or ""
     parts = profile_arn.split(":")
     if len(parts) >= 4 and parts[2] == "codewhisperer":

--- a/kiro/usage_tracking.py
+++ b/kiro/usage_tracking.py
@@ -45,9 +45,6 @@ def record_token_usage(model: str, prompt_tokens: int, completion_tokens: int) -
 
 def drain_pending_usage() -> List[Tuple[str, str, int, int, int]]:
     with _lock:
-        drained = [
-            (key_id, model, counts[0], counts[1], counts[2])
-            for (key_id, model), counts in _pending.items()
-        ]
+        drained = [(key_id, model, counts[0], counts[1], counts[2]) for (key_id, model), counts in _pending.items()]
         _pending.clear()
     return drained

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -9,7 +9,7 @@ and other common utilities.
 import hashlib
 import json
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from loguru import logger
 
@@ -81,7 +81,7 @@ def generate_completion_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex}"
 
 
-def generate_conversation_id(messages: List[Dict[str, Any]] = None) -> str:
+def generate_conversation_id(messages: Optional[List[Dict[str, Any]]] = None) -> str:
     """
     Generates a stable conversation ID based on message history.
 

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -9,7 +9,7 @@ and other common utilities.
 import hashlib
 import json
 import uuid
-from typing import TYPE_CHECKING, List, Dict, Any
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from loguru import logger
 
@@ -20,20 +20,20 @@ if TYPE_CHECKING:
 def get_machine_fingerprint() -> str:
     """
     Generates a unique machine fingerprint based on hostname and username.
-    
+
     Used for User-Agent formation to identify a specific gateway installation.
-    
+
     Returns:
         SHA256 hash of the string "{hostname}-{username}-kiro-gateway"
     """
     try:
-        import socket
         import getpass
-        
+        import socket
+
         hostname = socket.gethostname()
         username = getpass.getuser()
         unique_string = f"{hostname}-{username}-kiro-gateway"
-        
+
         return hashlib.sha256(unique_string.encode()).hexdigest()
     except Exception as e:
         logger.warning(f"Failed to get machine fingerprint: {e}")
@@ -43,21 +43,21 @@ def get_machine_fingerprint() -> str:
 def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
     """
     Builds headers for Kiro API requests.
-    
+
     Includes all necessary headers for authentication and identification:
     - Authorization with Bearer token
     - User-Agent with fingerprint
     - AWS CodeWhisperer specific headers
-    
+
     Args:
         auth_manager: Authentication manager for obtaining fingerprint
         token: Access token for authorization
-    
+
     Returns:
         Dictionary with headers for HTTP request
     """
     fingerprint = auth_manager.fingerprint
-    
+
     return {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/x-amz-json-1.0",
@@ -74,7 +74,7 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
 def generate_completion_id() -> str:
     """
     Generates a unique ID for chat completion.
-    
+
     Returns:
         ID in format "chatcmpl-{uuid_hex}"
     """
@@ -84,18 +84,18 @@ def generate_completion_id() -> str:
 def generate_conversation_id(messages: List[Dict[str, Any]] = None) -> str:
     """
     Generates a stable conversation ID based on message history.
-    
+
     For truncation recovery, we need a stable ID that persists across requests
     in the same conversation. This is generated from a hash of key messages.
-    
+
     If no messages provided, falls back to random UUID (for backward compatibility).
-    
+
     Args:
         messages: List of messages in the conversation (optional)
-    
+
     Returns:
         Stable conversation ID (16-char hex) or random UUID
-    
+
     Example:
         >>> messages = [
         ...     {"role": "user", "content": "Hello"},
@@ -107,7 +107,7 @@ def generate_conversation_id(messages: List[Dict[str, Any]] = None) -> str:
     if not messages:
         # Fallback to random UUID for backward compatibility
         return str(uuid.uuid4())
-    
+
     # Use first 3 messages + last message for stability
     # This ensures the ID stays the same as conversation grows,
     # but changes if the conversation history is different
@@ -115,14 +115,14 @@ def generate_conversation_id(messages: List[Dict[str, Any]] = None) -> str:
         key_messages = messages
     else:
         key_messages = messages[:3] + [messages[-1]]
-    
+
     # Extract role and first 100 chars of content for hashing
     # This makes the hash stable even if content has minor formatting differences
     simplified_messages = []
     for msg in key_messages:
         role = msg.get("role", "unknown")
         content = msg.get("content", "")
-        
+
         # Handle different content formats (string, list, dict)
         if isinstance(content, str):
             content_str = content[:100]
@@ -131,16 +131,13 @@ def generate_conversation_id(messages: List[Dict[str, Any]] = None) -> str:
             content_str = json.dumps(content, sort_keys=True)[:100]
         else:
             content_str = str(content)[:100]
-        
-        simplified_messages.append({
-            "role": role,
-            "content": content_str
-        })
-    
+
+        simplified_messages.append({"role": role, "content": content_str})
+
     # Generate stable hash
     content_json = json.dumps(simplified_messages, sort_keys=True)
     hash_digest = hashlib.sha256(content_json.encode()).hexdigest()
-    
+
     # Return first 16 chars for readability (still 64 bits of entropy)
     return hash_digest[:16]
 
@@ -148,7 +145,7 @@ def generate_conversation_id(messages: List[Dict[str, Any]] = None) -> str:
 def generate_tool_call_id() -> str:
     """
     Generates a unique ID for tool call.
-    
+
     Returns:
         ID in format "call_{uuid_hex[:8]}"
     """

--- a/main.py
+++ b/main.py
@@ -123,15 +123,20 @@ class InterceptHandler(logging.Handler):
             return
 
         # Get the corresponding loguru level
+        level: str | int
         try:
             level = logger.level(record.levelname).name
         except ValueError:
             level = record.levelno
 
         # Find the caller frame for correct source display
-        frame, depth = logging.currentframe(), 2
+        frame = logging.currentframe()
+        assert frame is not None
+        depth = 2
         while frame.f_code.co_filename == logging.__file__:
-            frame = frame.f_back
+            parent_frame = frame.f_back
+            assert parent_frame is not None
+            frame = parent_frame
             depth += 1
 
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
@@ -580,7 +585,10 @@ app.add_middleware(DebugLoggerMiddleware)
 
 
 # --- Validation Error Handler Registration ---
-app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(
+    RequestValidationError,
+    validation_exception_handler,  # type: ignore[arg-type]  # Starlette types handlers invariantly as Exception.
+)
 
 
 # --- Route Registration ---

--- a/main.py
+++ b/main.py
@@ -7,14 +7,14 @@ Application entry point. Creates FastAPI app and connects routes.
 Usage:
     # Using default settings (host: 0.0.0.0, port: 8000)
     python main.py
-    
+
     # With CLI arguments (highest priority)
     python main.py --port 9000
     python main.py --host 127.0.0.1 --port 9000
-    
+
     # With environment variables (medium priority)
     SERVER_PORT=9000 python main.py
-    
+
     # Using uvicorn directly (uvicorn handles its own CLI args)
     uvicorn main:app --host 0.0.0.0 --port 8000
 
@@ -25,66 +25,57 @@ import argparse
 import asyncio
 import json
 import logging
-import sys
 import os
+import sys
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 import httpx
 from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
+from kiro.account_manager import AccountManager
 from kiro.config import (
-    APP_TITLE,
-    APP_DESCRIPTION,
-    APP_VERSION,
-    REFRESH_TOKEN,
-    PROFILE_ARN,
-    REGION,
-    KIRO_CREDS_FILE,
-    KIRO_CLI_DB_FILE,
-    PROXY_API_KEY,
-    LOG_LEVEL,
-    SERVER_HOST,
-    SERVER_PORT,
-    DEFAULT_SERVER_HOST,
-    DEFAULT_SERVER_PORT,
-    STREAMING_READ_TIMEOUT,
-    HIDDEN_MODELS,
-    MODEL_ALIASES,
-    HIDDEN_FROM_LIST,
-    FALLBACK_MODELS,
-    VPN_PROXY_URL,
     ACCOUNT_SYSTEM,
     ACCOUNTS_CONFIG_FILE,
     ACCOUNTS_STATE_FILE,
-    _warn_timeout_configuration,
+    APP_DESCRIPTION,
+    APP_TITLE,
+    APP_VERSION,
+    DEFAULT_SERVER_HOST,
+    DEFAULT_SERVER_PORT,
+    KIRO_CLI_DB_FILE,
+    KIRO_CREDS_FILE,
+    LOG_LEVEL,
+    REFRESH_TOKEN,
+    SERVER_HOST,
+    SERVER_PORT,
+    STREAMING_READ_TIMEOUT,
     USAGE_REFRESH_INTERVAL_SECONDS,
+    VPN_PROXY_URL,
+    _warn_timeout_configuration,
 )
-from kiro.auth import KiroAuthManager
-from kiro.cache import ModelInfoCache
-from kiro.model_resolver import ModelResolver
-from kiro.account_manager import AccountManager
-from kiro.routes_openai import router as openai_router
-from kiro.routes_anthropic import router as anthropic_router
-from kiro.exceptions import validation_exception_handler
-from kiro.debug_middleware import DebugLoggerMiddleware
 from kiro.dashboard import (
-    router as dashboard_router,
+    flush_key_model_usage,
     initialize_dashboard_store,
-    record_request,
-    prune_request_logs,
-    record_rate_observations,
     load_rate_observations,
     prune_rate_observations,
-    flush_key_model_usage,
+    prune_request_logs,
+    record_rate_observations,
+    record_request,
     refresh_all_account_usage,
 )
-
+from kiro.dashboard import (
+    router as dashboard_router,
+)
+from kiro.debug_middleware import DebugLoggerMiddleware
+from kiro.exceptions import validation_exception_handler
+from kiro.routes_anthropic import router as anthropic_router
+from kiro.routes_openai import router as openai_router
 
 # --- Loguru Configuration ---
 logger.remove()
@@ -92,28 +83,28 @@ logger.add(
     sys.stderr,
     level=LOG_LEVEL,
     colorize=True,
-    format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+    format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
 )
 
 
 class InterceptHandler(logging.Handler):
     """
     Intercepts logs from standard logging and redirects them to loguru.
-    
+
     This allows capturing logs from uvicorn, FastAPI and other libraries
     that use standard logging instead of loguru.
-    
+
     Also filters out noisy shutdown-related exceptions (CancelledError, KeyboardInterrupt)
     that are normal during Ctrl+C but uvicorn logs as ERROR.
     """
-    
+
     # Exceptions that are normal during shutdown and should not be logged as errors
     SHUTDOWN_EXCEPTIONS = (
         "CancelledError",
         "KeyboardInterrupt",
         "asyncio.exceptions.CancelledError",
     )
-    
+
     def emit(self, record: logging.LogRecord) -> None:
         # Filter out shutdown-related exceptions that uvicorn logs as ERROR
         # These are normal during Ctrl+C and don't need to spam the console
@@ -125,31 +116,31 @@ class InterceptHandler(logging.Handler):
                     # Suppress the full traceback, just log a simple message
                     logger.info("Server shutdown in progress...")
                     return
-        
+
         # Also filter by message content for cases where exc_info is not set
         msg = record.getMessage()
         if any(exc in msg for exc in self.SHUTDOWN_EXCEPTIONS):
             return
-        
+
         # Get the corresponding loguru level
         try:
             level = logger.level(record.levelname).name
         except ValueError:
             level = record.levelno
-        
+
         # Find the caller frame for correct source display
         frame, depth = logging.currentframe(), 2
         while frame.f_code.co_filename == logging.__file__:
             frame = frame.f_back
             depth += 1
-        
+
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
 def setup_logging_intercept():
     """
     Configures log interception from standard logging to loguru.
-    
+
     Intercepts logs from:
     - uvicorn (access logs, error logs)
     - uvicorn.error
@@ -163,7 +154,7 @@ def setup_logging_intercept():
         "uvicorn.access",
         "fastapi",
     ]
-    
+
     for logger_name in loggers_to_intercept:
         logging_logger = logging.getLogger(logger_name)
         logging_logger.handlers = [InterceptHandler()]
@@ -183,12 +174,12 @@ setup_logging_intercept()
 if VPN_PROXY_URL:
     # Normalize URL - add http:// if no scheme specified
     proxy_url_with_scheme = VPN_PROXY_URL if "://" in VPN_PROXY_URL else f"http://{VPN_PROXY_URL}"
-    
+
     # Set environment variables for httpx to pick up automatically
-    os.environ['HTTP_PROXY'] = proxy_url_with_scheme
-    os.environ['HTTPS_PROXY'] = proxy_url_with_scheme
-    os.environ['ALL_PROXY'] = proxy_url_with_scheme
-    
+    os.environ["HTTP_PROXY"] = proxy_url_with_scheme
+    os.environ["HTTPS_PROXY"] = proxy_url_with_scheme
+    os.environ["ALL_PROXY"] = proxy_url_with_scheme
+
     # Exclude localhost from proxy to avoid routing local requests through it
     no_proxy_hosts = os.environ.get("NO_PROXY", "")
     local_hosts = "127.0.0.1,localhost"
@@ -196,7 +187,7 @@ if VPN_PROXY_URL:
         os.environ["NO_PROXY"] = f"{no_proxy_hosts},{local_hosts}"
     else:
         os.environ["NO_PROXY"] = local_hosts
-    
+
     logger.info(f"Proxy configured: {proxy_url_with_scheme}")
     logger.debug(f"NO_PROXY: {os.environ['NO_PROXY']}")
 
@@ -205,52 +196,53 @@ if VPN_PROXY_URL:
 def validate_configuration() -> None:
     """
     Validates that required configuration is present.
-    
+
     Priority:
     1. credentials.json (Account System) - if exists, skip legacy validation
     2. Legacy .env variables (REFRESH_TOKEN, KIRO_CREDS_FILE, KIRO_CLI_DB_FILE)
-    
+
     Checks:
     - Either credentials.json exists OR legacy variables are configured
     - Supports both .env file (local) and environment variables (Docker)
-    
+
     Raises:
         SystemExit: If critical configuration is missing
     """
     # Priority 1: Check if credentials.json exists (Account System)
     # If it exists, legacy .env validation is skipped
     from kiro.config import ACCOUNTS_CONFIG_FILE
+
     creds_json_path = Path(ACCOUNTS_CONFIG_FILE)
-    
+
     if creds_json_path.exists():
         logger.debug(f"Found {ACCOUNTS_CONFIG_FILE}, skipping legacy .env validation")
         return
-    
+
     # Priority 2: credentials.json doesn't exist - validate legacy .env variables
     errors = []
-    
+
     # Check if .env file exists (optional - can use environment variables)
     env_file = Path(".env")
-    
+
     # Check for credentials (from .env or environment variables)
     has_refresh_token = bool(REFRESH_TOKEN)
     has_creds_file = bool(KIRO_CREDS_FILE)
     has_cli_db = bool(KIRO_CLI_DB_FILE)
-    
+
     # Check if creds file actually exists
     if KIRO_CREDS_FILE:
         creds_path = Path(KIRO_CREDS_FILE).expanduser()
         if not creds_path.exists():
             has_creds_file = False
             logger.warning(f"KIRO_CREDS_FILE not found: {KIRO_CREDS_FILE}")
-    
+
     # Check if CLI database file actually exists
     if KIRO_CLI_DB_FILE:
         cli_db_path = Path(KIRO_CLI_DB_FILE).expanduser()
         if not cli_db_path.exists():
             has_cli_db = False
             logger.warning(f"KIRO_CLI_DB_FILE not found: {KIRO_CLI_DB_FILE}")
-    
+
     # If no credentials found, show helpful error
     if not has_refresh_token and not has_creds_file and not has_cli_db:
         if not env_file.exists():
@@ -270,7 +262,7 @@ def validate_configuration() -> None:
                 "      - Option 3: KIRO_CLI_DB_FILE to kiro-cli SQLite database\n"
                 "\n"
                 "Or use environment variables (for Docker):\n"
-                "   docker run -e PROXY_API_KEY=\"...\" -e REFRESH_TOKEN=\"...\" ...\n"
+                '   docker run -e PROXY_API_KEY="..." -e REFRESH_TOKEN="..." ...\n'
                 "\n"
                 "See README.md for detailed instructions."
             )
@@ -282,20 +274,20 @@ def validate_configuration() -> None:
                 "   Configure one of the following in your .env file:\n"
                 "\n"
                 "Set you super-secret password as PROXY_API_KEY\n"
-                "   PROXY_API_KEY=\"my-super-secret-password-123\"\n"
+                '   PROXY_API_KEY="my-super-secret-password-123"\n'
                 "\n"
                 "   Option 1 (Recommended): JSON credentials file\n"
-                "      KIRO_CREDS_FILE=\"path/to/your/kiro-credentials.json\"\n"
+                '      KIRO_CREDS_FILE="path/to/your/kiro-credentials.json"\n'
                 "\n"
                 "   Option 2: Refresh token\n"
-                "      REFRESH_TOKEN=\"your_refresh_token_here\"\n"
+                '      REFRESH_TOKEN="your_refresh_token_here"\n'
                 "\n"
                 "   Option 3: kiro-cli SQLite database (AWS SSO)\n"
-                "      KIRO_CLI_DB_FILE=\"~/.local/share/kiro-cli/data.sqlite3\"\n"
+                '      KIRO_CLI_DB_FILE="~/.local/share/kiro-cli/data.sqlite3"\n'
                 "\n"
                 "   See README.md for how to obtain credentials."
             )
-    
+
     # Print errors and exit if any
     if errors:
         logger.error("")
@@ -303,12 +295,12 @@ def validate_configuration() -> None:
         logger.error("  CONFIGURATION ERROR")
         logger.error("=" * 60)
         for error in errors:
-            for line in error.split('\n'):
+            for line in error.split("\n"):
                 logger.error(f"  {line}")
         logger.error("=" * 60)
         logger.error("")
         raise RuntimeError("Configuration validation failed")
-    
+
     # Note: Credential loading details are logged by KiroAuthManager
 
 
@@ -317,12 +309,12 @@ def validate_configuration() -> None:
 async def lifespan(app: FastAPI):
     """
     Manages the application lifecycle.
-    
+
     Creates and initializes:
     - Shared HTTP client with connection pooling
     - KiroAuthManager for token management
     - ModelInfoCache for model caching
-    
+
     The shared HTTP client is used by all requests to reduce memory usage
     and enable connection reuse. This is especially important for handling
     concurrent requests efficiently (fixes issue #24).
@@ -330,176 +322,151 @@ async def lifespan(app: FastAPI):
     logger.info("Starting application... Creating state managers.")
     app.state.started_at = time.time()
     initialize_dashboard_store()
-    
+
     # Create shared HTTP client with connection pooling
     # This reduces memory usage and enables connection reuse across requests
     # Limits: max 100 total connections, max 20 keep-alive connections
     limits = httpx.Limits(
         max_connections=100,
         max_keepalive_connections=20,
-        keepalive_expiry=30.0  # Close idle connections after 30 seconds
+        keepalive_expiry=30.0,  # Close idle connections after 30 seconds
     )
     # Timeout configuration for streaming (long read timeout for model "thinking")
     timeout = httpx.Timeout(
         connect=30.0,
         read=STREAMING_READ_TIMEOUT,  # 300 seconds for streaming
         write=30.0,
-        pool=30.0
+        pool=30.0,
     )
-    app.state.http_client = httpx.AsyncClient(
-        limits=limits,
-        timeout=timeout,
-        follow_redirects=True
-    )
+    app.state.http_client = httpx.AsyncClient(limits=limits, timeout=timeout, follow_redirects=True)
     logger.info("Shared HTTP client created with connection pooling")
-    
+
     # ==============================================================================
     # Legacy Fallback: .env → credentials.json
     # ==============================================================================
     creds_path = Path(ACCOUNTS_CONFIG_FILE)
-    
+
     # Check if we have legacy .env credentials
     has_refresh_token = bool(REFRESH_TOKEN)
     has_creds_file = bool(KIRO_CREDS_FILE) and Path(KIRO_CREDS_FILE).expanduser().exists()
     has_cli_db = bool(KIRO_CLI_DB_FILE) and Path(KIRO_CLI_DB_FILE).expanduser().exists()
-    
+
     # Helper function to add optional per-account overrides from .env
     def _add_env_overrides(entry: dict) -> None:
         """Add optional per-account overrides from .env (only if set)"""
         profile_arn = os.getenv("PROFILE_ARN")
         if profile_arn:
             entry["profile_arn"] = profile_arn
-        
+
         region = os.getenv("KIRO_REGION")
         if region:
             entry["region"] = region
-        
+
         api_region = os.getenv("KIRO_API_REGION")
         if api_region:
             entry["api_region"] = api_region
-    
+
     if ACCOUNT_SYSTEM:
         # Account system enabled: create credentials.json ONCE (migration)
         if not creds_path.exists():
             if has_refresh_token or has_creds_file or has_cli_db:
                 logger.info("credentials.json not found, creating from .env (one-time migration)")
                 credentials = []
-                
+
                 # Priority: SQLite DB > JSON file > environment variables (same as KiroAuthManager)
                 if has_cli_db:
-                    entry = {
-                        "type": "sqlite",
-                        "path": KIRO_CLI_DB_FILE
-                    }
+                    entry = {"type": "sqlite", "path": KIRO_CLI_DB_FILE}
                     _add_env_overrides(entry)
                     credentials.append(entry)
                 elif has_creds_file:
-                    entry = {
-                        "type": "json",
-                        "path": KIRO_CREDS_FILE
-                    }
+                    entry = {"type": "json", "path": KIRO_CREDS_FILE}
                     _add_env_overrides(entry)
                     credentials.append(entry)
                 elif has_refresh_token:
-                    entry = {
-                        "type": "refresh_token",
-                        "refresh_token": REFRESH_TOKEN
-                    }
+                    entry = {"type": "refresh_token", "refresh_token": REFRESH_TOKEN}
                     _add_env_overrides(entry)
                     credentials.append(entry)
-            
+
                 # Save credentials.json
-                with open(creds_path, 'w', encoding='utf-8') as f:
+                with open(creds_path, "w", encoding="utf-8") as f:
                     json.dump(credentials, f, indent=2, ensure_ascii=False)
-                
+
                 logger.info("Created credentials.json from .env (one-time migration)")
     else:
         # Legacy mode: ALWAYS recreate credentials.json from .env
         if has_refresh_token or has_creds_file or has_cli_db:
             logger.debug("Legacy mode: recreating credentials.json from .env")
             credentials = []
-            
+
             # Priority: SQLite DB > JSON file > environment variables (same as KiroAuthManager)
             if has_cli_db:
-                entry = {
-                    "type": "sqlite",
-                    "path": KIRO_CLI_DB_FILE
-                }
+                entry = {"type": "sqlite", "path": KIRO_CLI_DB_FILE}
                 _add_env_overrides(entry)
                 credentials.append(entry)
             elif has_creds_file:
-                entry = {
-                    "type": "json",
-                    "path": KIRO_CREDS_FILE
-                }
+                entry = {"type": "json", "path": KIRO_CREDS_FILE}
                 _add_env_overrides(entry)
                 credentials.append(entry)
             elif has_refresh_token:
-                entry = {
-                    "type": "refresh_token",
-                    "refresh_token": REFRESH_TOKEN
-                }
+                entry = {"type": "refresh_token", "refresh_token": REFRESH_TOKEN}
                 _add_env_overrides(entry)
                 credentials.append(entry)
-            
+
             # Save credentials.json (overwrite if exists)
-            with open(creds_path, 'w', encoding='utf-8') as f:
+            with open(creds_path, "w", encoding="utf-8") as f:
                 json.dump(credentials, f, indent=2, ensure_ascii=False)
-            
+
             logger.debug("credentials.json recreated from .env (legacy mode)")
-    
+
     # ==============================================================================
     # Create AccountManager
     # ==============================================================================
-    app.state.account_manager = AccountManager(
-        credentials_file=ACCOUNTS_CONFIG_FILE,
-        state_file=ACCOUNTS_STATE_FILE
-    )
-    
+    app.state.account_manager = AccountManager(credentials_file=ACCOUNTS_CONFIG_FILE, state_file=ACCOUNTS_STATE_FILE)
+
     # Load credentials and state
     await app.state.account_manager.load_credentials()
     await app.state.account_manager.load_state()
-    
+
     # Store account_system flag
     app.state.account_system = ACCOUNT_SYSTEM
-    
+
     # ==============================================================================
     # Initialize first working account (blocking)
     # ==============================================================================
     all_accounts = list(app.state.account_manager._accounts.keys())
-    
+
     if not all_accounts:
         logger.error("No accounts configured in credentials.json")
         raise RuntimeError("No accounts configured in credentials.json")
-    
+
     # Determine start index from state.json
     start_index = app.state.account_manager._current_account_index
-    
+
     # Try to initialize accounts (full circle)
     initialized = False
-    
+
     for i in range(len(all_accounts)):
         current_index = (start_index + i) % len(all_accounts)
         account_id = all_accounts[current_index]
-        
+
         logger.info(f"Attempting to initialize account: {account_id}")
-        
+
         success = await app.state.account_manager._initialize_account(account_id)
-        
+
         if success:
             logger.info(f"Successfully initialized account: {account_id}")
             initialized = True
             break
         else:
             logger.warning(f"Failed to initialize account: {account_id}")
-    
+
     if not initialized:
         logger.error("Failed to initialize any account. Check your credentials.")
         raise RuntimeError("Failed to initialize any account")
-    
+
     # Save initial state
     await app.state.account_manager._save_state()
-    
+
     # Start background task for periodic state saving.
     save_task = asyncio.create_task(app.state.account_manager.save_state_periodically())
 
@@ -558,10 +525,10 @@ async def lifespan(app: FastAPI):
     logger.info("Account system initialized successfully")
 
     yield
-    
+
     # Graceful shutdown
     logger.info("Shutting down application...")
-    
+
     # Cancel background tasks.
     for task in (save_task, usage_task, prune_task, rate_task):
         task.cancel()
@@ -577,11 +544,11 @@ async def lifespan(app: FastAPI):
             await task
         except asyncio.CancelledError:
             pass
-    
+
     # Final state save
     await app.state.account_manager._save_state()
     logger.info("Final state saved")
-    
+
     # Close HTTP client
     try:
         await app.state.http_client.aclose()
@@ -591,12 +558,7 @@ async def lifespan(app: FastAPI):
 
 
 # --- FastAPI Application ---
-app = FastAPI(
-    title=APP_TITLE,
-    description=APP_DESCRIPTION,
-    version=APP_VERSION,
-    lifespan=lifespan
-)
+app = FastAPI(title=APP_TITLE, description=APP_DESCRIPTION, version=APP_VERSION, lifespan=lifespan)
 
 
 # --- CORS Middleware ---
@@ -692,10 +654,10 @@ UVICORN_LOG_CONFIG = {
 def parse_cli_args() -> argparse.Namespace:
     """
     Parse command-line arguments for server configuration.
-    
+
     CLI arguments have the highest priority, overriding both
     environment variables and default values.
-    
+
     Returns:
         Parsed arguments namespace with host and port values
     """
@@ -713,49 +675,47 @@ Examples:
   python main.py --port 9000              # Override port only
   python main.py --host 127.0.0.1         # Local connections only
   python main.py -H 0.0.0.0 -p 8080       # Short form
-  
+
   SERVER_PORT=9000 python main.py         # Via environment
   uvicorn main:app --port 9000            # Via uvicorn directly
-        """
+        """,
     )
-    
+
     parser.add_argument(
-        "-H", "--host",
+        "-H",
+        "--host",
         type=str,
         default=None,  # None means "use env or default"
         metavar="HOST",
-        help=f"Server host address (default: {DEFAULT_SERVER_HOST}, env: SERVER_HOST)"
+        help=f"Server host address (default: {DEFAULT_SERVER_HOST}, env: SERVER_HOST)",
     )
-    
+
     parser.add_argument(
-        "-p", "--port",
+        "-p",
+        "--port",
         type=int,
         default=None,  # None means "use env or default"
         metavar="PORT",
-        help=f"Server port (default: {DEFAULT_SERVER_PORT}, env: SERVER_PORT)"
+        help=f"Server port (default: {DEFAULT_SERVER_PORT}, env: SERVER_PORT)",
     )
-    
-    parser.add_argument(
-        "-v", "--version",
-        action="version",
-        version=f"%(prog)s {APP_VERSION}"
-    )
-    
+
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {APP_VERSION}")
+
     return parser.parse_args()
 
 
 def resolve_server_config(args: argparse.Namespace) -> tuple[str, int]:
     """
     Resolve final server configuration using priority hierarchy.
-    
+
     Priority (highest to lowest):
     1. CLI arguments (--host, --port)
     2. Environment variables (SERVER_HOST, SERVER_PORT)
     3. Default values (0.0.0.0:8000)
-    
+
     Args:
         args: Parsed CLI arguments
-        
+
     Returns:
         Tuple of (host, port) with resolved values
     """
@@ -769,7 +729,7 @@ def resolve_server_config(args: argparse.Namespace) -> tuple[str, int]:
     else:
         final_host = DEFAULT_SERVER_HOST
         host_source = "default"
-    
+
     # Port resolution: CLI > ENV > Default
     if args.port is not None:
         final_port = args.port
@@ -780,35 +740,34 @@ def resolve_server_config(args: argparse.Namespace) -> tuple[str, int]:
     else:
         final_port = DEFAULT_SERVER_PORT
         port_source = "default"
-    
+
     # Log configuration sources for transparency
     logger.debug(f"Host: {final_host} (from {host_source})")
     logger.debug(f"Port: {final_port} (from {port_source})")
-    
+
     return final_host, final_port
 
 
 def print_startup_banner(host: str, port: int) -> None:
     """
     Print a startup banner with server information.
-    
+
     Args:
         host: Server host address
         port: Server port
     """
     # ANSI color codes
     GREEN = "\033[92m"
-    CYAN = "\033[96m"
     YELLOW = "\033[93m"
     WHITE = "\033[97m"
     BOLD = "\033[1m"
     DIM = "\033[2m"
     RESET = "\033[0m"
-    
+
     # Determine display URL
     display_host = "localhost" if host == "0.0.0.0" else host
     url = f"http://{display_host}:{port}"
-    
+
     print()
     print(f"  {WHITE}{BOLD}👻 {APP_TITLE} v{APP_VERSION}{RESET}")
     print()
@@ -828,24 +787,24 @@ def print_startup_banner(host: str, port: int) -> None:
 # --- Entry Point ---
 if __name__ == "__main__":
     import uvicorn
-    
+
     # Parse CLI arguments first (handles --version, --help without requiring config)
     args = parse_cli_args()
-    
+
     # Run configuration validation before starting server
     validate_configuration()
-    
+
     # Warn about suboptimal timeout configuration
     _warn_timeout_configuration()
-    
+
     # Resolve final configuration with priority hierarchy
     final_host, final_port = resolve_server_config(args)
-    
+
     # Print startup banner
     print_startup_banner(final_host, final_port)
-    
+
     logger.info(f"Starting Uvicorn server on {final_host}:{final_port}...")
-    
+
     # Use string reference to avoid double module import
     uvicorn.run(
         "main:app",

--- a/manual_api_test.py
+++ b/manual_api_test.py
@@ -22,8 +22,8 @@ import os
 import sqlite3
 import sys
 import uuid
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 
 import httpx
 from dotenv import load_dotenv
@@ -35,6 +35,7 @@ load_dotenv()
 
 class AuthType(Enum):
     """Type of authentication mechanism."""
+
     KIRO_DESKTOP = "kiro_desktop"
     AWS_SSO_OIDC = "aws_sso_oidc"
 
@@ -67,46 +68,46 @@ def load_credentials_from_json(file_path: str) -> bool:
     """Load credentials from JSON file."""
     global REFRESH_TOKEN, PROFILE_ARN, CLIENT_ID, CLIENT_SECRET, AUTH_TYPE
     global SSO_REGION, AWS_SSO_OIDC_TOKEN_URL
-    
+
     try:
         creds_path = Path(file_path).expanduser()
         if not creds_path.exists():
             logger.warning(f"Credentials file not found: {file_path}")
             return False
-        
-        with open(creds_path, 'r', encoding='utf-8') as f:
+
+        with open(creds_path, "r", encoding="utf-8") as f:
             creds_data = json.load(f)
-        
+
         # Load common fields
-        if 'refreshToken' in creds_data:
-            REFRESH_TOKEN = creds_data['refreshToken']
-        if 'profileArn' in creds_data:
-            PROFILE_ARN = creds_data['profileArn']
-        if 'region' in creds_data:
+        if "refreshToken" in creds_data:
+            REFRESH_TOKEN = creds_data["refreshToken"]
+        if "profileArn" in creds_data:
+            PROFILE_ARN = creds_data["profileArn"]
+        if "region" in creds_data:
             # Store as SSO region for OIDC token refresh only
             # IMPORTANT: CodeWhisperer API is only available in us-east-1,
             # so we don't update KIRO_API_HOST here
-            SSO_REGION = creds_data['region']
+            SSO_REGION = creds_data["region"]
             AWS_SSO_OIDC_TOKEN_URL = f"https://oidc.{SSO_REGION}.amazonaws.com/token"
             logger.debug(f"SSO region from JSON: {SSO_REGION} (API stays at {API_REGION})")
-        
+
         # Load AWS SSO OIDC specific fields
-        if 'clientId' in creds_data:
-            CLIENT_ID = creds_data['clientId']
-        if 'clientSecret' in creds_data:
-            CLIENT_SECRET = creds_data['clientSecret']
-        
+        if "clientId" in creds_data:
+            CLIENT_ID = creds_data["clientId"]
+        if "clientSecret" in creds_data:
+            CLIENT_SECRET = creds_data["clientSecret"]
+
         # Detect auth type
         if CLIENT_ID and CLIENT_SECRET:
             AUTH_TYPE = AuthType.AWS_SSO_OIDC
-            logger.info(f"Detected auth type: AWS SSO OIDC")
+            logger.info("Detected auth type: AWS SSO OIDC")
         else:
             AUTH_TYPE = AuthType.KIRO_DESKTOP
-            logger.info(f"Detected auth type: Kiro Desktop")
-        
+            logger.info("Detected auth type: Kiro Desktop")
+
         logger.info(f"Credentials loaded from {file_path}")
         return True
-        
+
     except Exception as e:
         logger.error(f"Error loading credentials from file: {e}")
         return False
@@ -116,73 +117,74 @@ def load_credentials_from_sqlite(db_path: str) -> bool:
     """Load credentials from kiro-cli SQLite database."""
     global REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET, AUTH_TYPE, SCOPES, AUTH_TOKEN
     global SSO_REGION, AWS_SSO_OIDC_TOKEN_URL
-    
+
     try:
         path = Path(db_path).expanduser()
         if not path.exists():
             logger.warning(f"SQLite database not found: {db_path}")
             return False
-        
+
         conn = sqlite3.connect(str(path))
         cursor = conn.cursor()
-        
+
         # Load token data (try both kiro-cli and codewhisperer key formats)
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
         token_row = cursor.fetchone()
         if not token_row:
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
             token_row = cursor.fetchone()
-        
+
         if token_row:
             token_data = json.loads(token_row[0])
             if token_data:
                 # Check if we have a valid access token
-                if 'access_token' in token_data and 'expires_at' in token_data:
+                if "access_token" in token_data and "expires_at" in token_data:
                     from datetime import datetime
-                    expires_at = datetime.fromisoformat(token_data['expires_at'].replace('Z', '+00:00'))
+
+                    expires_at = datetime.fromisoformat(token_data["expires_at"].replace("Z", "+00:00"))
                     if expires_at > datetime.now().astimezone():
-                        AUTH_TOKEN = token_data['access_token']
+                        AUTH_TOKEN = token_data["access_token"]
                         logger.info("Found valid access token in database (will use after HEADERS init)")
-                if 'refresh_token' in token_data:
-                    REFRESH_TOKEN = token_data['refresh_token']
-                if 'scopes' in token_data:
-                    SCOPES = token_data['scopes']
-                if 'region' in token_data:
+                if "refresh_token" in token_data:
+                    REFRESH_TOKEN = token_data["refresh_token"]
+                if "scopes" in token_data:
+                    SCOPES = token_data["scopes"]
+                if "region" in token_data:
                     # Store as SSO region for OIDC token refresh only
                     # IMPORTANT: CodeWhisperer API is only available in us-east-1,
                     # so we don't update KIRO_API_HOST here
-                    SSO_REGION = token_data['region']
+                    SSO_REGION = token_data["region"]
                     AWS_SSO_OIDC_TOKEN_URL = f"https://oidc.{SSO_REGION}.amazonaws.com/token"
                     logger.debug(f"SSO region from SQLite: {SSO_REGION} (API stays at {API_REGION})")
-        
+
         # Load device registration (client_id, client_secret) - try both key formats
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:device-registration",))
         registration_row = cursor.fetchone()
         if not registration_row:
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:device-registration",))
             registration_row = cursor.fetchone()
-        
+
         if registration_row:
             registration_data = json.loads(registration_row[0])
             if registration_data:
-                if 'client_id' in registration_data:
-                    CLIENT_ID = registration_data['client_id']
-                if 'client_secret' in registration_data:
-                    CLIENT_SECRET = registration_data['client_secret']
-        
+                if "client_id" in registration_data:
+                    CLIENT_ID = registration_data["client_id"]
+                if "client_secret" in registration_data:
+                    CLIENT_SECRET = registration_data["client_secret"]
+
         conn.close()
-        
+
         # Detect auth type
         if CLIENT_ID and CLIENT_SECRET:
             AUTH_TYPE = AuthType.AWS_SSO_OIDC
-            logger.info(f"Detected auth type: AWS SSO OIDC (from SQLite)")
+            logger.info("Detected auth type: AWS SSO OIDC (from SQLite)")
         else:
             AUTH_TYPE = AuthType.KIRO_DESKTOP
-            logger.info(f"Detected auth type: Kiro Desktop (from SQLite)")
-        
+            logger.info("Detected auth type: Kiro Desktop (from SQLite)")
+
         logger.info(f"Credentials loaded from SQLite: {db_path}")
         return True
-        
+
     except sqlite3.Error as e:
         logger.error(f"SQLite error: {e}")
         return False
@@ -226,7 +228,7 @@ HEADERS = {
 def refresh_auth_token():
     """Refreshes AUTH_TOKEN via appropriate endpoint based on auth type."""
     global AUTH_TOKEN, HEADERS
-    
+
     if AUTH_TYPE == AuthType.AWS_SSO_OIDC:
         return refresh_auth_token_aws_sso_oidc()
     else:
@@ -237,33 +239,33 @@ def refresh_auth_token_kiro_desktop():
     """Refreshes AUTH_TOKEN via Kiro Desktop Auth endpoint."""
     global AUTH_TOKEN, HEADERS
     logger.info("Refreshing Kiro token via Kiro Desktop Auth...")
-    
+
     payload = {"refreshToken": REFRESH_TOKEN}
     headers = {
         "Content-Type": "application/json",
         "User-Agent": "KiroIDE-0.7.45-31c325a0ff0a9c8dec5d13048f4257462d751fe5b8af4cb1088f1fca45856c64",
     }
-    
+
     try:
         response = httpx.post(KIRO_DESKTOP_TOKEN_URL, json=payload, headers=headers)
         response.raise_for_status()
         data = response.json()
-        
+
         new_token = data.get("accessToken")
         expires_in = data.get("expiresIn")
-        
+
         if not new_token:
             logger.error("Failed to get accessToken from response")
             return False
 
         logger.success(f"Token refreshed via Kiro Desktop Auth. Expires in: {expires_in}s")
         AUTH_TOKEN = new_token
-        HEADERS['Authorization'] = f"Bearer {AUTH_TOKEN}"
+        HEADERS["Authorization"] = f"Bearer {AUTH_TOKEN}"
         return True
-        
+
     except httpx.HTTPError as e:
         logger.error(f"Error refreshing token via Kiro Desktop Auth: {e}")
-        if hasattr(e, 'response') and e.response:
+        if hasattr(e, "response") and e.response:
             logger.error(f"Server response: {e.response.status_code} {e.response.text}")
         return False
 
@@ -272,11 +274,11 @@ def refresh_auth_token_aws_sso_oidc():
     """Refreshes AUTH_TOKEN via AWS SSO OIDC endpoint."""
     global AUTH_TOKEN, HEADERS
     logger.info("Refreshing Kiro token via AWS SSO OIDC...")
-    
+
     # Determine SSO OIDC URL (use SSO_REGION if set, otherwise fall back to API_REGION)
     sso_region = SSO_REGION or API_REGION
     oidc_url = AWS_SSO_OIDC_TOKEN_URL or f"https://oidc.{sso_region}.amazonaws.com/token"
-    
+
     # AWS SSO OIDC uses form-urlencoded data
     data = {
         "grant_type": "refresh_token",
@@ -284,21 +286,23 @@ def refresh_auth_token_aws_sso_oidc():
         "client_secret": CLIENT_SECRET,
         "refresh_token": REFRESH_TOKEN,
     }
-    
+
     # Note: scope parameter is NOT sent during refresh per OAuth 2.0 RFC 6749 Section 6
     # AWS SSO OIDC uses the originally granted scopes automatically
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
     }
-    
+
     # Log request details (without secrets) for debugging
-    logger.debug(f"AWS SSO OIDC refresh request: url={oidc_url}, "
-                 f"sso_region={sso_region}, api_region={API_REGION}, "
-                 f"client_id={CLIENT_ID[:8] if CLIENT_ID else 'None'}...")
-    
+    logger.debug(
+        f"AWS SSO OIDC refresh request: url={oidc_url}, "
+        f"sso_region={sso_region}, api_region={API_REGION}, "
+        f"client_id={CLIENT_ID[:8] if CLIENT_ID else 'None'}..."
+    )
+
     try:
         response = httpx.post(oidc_url, data=data, headers=headers)
-        
+
         # Log response details for debugging (especially on errors)
         if response.status_code != 200:
             logger.error(f"AWS SSO OIDC refresh failed: status={response.status_code}")
@@ -308,29 +312,28 @@ def refresh_auth_token_aws_sso_oidc():
                 error_json = response.json()
                 error_code = error_json.get("error", "unknown")
                 error_desc = error_json.get("error_description", "no description")
-                logger.error(f"AWS SSO OIDC error details: error={error_code}, "
-                             f"description={error_desc}")
+                logger.error(f"AWS SSO OIDC error details: error={error_code}, description={error_desc}")
             except Exception:
                 pass  # Body wasn't JSON, already logged as text
             response.raise_for_status()
-        
+
         result = response.json()
-        
+
         new_token = result.get("accessToken")
         expires_in = result.get("expiresIn", 3600)
-        
+
         if not new_token:
             logger.error(f"Failed to get accessToken from AWS SSO OIDC response: {result}")
             return False
 
         logger.success(f"Token refreshed via AWS SSO OIDC. Expires in: {expires_in}s")
         AUTH_TOKEN = new_token
-        HEADERS['Authorization'] = f"Bearer {AUTH_TOKEN}"
+        HEADERS["Authorization"] = f"Bearer {AUTH_TOKEN}"
         return True
-        
+
     except httpx.HTTPError as e:
         logger.error(f"Error refreshing token via AWS SSO OIDC: {e}")
-        if hasattr(e, 'response') and e.response is not None:
+        if hasattr(e, "response") and e.response is not None:
             logger.error(f"Server response: {e.response.status_code} {e.response.text}")
         return False
 
@@ -340,12 +343,12 @@ def get_profile_arn():
     global PROFILE_ARN
     logger.info("Getting profile ARN from /ListAvailableProfiles...")
     url = f"{KIRO_API_HOST}/ListAvailableProfiles"
-    
+
     try:
         response = httpx.get(url, headers=HEADERS)
         response.raise_for_status()
         data = response.json()
-        
+
         profiles = data.get("profiles", [])
         if profiles:
             # Use the first available profile
@@ -357,7 +360,7 @@ def get_profile_arn():
             return False
     except httpx.HTTPError as e:
         logger.error(f"ListAvailableProfiles failed: {e}")
-        if hasattr(e, 'response') and e.response is not None:
+        if hasattr(e, "response") and e.response is not None:
             logger.error(f"Server response: {e.response.status_code} {e.response.text}")
         return False
 
@@ -366,10 +369,7 @@ def test_get_models():
     """Tests the ListAvailableModels endpoint."""
     logger.info("Testing /ListAvailableModels...")
     url = f"{KIRO_API_HOST}/ListAvailableModels"
-    params = {
-        "origin": "AI_EDITOR",
-        "profileArn": PROFILE_ARN
-    }
+    params = {"origin": "AI_EDITOR", "profileArn": PROFILE_ARN}
 
     try:
         response = httpx.get(url, headers=HEADERS, params=params)
@@ -388,7 +388,7 @@ def test_generate_content():
     """Tests the generateAssistantResponse endpoint."""
     logger.info("Testing /generateAssistantResponse...")
     url = f"{KIRO_API_HOST}/generateAssistantResponse"
-    
+
     payload = {
         "conversationState": {
             "agentContinuationId": str(uuid.uuid4()),
@@ -400,15 +400,13 @@ def test_generate_content():
                     "content": "Hello! Say something short.",
                     "modelId": "claude-haiku-4.5",
                     "origin": "AI_EDITOR",
-                    "userInputMessageContext": {
-                        "tools": []
-                    }
+                    "userInputMessageContext": {"tools": []},
                 }
             },
-            "history": []
+            "history": [],
         }
     }
-    
+
     # Only add profileArn if it's set and not AWS SSO OIDC
     # AWS SSO OIDC (Builder ID) users don't need profileArn and it causes 403 if sent
     if PROFILE_ARN and AUTH_TYPE != AuthType.AWS_SSO_OIDC:
@@ -423,7 +421,7 @@ def test_generate_content():
             for chunk in response.iter_bytes(chunk_size=1024):
                 if chunk:
                     # Try to decode and find JSON
-                    chunk_str = chunk.decode('utf-8', errors='ignore')
+                    chunk_str = chunk.decode("utf-8", errors="ignore")
                     logger.debug(f"Chunk: {chunk_str[:200]}...")
 
         logger.success("generateAssistantResponse test COMPLETED")
@@ -434,7 +432,7 @@ def test_generate_content():
 
 
 if __name__ == "__main__":
-    logger.info(f"Starting Kiro API tests...")
+    logger.info("Starting Kiro API tests...")
     logger.info(f"  Credentials source: {cred_source}")
     logger.info(f"  Auth type: {AUTH_TYPE.value}")
     logger.info(f"  API Region: {API_REGION}")
@@ -443,7 +441,7 @@ if __name__ == "__main__":
 
     # Check if we already have a valid token from the database
     if AUTH_TOKEN:
-        HEADERS['Authorization'] = f"Bearer {AUTH_TOKEN}"
+        HEADERS["Authorization"] = f"Bearer {AUTH_TOKEN}"
         logger.info("Using existing valid access token from database")
         token_ok = True
     else:
@@ -453,16 +451,16 @@ if __name__ == "__main__":
         # Get profile ARN dynamically for AWS SSO OIDC users
         if AUTH_TYPE == AuthType.AWS_SSO_OIDC:
             get_profile_arn()
-        
+
         models_ok = test_get_models()
         generate_ok = test_generate_content()
 
         if models_ok and generate_ok:
-            logger.success(f"All tests passed successfully!")
+            logger.success("All tests passed successfully!")
             logger.success(f"  Auth type: {AUTH_TYPE.value}")
             logger.success(f"  Credentials: {cred_source}")
         else:
-            logger.warning(f"One or more tests failed.")
+            logger.warning("One or more tests failed.")
     else:
         logger.error("Failed to refresh token. Tests not started.")
         logger.error(f"  Auth type: {AUTH_TYPE.value}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+# Tooling configuration only; the project is not packaged. Runtime deps stay in
+# requirements.txt, quality-gate deps in requirements-dev.txt.
+
+[tool.ruff]
+# CI and the Docker image run 3.10, which is older than a typical dev machine.
+target-version = "py310"
+line-length = 120
+extend-exclude = ["kiro/static", "frontend"]
+
+[tool.ruff.lint]
+# E501 is deliberately absent: `ruff format` owns line length, and enforcing it
+# here too only flags lines the formatter cannot split (long URLs, embedded
+# payload literals).
+select = ["E4", "E7", "E9", "F", "I", "W"]
+
+[tool.ruff.lint.per-file-ignores]
+# Re-export surface: the package exposes what it imports.
+"kiro/__init__.py" = ["F401"]
+
+[tool.mypy]
+python_version = "3.10"
+files = ["kiro", "main.py"]
+ignore_missing_imports = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Quality gates. Pinned so a tool release cannot turn CI red on its own.
+ruff==0.16.0
+mypy==1.19.0
+pytest-cov==7.0.0

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,6 +1,6 @@
 # tests/ — pytest suite
 
-1694 tests, ~42k lines. Unit tests dominate (44 modules); integration tests
+1694 tests, ~44k lines. Unit tests dominate (44 modules); 4 integration modules
 exercise route and stream wiring. Full run is under 10 seconds because nothing
 touches network.
 
@@ -9,8 +9,9 @@ touches network.
 ```
 tests/
 ├── conftest.py            # session fixtures incl. network blocking
+├── fixtures/              # recorded bad-order payloads for validation tests
 ├── unit/                  # 44 modules, roughly one per kiro/ module
-└── integration/           # route/stream flows + manual probes
+└── integration/           # 4 route/stream flow modules + 2 live probes
 ```
 
 ## WHERE TO LOOK
@@ -31,13 +32,19 @@ tests/
 
 ## CONVENTIONS
 
-- `block_all_network_calls` in `conftest.py:419` is session-scoped and autouse.
-  Real network access fails the test; mock at the httpx layer.
-- `setup_test_environment` (`conftest.py:44`) is also autouse and points
-  credentials/state at a tmp path. Never let a test read the real `data/`.
+- `block_all_network_calls` (`conftest.py:420`) is session-scoped and autouse. It
+  patches `httpx.AsyncClient` in `kiro.auth`, `kiro.http_client`,
+  `kiro.streaming_openai`, and `kiro.account_manager`; real network access fails
+  the test. Fake streams come back as a real async `aiter_bytes` generator, so
+  code under test sees bytes, not a coroutine mock.
+- `setup_test_environment` (`conftest.py:45`) is also autouse and repoints
+  `ACCOUNTS_CONFIG_FILE`, `ACCOUNTS_STATE_FILE`, and `DASHBOARD_DATA_DIR` at a
+  tmp path. Never let a test read the real `data/`.
 - Naming is enforced by `pytest.ini`: `test_*.py`, `Test*`, `test_*`.
 - Classes group by outcome: `Test*Success`, `Test*Errors`, `Test*EdgeCases`.
 - Add tests to the existing module for a subsystem; new files only for new modules.
+- Upstream stream bytes come from the `mock_kiro_*_chunks` fixtures or from
+  patching the parser to emit `KiroEvent`s directly; do not hand-roll a client.
 - Protocol tests assert parsed structure and event order, not prose or exact
   prompt sentences.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,11 +95,16 @@ def setup_test_environment(tmp_path_factory):
     # container paths, so the environment must be isolated too.
     original_environ = {
         key: os.environ.get(key)
-        for key in ("ACCOUNTS_CONFIG_FILE", "ACCOUNTS_STATE_FILE", "DASHBOARD_DATA_DIR")
+        for key in ("ACCOUNTS_CONFIG_FILE", "ACCOUNTS_STATE_FILE", "DASHBOARD_DATA_DIR", "PROXY_API_KEY")
     }
     os.environ["ACCOUNTS_CONFIG_FILE"] = str(creds_file)
     os.environ["ACCOUNTS_STATE_FILE"] = str(tmp_dir / "state.json")
     os.environ["DASHBOARD_DATA_DIR"] = str(tmp_dir / "dashboard")
+    # config.PROXY_API_KEY falls back to a built-in default, but the data-plane
+    # authenticator reads PROXY_API_KEY straight from the environment. Without a
+    # local .env (as in CI) the two disagree and every authenticated route
+    # answers 401, so pin the environment to whatever config actually resolved.
+    os.environ["PROXY_API_KEY"] = kiro.config.PROXY_API_KEY
 
     import main
     main.ACCOUNTS_CONFIG_FILE = str(creds_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,19 +10,19 @@ All tests MUST be completely isolated from the network.
 import asyncio
 import json
 import os
-import pytest
 import time
-from typing import AsyncGenerator, Dict, Any, List
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from datetime import datetime, timezone
+from typing import Any, Dict
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
+import pytest
 from fastapi.testclient import TestClient
-
 
 # =============================================================================
 # Event Loop Fixtures
 # =============================================================================
+
 
 @pytest.fixture(scope="session")
 def event_loop():
@@ -41,15 +41,16 @@ def event_loop():
 # Environment Fixtures
 # =============================================================================
 
+
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_environment(tmp_path_factory):
     """
     CRITICAL FIXTURE: Sets up isolated test environment.
-    
+
     Creates temporary credentials.json and state.json to prevent:
     1. Tests failing when .env doesn't exist
     2. Pollution of working directory with test files
-    
+
     This fixture:
     - Creates temporary directory for test files
     - Creates mock credentials.json with valid test data
@@ -57,34 +58,29 @@ def setup_test_environment(tmp_path_factory):
     - Patches config paths to use temporary files
     """
     print("🔧 Setting up isolated test environment...")
-    
+
     # Create temporary directory for test files
     tmp_dir = tmp_path_factory.mktemp("test_config")
-    
+
     # Create mock Kiro credentials file (JSON format)
     mock_kiro_creds = {
         "accessToken": "mock_access_token_from_fixture",
         "refreshToken": "mock_refresh_token_from_fixture",
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/mock",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
     mock_creds_file = tmp_dir / "mock_kiro_creds.json"
     mock_creds_file.write_text(json.dumps(mock_kiro_creds, indent=2))
-    
+
     # Create credentials.json pointing to mock file
-    credentials_data = [
-        {
-            "type": "json",
-            "path": str(mock_creds_file),
-            "enabled": True
-        }
-    ]
+    credentials_data = [{"type": "json", "path": str(mock_creds_file), "enabled": True}]
     creds_file = tmp_dir / "credentials.json"
     creds_file.write_text(json.dumps(credentials_data, indent=2))
-    
+
     # Patch config paths to use temporary files
     import kiro.config
+
     original_creds_file = kiro.config.ACCOUNTS_CONFIG_FILE
     original_state_file = kiro.config.ACCOUNTS_STATE_FILE
 
@@ -107,14 +103,15 @@ def setup_test_environment(tmp_path_factory):
     os.environ["PROXY_API_KEY"] = kiro.config.PROXY_API_KEY
 
     import main
+
     main.ACCOUNTS_CONFIG_FILE = str(creds_file)
     main.ACCOUNTS_STATE_FILE = str(tmp_dir / "state.json")
-    
+
     print(f"✅ Test credentials: {creds_file}")
     print(f"✅ Test state: {tmp_dir / 'state.json'}")
-    
+
     yield
-    
+
     # Restore original paths
     kiro.config.ACCOUNTS_CONFIG_FILE = original_creds_file
     kiro.config.ACCOUNTS_STATE_FILE = original_state_file
@@ -125,7 +122,7 @@ def setup_test_environment(tmp_path_factory):
             os.environ.pop(key, None)
         else:
             os.environ[key] = value
-    
+
     print("🧹 Test environment cleaned up")
 
 
@@ -143,13 +140,14 @@ def mock_env_vars(monkeypatch):
         "REFRESH_TOKEN": "test_refresh_token_abcdef",
         "PROXY_API_KEY": "test_proxy_key_12345",
         "PROFILE_ARN": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        "KIRO_REGION": "us-east-1"
+        "KIRO_REGION": "us-east-1",
     }
 
 
 # =============================================================================
 # Token and Authentication Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def valid_kiro_token():
@@ -162,13 +160,15 @@ def mock_kiro_token_response(valid_kiro_token):
     """
     Factory for creating mock Kiro token refresh endpoint responses.
     """
+
     def _create_response(expires_in: int = 3600, token: str = None):
         return {
             "accessToken": token or valid_kiro_token,
             "refreshToken": "new_refresh_token_xyz",
             "expiresIn": expires_in,
-            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
+            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
         }
+
     return _create_response
 
 
@@ -176,11 +176,12 @@ def mock_kiro_token_response(valid_kiro_token):
 def valid_proxy_api_key():
     """
     Returns the actual PROXY_API_KEY that the application is using.
-    
+
     This reads the value from kiro.config, which was loaded when the app
     was imported. This ensures tests use the same key the app validates against.
     """
     from kiro.config import PROXY_API_KEY
+
     return PROXY_API_KEY
 
 
@@ -195,18 +196,20 @@ def auth_headers(valid_proxy_api_key):
     """
     Factory for creating valid and invalid Authorization headers.
     """
+
     def _create_headers(api_key: str = None, invalid: bool = False):
         if invalid:
             return {"Authorization": "Bearer wrong_key_123"}
         key = api_key or valid_proxy_api_key
         return {"Authorization": f"Bearer {key}"}
-    
+
     return _create_headers
 
 
 # =============================================================================
 # Kiro Models Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def mock_kiro_models_response():
@@ -218,27 +221,18 @@ def mock_kiro_models_response():
             {
                 "modelId": "claude-sonnet-4.5",
                 "displayName": "Claude Sonnet 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-opus-4.5",
                 "displayName": "Claude Opus 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-haiku-4.5",
                 "displayName": "Claude Haiku 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
-            }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
+            },
         ]
     }
 
@@ -246,6 +240,7 @@ def mock_kiro_models_response():
 # =============================================================================
 # Kiro Streaming Response Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def mock_kiro_streaming_chunks():
@@ -269,6 +264,7 @@ def mock_kiro_streaming_chunks():
         # Chunk 7: Context usage
         b'{"contextUsagePercentage":25.5}',
     ]
+
 
 @pytest.fixture
 def mock_kiro_simple_text_chunks():
@@ -298,11 +294,13 @@ def mock_kiro_stream_with_usage():
 # OpenAI Request Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def sample_openai_chat_request():
     """
     Factory for creating valid OpenAI chat completion requests.
     """
+
     def _create_request(
         model: str = "claude-sonnet-4-5",
         messages: list = None,
@@ -310,27 +308,23 @@ def sample_openai_chat_request():
         temperature: float = None,
         max_tokens: int = None,
         tools: list = None,
-        **kwargs
+        **kwargs,
     ):
         if messages is None:
             messages = [{"role": "user", "content": "Hello, AI!"}]
-        
-        request = {
-            "model": model,
-            "messages": messages,
-            "stream": stream
-        }
-        
+
+        request = {"model": model, "messages": messages, "stream": stream}
+
         if temperature is not None:
             request["temperature"] = temperature
         if max_tokens is not None:
             request["max_tokens"] = max_tokens
         if tools is not None:
             request["tools"] = tools
-        
+
         request.update(kwargs)
         return request
-    
+
     return _create_request
 
 
@@ -346,18 +340,17 @@ def sample_tool_definition():
             "description": "Get weather for a location",
             "parameters": {
                 "type": "object",
-                "properties": {
-                    "location": {"type": "string", "description": "City name"}
-                },
-                "required": ["location"]
-            }
-        }
+                "properties": {"location": {"type": "string", "description": "City name"}},
+                "required": ["location"],
+            },
+        },
     }
 
 
 # =============================================================================
 # HTTP Client Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 async def mock_httpx_client():
@@ -366,7 +359,7 @@ async def mock_httpx_client():
     """
     print("Creating mocked httpx.AsyncClient...")
     mock_client = AsyncMock(spec=httpx.AsyncClient)
-    
+
     # Mock methods
     mock_client.post = AsyncMock()
     mock_client.get = AsyncMock()
@@ -374,7 +367,7 @@ async def mock_httpx_client():
     mock_client.build_request = Mock()
     mock_client.send = AsyncMock()
     mock_client.is_closed = False
-    
+
     return mock_client
 
 
@@ -383,37 +376,35 @@ def mock_httpx_response():
     """
     Factory for creating mocked httpx.Response objects.
     """
+
     def _create_response(
-        status_code: int = 200,
-        json_data: Dict[str, Any] = None,
-        text: str = None,
-        stream_chunks: list = None
+        status_code: int = 200, json_data: Dict[str, Any] = None, text: str = None, stream_chunks: list = None
     ):
         print(f"Creating mock httpx.Response (status={status_code})...")
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = status_code
-        
+
         if json_data is not None:
             mock_response.json = Mock(return_value=json_data)
-        
+
         if text is not None:
             mock_response.text = text
             mock_response.content = text.encode()
-        
+
         if stream_chunks is not None:
             # For streaming responses
             async def mock_aiter_bytes():
                 for chunk in stream_chunks:
                     yield chunk
-            
+
             mock_response.aiter_bytes = mock_aiter_bytes
-        
+
         mock_response.raise_for_status = Mock()
         mock_response.aclose = AsyncMock()
         mock_response.aread = AsyncMock(return_value=b'{"error": "mocked error"}')
-        
+
         return mock_response
-    
+
     return _create_response
 
 
@@ -421,18 +412,19 @@ def mock_httpx_response():
 # Global Network Blocking
 # =============================================================================
 
+
 @pytest.fixture(scope="session", autouse=True)
 def block_all_network_calls():
     """
     CRITICAL FIXTURE: Globally blocks ALL network calls.
     Ensures that NO test can make a real network request.
-    
+
     Provides mock responses for:
     - Token refresh (Kiro Desktop Auth and AWS SSO OIDC)
     - ListAvailableModels API
     - Streaming responses (for route tests)
     """
-    
+
     # Create a mock that will be used for all AsyncClient instances
     mock_async_client = AsyncMock(spec=httpx.AsyncClient)
 
@@ -444,7 +436,7 @@ def block_all_network_calls():
         "accessToken": "mock_access_token_global_fixture",
         "refreshToken": "mock_refresh_token_global_fixture",
         "expiresIn": 3600,
-        "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/mock"
+        "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/mock",
     }
     mock_token_response.raise_for_status = Mock()
 
@@ -457,19 +449,13 @@ def block_all_network_calls():
             {
                 "modelId": "claude-sonnet-4.5",
                 "displayName": "Claude Sonnet 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-opus-4.5",
                 "displayName": "Claude Opus 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
-            }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
+            },
         ]
     }
     mock_models_response.raise_for_status = Mock()
@@ -478,7 +464,7 @@ def block_all_network_calls():
     # Used by test_routes_openai.py and test_routes_anthropic.py
     mock_streaming_response = AsyncMock(spec=httpx.Response)
     mock_streaming_response.status_code = 200
-    
+
     # Create proper bytes chunks for streaming (NOT AsyncMock)
     async def mock_aiter_bytes():
         """Generator that yields real bytes chunks, not AsyncMock objects."""
@@ -489,7 +475,7 @@ def block_all_network_calls():
         ]
         for chunk in chunks:
             yield chunk
-    
+
     mock_streaming_response.aiter_bytes = mock_aiter_bytes
     mock_streaming_response.raise_for_status = Mock()
     mock_streaming_response.aclose = AsyncMock()
@@ -501,52 +487,56 @@ def block_all_network_calls():
     mock_async_client.get = AsyncMock(return_value=mock_models_response)
     mock_async_client.request = AsyncMock(return_value=mock_models_response)
     mock_async_client.send = AsyncMock(return_value=mock_streaming_response)
-    
+
     # Mock stream() method for streaming requests
     # Returns a context manager that yields streaming response
     async def mock_stream(*args, **kwargs):
         """Mock stream() method that returns streaming response."""
+
         class StreamContextManager:
             async def __aenter__(self):
                 return mock_streaming_response
+
             async def __aexit__(self, *args):
                 pass
+
         return StreamContextManager()
-    
+
     mock_async_client.stream = mock_stream
-    
+
     # Mock context manager
     mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
     mock_async_client.__aexit__ = AsyncMock()
     mock_async_client.aclose = AsyncMock()
     mock_async_client.is_closed = False
 
-    # Patch AsyncClient in modules where it's used
+    # Patch AsyncClient in modules where it's used. account_manager is absent on
+    # purpose: it owns no client and reaches upstream through KiroHttpClient.
     patchers = [
-        patch('kiro.auth.httpx.AsyncClient', return_value=mock_async_client),
-        patch('kiro.http_client.httpx.AsyncClient', return_value=mock_async_client),
-        patch('kiro.streaming_openai.httpx.AsyncClient', return_value=mock_async_client),
-        patch('kiro.account_manager.httpx.AsyncClient', return_value=mock_async_client),
+        patch("kiro.auth.httpx.AsyncClient", return_value=mock_async_client),
+        patch("kiro.http_client.httpx.AsyncClient", return_value=mock_async_client),
+        patch("kiro.streaming_openai.httpx.AsyncClient", return_value=mock_async_client),
     ]
-    
+
     # Start patchers
     for patcher in patchers:
         patcher.start()
-    
+
     print("🛡️ GLOBAL NETWORK BLOCKING ACTIVATED")
-    
+
     yield
 
     # Stop patchers
     for patcher in patchers:
         patcher.stop()
-    
+
     print("🛡️ GLOBAL NETWORK BLOCKING DEACTIVATED")
 
 
 # =============================================================================
 # Application Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def clean_app():
@@ -555,6 +545,7 @@ def clean_app():
     """
     print("Importing application for test...")
     from main import app
+
     # Reset all dependency overrides before test
     app.dependency_overrides = {}
     return app
@@ -578,12 +569,12 @@ async def async_test_client(clean_app):
     Creates an asynchronous test client for async endpoints.
     """
     print("Creating async test client...")
-    from httpx import AsyncClient, ASGITransport
-    
+    from httpx import ASGITransport, AsyncClient
+
     transport = ASGITransport(app=clean_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
-    
+
     print("Closing async test client...")
 
 
@@ -591,25 +582,26 @@ async def async_test_client(clean_app):
 # KiroAuthManager Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def mock_auth_manager():
     """
     Creates a mocked KiroAuthManager for tests.
     """
     from kiro.auth import KiroAuthManager
-    
+
     manager = KiroAuthManager(
         refresh_token="test_refresh_token",
         profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        region="us-east-1"
+        region="us-east-1",
     )
-    
+
     # Set valid token
     manager._access_token = "test_access_token"
     manager._expires_at = datetime.now(timezone.utc).replace(
         year=2099  # Far in the future
     )
-    
+
     return manager
 
 
@@ -619,25 +611,26 @@ def expired_auth_manager():
     Creates a KiroAuthManager with an expired token.
     """
     from kiro.auth import KiroAuthManager
-    
+
     manager = KiroAuthManager(
         refresh_token="test_refresh_token",
         profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        region="us-east-1"
+        region="us-east-1",
     )
-    
+
     # Set expired token
     manager._access_token = "expired_token"
     manager._expires_at = datetime.now(timezone.utc).replace(
         year=2020  # In the past
     )
-    
+
     return manager
 
 
 # =============================================================================
 # ModelInfoCache Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def sample_models_data():
@@ -648,27 +641,18 @@ def sample_models_data():
         {
             "modelId": "claude-sonnet-4",
             "displayName": "Claude Sonnet 4",
-            "tokenLimits": {
-                "maxInputTokens": 200000,
-                "maxOutputTokens": 8192
-            }
+            "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
         },
         {
             "modelId": "claude-opus-4.5",
             "displayName": "Claude Opus 4.5",
-            "tokenLimits": {
-                "maxInputTokens": 200000,
-                "maxOutputTokens": 8192
-            }
+            "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
         },
         {
             "modelId": "claude-haiku-4.5",
             "displayName": "Claude Haiku 4.5",
-            "tokenLimits": {
-                "maxInputTokens": 100000,
-                "maxOutputTokens": 4096
-            }
-        }
+            "tokenLimits": {"maxInputTokens": 100000, "maxOutputTokens": 4096},
+        },
     ]
 
 
@@ -678,6 +662,7 @@ def empty_model_cache():
     Creates an empty ModelInfoCache.
     """
     from kiro.cache import ModelInfoCache
+
     return ModelInfoCache()
 
 
@@ -687,7 +672,7 @@ async def populated_model_cache(mock_kiro_models_response):
     Creates a ModelInfoCache with pre-populated data.
     """
     from kiro.cache import ModelInfoCache
-    
+
     cache = ModelInfoCache()
     await cache.update(mock_kiro_models_response["models"])
     return cache
@@ -697,12 +682,13 @@ async def populated_model_cache(mock_kiro_models_response):
 # Time Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def mock_time():
     """
     Mocks time.time() for predictable behavior in tests.
     """
-    with patch('time.time') as mock:
+    with patch("time.time") as mock:
         # Fixed point in time: 2024-01-01 12:00:00
         mock.return_value = 1704110400.0
         yield mock
@@ -714,8 +700,8 @@ def mock_datetime():
     Mocks datetime.now() for predictable behavior.
     """
     fixed_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    
-    with patch('kiro.auth.datetime') as mock_dt:
+
+    with patch("kiro.auth.datetime") as mock_dt:
         mock_dt.now.return_value = fixed_time
         mock_dt.fromisoformat = datetime.fromisoformat
         mock_dt.fromtimestamp = datetime.fromtimestamp
@@ -725,6 +711,7 @@ def mock_datetime():
 # =============================================================================
 # Temporary File Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def temp_creds_file(tmp_path):
@@ -737,7 +724,7 @@ def temp_creds_file(tmp_path):
         "refreshToken": "file_refresh_token",
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
     creds_file.write_text(json.dumps(creds_data))
     return str(creds_file)
@@ -756,7 +743,7 @@ def temp_aws_sso_creds_file(tmp_path):
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "region": "us-east-1",
         "clientId": "test_client_id_12345",
-        "clientSecret": "test_client_secret_67890"
+        "clientSecret": "test_client_secret_67890",
     }
     creds_file.write_text(json.dumps(creds_data))
     return str(creds_file)
@@ -766,17 +753,17 @@ def temp_aws_sso_creds_file(tmp_path):
 def temp_sqlite_db(tmp_path):
     """
     Creates a temporary SQLite database for tests (kiro-cli format).
-    
+
     Contains auth_kv table with keys:
     - 'codewhisperer:odic:token': JSON with access_token, refresh_token, expires_at, region
     - 'codewhisperer:odic:device-registration': JSON with client_id, client_secret
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -784,33 +771,32 @@ def temp_sqlite_db(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert token data
     token_data = {
         "access_token": "sqlite_access_token",
         "refresh_token": "sqlite_refresh_token",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "eu-west-1"
+        "region": "eu-west-1",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    
+
     # Insert device registration data
     registration_data = {
         "client_id": "sqlite_client_id",
         "client_secret": "sqlite_client_secret",
-        "region": "eu-west-1"
+        "region": "eu-west-1",
     }
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+        ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -821,31 +807,30 @@ def temp_sqlite_db_token_only(tmp_path):
     Used for testing partial loading.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_token_only.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     cursor.execute("""
         CREATE TABLE auth_kv (
             key TEXT PRIMARY KEY,
             value TEXT
         )
     """)
-    
+
     token_data = {
         "access_token": "partial_access_token",
         "refresh_token": "partial_refresh_token",
-        "region": "ap-southeast-1"
+        "region": "ap-southeast-1",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -856,27 +841,26 @@ def temp_sqlite_db_invalid_json(tmp_path):
     Used for testing error handling.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_invalid.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     cursor.execute("""
         CREATE TABLE auth_kv (
             key TEXT PRIMARY KEY,
             value TEXT
         )
     """)
-    
+
     # Insert invalid JSON
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", "not a valid json {{{")
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", "not a valid json {{{")
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -885,17 +869,19 @@ def mock_aws_sso_oidc_token_response():
     """
     Factory for creating mock AWS SSO OIDC token endpoint responses.
     """
+
     def _create_response(
         access_token: str = "new_aws_sso_access_token",
         refresh_token: str = "new_aws_sso_refresh_token",
-        expires_in: int = 3600
+        expires_in: int = 3600,
     ):
         return {
             "accessToken": access_token,
             "refreshToken": refresh_token,
             "expiresIn": expires_in,
-            "tokenType": "Bearer"
+            "tokenType": "Bearer",
         }
+
     return _create_response
 
 
@@ -913,18 +899,21 @@ def temp_debug_dir(tmp_path):
 # Parser Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def aws_event_parser():
     """
     Creates an AwsEventStreamParser instance for tests.
     """
     from kiro.parsers import AwsEventStreamParser
+
     return AwsEventStreamParser()
 
 
 # =============================================================================
 # Test Utilities
 # =============================================================================
+
 
 def create_kiro_content_chunk(content: str) -> bytes:
     """Utility for creating a Kiro SSE chunk with content."""
@@ -961,22 +950,23 @@ def create_kiro_context_usage_chunk(percentage: float) -> bytes:
 # Social Login Fixtures (for new functionality)
 # =============================================================================
 
+
 @pytest.fixture
 def temp_sqlite_db_social(tmp_path):
     """
     Creates a temporary SQLite database with social login credentials.
-    
+
     Contains auth_kv table with key:
     - 'kirocli:social:token': JSON with access_token, refresh_token, expires_at, provider
-    
+
     This simulates kiro-cli with Google/GitHub social login (no client_id/client_secret).
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_social.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -984,7 +974,7 @@ def temp_sqlite_db_social(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert social login token data
     token_data = {
         "access_token": "social_access_token",
@@ -992,16 +982,13 @@ def temp_sqlite_db_social(tmp_path):
         "expires_at": "2099-01-01T00:00:00Z",
         "provider": "google",
         "profile_arn": "arn:aws:codewhisperer:us-east-1:123456789:profile/social",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
-    cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("kirocli:social:token", json.dumps(token_data))
-    )
-    
+    cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data)))
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -1009,60 +996,49 @@ def temp_sqlite_db_social(tmp_path):
 def temp_sqlite_db_all_keys(tmp_path):
     """
     Creates a SQLite database with ALL three token keys.
-    
+
     Used for testing key priority:
     1. kirocli:social:token (highest priority)
     2. kirocli:odic:token
     3. codewhisperer:odic:token (lowest priority)
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_all_keys.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     cursor.execute("""
         CREATE TABLE auth_kv (
             key TEXT PRIMARY KEY,
             value TEXT
         )
     """)
-    
+
     # Insert all three keys with different tokens
     social_data = {
         "access_token": "social_token",
         "refresh_token": "social_refresh",
         "expires_at": "2099-01-01T00:00:00Z",
-        "provider": "google"
+        "provider": "google",
     }
-    cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("kirocli:social:token", json.dumps(social_data))
-    )
-    
-    odic_data = {
-        "access_token": "odic_token",
-        "refresh_token": "odic_refresh",
-        "expires_at": "2099-01-01T00:00:00Z"
-    }
-    cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("kirocli:odic:token", json.dumps(odic_data))
-    )
-    
+    cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(social_data)))
+
+    odic_data = {"access_token": "odic_token", "refresh_token": "odic_refresh", "expires_at": "2099-01-01T00:00:00Z"}
+    cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(odic_data)))
+
     legacy_data = {
         "access_token": "legacy_token",
         "refresh_token": "legacy_refresh",
-        "expires_at": "2099-01-01T00:00:00Z"
+        "expires_at": "2099-01-01T00:00:00Z",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(legacy_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(legacy_data))
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -1070,15 +1046,16 @@ def temp_sqlite_db_all_keys(tmp_path):
 # Enterprise Kiro IDE Fixtures (Issue #45)
 # =============================================================================
 
+
 @pytest.fixture
 def temp_enterprise_ide_creds_file(tmp_path):
     """
     Creates a temporary credentials file for Enterprise Kiro IDE.
-    
+
     Contains:
     - clientIdHash: Hash used to locate device registration file
     - refreshToken, accessToken, expiresAt, region
-    
+
     This simulates Enterprise Kiro IDE with IdC (AWS IAM Identity Center) login.
     """
     creds_file = tmp_path / "kiro-auth-token.json"
@@ -1088,7 +1065,7 @@ def temp_enterprise_ide_creds_file(tmp_path):
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/enterprise",
         "region": "us-east-1",
-        "clientIdHash": "abc123def456"
+        "clientIdHash": "abc123def456",
     }
     creds_file.write_text(json.dumps(creds_data))
     return str(creds_file)
@@ -1098,23 +1075,23 @@ def temp_enterprise_ide_creds_file(tmp_path):
 def temp_enterprise_device_registration(tmp_path):
     """
     Creates a temporary device registration file for Enterprise Kiro IDE.
-    
+
     Located at: ~/.aws/sso/cache/{clientIdHash}.json
     Contains: clientId, clientSecret
     """
     # Create .aws/sso/cache directory structure
     aws_dir = tmp_path / ".aws" / "sso" / "cache"
     aws_dir.mkdir(parents=True, exist_ok=True)
-    
+
     # Create device registration file
     device_reg_file = aws_dir / "abc123def456.json"
     device_reg_data = {
         "clientId": "enterprise_client_id_12345",
         "clientSecret": "enterprise_client_secret_67890",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
     device_reg_file.write_text(json.dumps(device_reg_data))
-    
+
     return str(device_reg_file)
 
 
@@ -1122,12 +1099,12 @@ def temp_enterprise_device_registration(tmp_path):
 def temp_enterprise_ide_complete(tmp_path, monkeypatch):
     """
     Creates a complete Enterprise IDE setup with both credentials and device registration.
-    
+
     Returns tuple: (creds_file_path, device_reg_file_path)
     """
     # Mock Path.home() to return tmp_path
-    monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
-    
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
     # Create credentials file
     creds_file = tmp_path / "kiro-auth-token.json"
     creds_data = {
@@ -1136,22 +1113,22 @@ def temp_enterprise_ide_complete(tmp_path, monkeypatch):
         "expiresAt": "2099-01-01T00:00:00.000Z",
         "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/enterprise",
         "region": "us-east-1",
-        "clientIdHash": "abc123def456"
+        "clientIdHash": "abc123def456",
     }
     creds_file.write_text(json.dumps(creds_data))
-    
+
     # Create device registration file
     aws_dir = tmp_path / ".aws" / "sso" / "cache"
     aws_dir.mkdir(parents=True, exist_ok=True)
-    
+
     device_reg_file = aws_dir / "abc123def456.json"
     device_reg_data = {
         "clientId": "enterprise_client_id_12345",
         "clientSecret": "enterprise_client_secret_67890",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
     device_reg_file.write_text(json.dumps(device_reg_data))
-    
+
     return (str(creds_file), str(device_reg_file))
 
 
@@ -1159,23 +1136,24 @@ def temp_enterprise_ide_complete(tmp_path, monkeypatch):
 # API Region Auto-Detection Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def temp_sqlite_db_with_profile_arn(tmp_path):
     """
     Creates SQLite database with state table containing profile ARN.
-    
+
     Tables:
     - auth_kv: token data with SSO region=eu-west-1
     - state: profile ARN with API region=eu-central-1
-    
+
     This simulates kiro-cli with profile ARN that has different API region.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_with_arn.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -1183,30 +1161,25 @@ def temp_sqlite_db_with_profile_arn(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert token data with SSO region
     token_data = {
         "access_token": "arn_access_token",
         "refresh_token": "arn_refresh_token",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "eu-west-1"  # SSO region
+        "region": "eu-west-1",  # SSO region
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    
+
     # Insert device registration
-    registration_data = {
-        "client_id": "test_client_id",
-        "client_secret": "test_client_secret",
-        "region": "eu-west-1"
-    }
+    registration_data = {"client_id": "test_client_id", "client_secret": "test_client_secret", "region": "eu-west-1"}
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+        ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
     )
-    
+
     # Create state table with profile ARN
     cursor.execute("""
         CREATE TABLE state (
@@ -1214,20 +1187,19 @@ def temp_sqlite_db_with_profile_arn(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert profile with ARN containing different API region
     profile_data = {
         "arn": "arn:aws:codewhisperer:eu-central-1:123456789012:profile/test-profile",
-        "name": "test-profile"
+        "name": "test-profile",
     }
     cursor.execute(
-        "INSERT INTO state (key, value) VALUES (?, ?)",
-        ("api.codewhisperer.profile", json.dumps(profile_data))
+        "INSERT INTO state (key, value) VALUES (?, ?)", ("api.codewhisperer.profile", json.dumps(profile_data))
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -1235,15 +1207,15 @@ def temp_sqlite_db_with_profile_arn(tmp_path):
 def temp_sqlite_db_with_empty_state_table(tmp_path):
     """
     Creates SQLite database with empty state table (no profile key).
-    
+
     Used for testing fallback behavior when state table exists but has no profile.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_empty_state.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -1251,19 +1223,18 @@ def temp_sqlite_db_with_empty_state_table(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert token data
     token_data = {
         "access_token": "empty_state_access",
         "refresh_token": "empty_state_refresh",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "us-west-2"
+        "region": "us-west-2",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    
+
     # Create empty state table
     cursor.execute("""
         CREATE TABLE state (
@@ -1271,23 +1242,25 @@ def temp_sqlite_db_with_empty_state_table(tmp_path):
             value TEXT
         )
     """)
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
-@pytest.fixture(params=[
-    "not-an-arn",
-    "arn:aws:codewhisperer",
-    "arn:aws:codewhisperer:INVALID_REGION:account:profile",
-    "arn:aws:codewhisperer::account:profile",
-])
+@pytest.fixture(
+    params=[
+        "not-an-arn",
+        "arn:aws:codewhisperer",
+        "arn:aws:codewhisperer:INVALID_REGION:account:profile",
+        "arn:aws:codewhisperer::account:profile",
+    ]
+)
 def temp_sqlite_db_with_invalid_arn(tmp_path, request):
     """
     Creates SQLite database with invalid ARN formats.
-    
+
     Parametrized fixture that tests various invalid ARN formats:
     - Not an ARN at all
     - Too short ARN
@@ -1295,11 +1268,11 @@ def temp_sqlite_db_with_invalid_arn(tmp_path, request):
     - Empty region
     """
     import sqlite3
-    
+
     db_file = tmp_path / f"data_invalid_arn_{request.param_index}.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -1307,19 +1280,18 @@ def temp_sqlite_db_with_invalid_arn(tmp_path, request):
             value TEXT
         )
     """)
-    
+
     # Insert token data
     token_data = {
         "access_token": "invalid_arn_access",
         "refresh_token": "invalid_arn_refresh",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "ap-southeast-1"
+        "region": "ap-southeast-1",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    
+
     # Create state table with invalid ARN
     cursor.execute("""
         CREATE TABLE state (
@@ -1327,19 +1299,18 @@ def temp_sqlite_db_with_invalid_arn(tmp_path, request):
             value TEXT
         )
     """)
-    
+
     profile_data = {
         "arn": request.param,  # Invalid ARN from parametrize
-        "name": "test-profile"
+        "name": "test-profile",
     }
     cursor.execute(
-        "INSERT INTO state (key, value) VALUES (?, ?)",
-        ("api.codewhisperer.profile", json.dumps(profile_data))
+        "INSERT INTO state (key, value) VALUES (?, ?)", ("api.codewhisperer.profile", json.dumps(profile_data))
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -1347,15 +1318,15 @@ def temp_sqlite_db_with_invalid_arn(tmp_path, request):
 def temp_sqlite_db_with_malformed_state_json(tmp_path):
     """
     Creates SQLite database with malformed JSON in state table.
-    
+
     Used for testing graceful error handling when state table contains invalid JSON.
     """
     import sqlite3
-    
+
     db_file = tmp_path / "data_malformed_state.sqlite3"
     conn = sqlite3.connect(str(db_file))
     cursor = conn.cursor()
-    
+
     # Create auth_kv table
     cursor.execute("""
         CREATE TABLE auth_kv (
@@ -1363,19 +1334,18 @@ def temp_sqlite_db_with_malformed_state_json(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert token data
     token_data = {
         "access_token": "malformed_state_access",
         "refresh_token": "malformed_state_refresh",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "ap-south-1"
+        "region": "ap-south-1",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    
+
     # Create state table with malformed JSON
     cursor.execute("""
         CREATE TABLE state (
@@ -1383,16 +1353,15 @@ def temp_sqlite_db_with_malformed_state_json(tmp_path):
             value TEXT
         )
     """)
-    
+
     # Insert malformed JSON
     cursor.execute(
-        "INSERT INTO state (key, value) VALUES (?, ?)",
-        ("api.codewhisperer.profile", "not a valid json {{{")
+        "INSERT INTO state (key, value) VALUES (?, ?)", ("api.codewhisperer.profile", "not a valid json {{{")
     )
-    
+
     conn.commit()
     conn.close()
-    
+
     return str(db_file)
 
 
@@ -1400,18 +1369,13 @@ def temp_sqlite_db_with_malformed_state_json(tmp_path):
 # Account System Fixtures
 # =============================================================================
 
+
 @pytest.fixture
 def sample_credentials_single_account():
     """
     Sample credentials.json with single account (JSON type).
     """
-    return [
-        {
-            "type": "json",
-            "path": "~/.aws/sso/cache/kiro-auth-token.json",
-            "enabled": True
-        }
-    ]
+    return [{"type": "json", "path": "~/.aws/sso/cache/kiro-auth-token.json", "enabled": True}]
 
 
 @pytest.fixture
@@ -1420,23 +1384,15 @@ def sample_credentials_multi_account():
     Sample credentials.json with multiple accounts (different types).
     """
     return [
-        {
-            "type": "json",
-            "path": "~/.aws/sso/cache/main.json",
-            "enabled": True
-        },
-        {
-            "type": "sqlite",
-            "path": "~/.local/share/kiro-cli/data.sqlite3",
-            "enabled": True
-        },
+        {"type": "json", "path": "~/.aws/sso/cache/main.json", "enabled": True},
+        {"type": "sqlite", "path": "~/.local/share/kiro-cli/data.sqlite3", "enabled": True},
         {
             "type": "refresh_token",
             "refresh_token": "eyJhbGc...",
             "profile_arn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
             "region": "us-east-1",
-            "enabled": True
-        }
+            "enabled": True,
+        },
     ]
 
 
@@ -1445,13 +1401,7 @@ def sample_credentials_with_folder():
     """
     Sample credentials.json with folder scanning.
     """
-    return [
-        {
-            "type": "json",
-            "path": "/home/user/kiro-accounts/",
-            "enabled": True
-        }
-    ]
+    return [{"type": "json", "path": "/home/user/kiro-accounts/", "enabled": True}]
 
 
 @pytest.fixture
@@ -1460,16 +1410,8 @@ def sample_credentials_with_disabled():
     Sample credentials.json with disabled account.
     """
     return [
-        {
-            "type": "json",
-            "path": "~/.aws/sso/cache/main.json",
-            "enabled": True
-        },
-        {
-            "type": "json",
-            "path": "~/.aws/sso/cache/disabled.json",
-            "enabled": False
-        }
+        {"type": "json", "path": "~/.aws/sso/cache/main.json", "enabled": True},
+        {"type": "json", "path": "~/.aws/sso/cache/disabled.json", "enabled": False},
     ]
 
 
@@ -1485,7 +1427,7 @@ def sample_credentials_with_overrides():
             "enabled": True,
             "profile_arn": "arn:aws:codewhisperer:eu-central-1:123456789:profile/eu",
             "region": "eu-west-1",
-            "api_region": "eu-central-1"
+            "api_region": "eu-central-1",
         }
     ]
 
@@ -1495,11 +1437,7 @@ def sample_state_empty():
     """
     Empty state.json (initial state).
     """
-    return {
-        "current_account_index": 0,
-        "model_to_accounts": {},
-        "accounts": {}
-    }
+    return {"current_account_index": 0, "model_to_accounts": {}, "accounts": {}}
 
 
 @pytest.fixture
@@ -1511,37 +1449,24 @@ def sample_state_with_data():
         "current_account_index": 0,
         "model_to_accounts": {
             "claude-opus-4.5": {
-                "accounts": [
-                    "/home/user/.aws/sso/cache/main.json",
-                    "/home/user/.local/share/kiro-cli/data.sqlite3"
-                ]
+                "accounts": ["/home/user/.aws/sso/cache/main.json", "/home/user/.local/share/kiro-cli/data.sqlite3"]
             },
-            "claude-sonnet-4.5": {
-                "accounts": ["/home/user/.aws/sso/cache/main.json"]
-            }
+            "claude-sonnet-4.5": {"accounts": ["/home/user/.aws/sso/cache/main.json"]},
         },
         "accounts": {
             "/home/user/.aws/sso/cache/main.json": {
                 "failures": 0,
                 "last_failure_time": 0.0,
                 "models_cached_at": 1704110400.0,
-                "stats": {
-                    "total_requests": 150,
-                    "successful_requests": 145,
-                    "failed_requests": 5
-                }
+                "stats": {"total_requests": 150, "successful_requests": 145, "failed_requests": 5},
             },
             "/home/user/.local/share/kiro-cli/data.sqlite3": {
                 "failures": 2,
                 "last_failure_time": 1704114000.0,
                 "models_cached_at": 1704106800.0,
-                "stats": {
-                    "total_requests": 50,
-                    "successful_requests": 48,
-                    "failed_requests": 2
-                }
-            }
-        }
+                "stats": {"total_requests": 50, "successful_requests": 48, "failed_requests": 2},
+            },
+        },
     }
 
 
@@ -1554,10 +1479,7 @@ def sample_state_with_failures():
         "current_account_index": 0,
         "model_to_accounts": {
             "claude-opus-4.5": {
-                "accounts": [
-                    "/home/user/.aws/sso/cache/main.json",
-                    "/home/user/.aws/sso/cache/backup.json"
-                ]
+                "accounts": ["/home/user/.aws/sso/cache/main.json", "/home/user/.aws/sso/cache/backup.json"]
             }
         },
         "accounts": {
@@ -1565,23 +1487,15 @@ def sample_state_with_failures():
                 "failures": 5,
                 "last_failure_time": 1704110400.0,
                 "models_cached_at": 1704106800.0,
-                "stats": {
-                    "total_requests": 100,
-                    "successful_requests": 95,
-                    "failed_requests": 5
-                }
+                "stats": {"total_requests": 100, "successful_requests": 95, "failed_requests": 5},
             },
             "/home/user/.aws/sso/cache/backup.json": {
                 "failures": 0,
                 "last_failure_time": 0.0,
                 "models_cached_at": 1704110400.0,
-                "stats": {
-                    "total_requests": 10,
-                    "successful_requests": 10,
-                    "failed_requests": 0
-                }
-            }
-        }
+                "stats": {"total_requests": 10, "successful_requests": 10, "failed_requests": 0},
+            },
+        },
     }
 
 
@@ -1589,17 +1503,18 @@ def sample_state_with_failures():
 def temp_credentials_json(tmp_path, sample_credentials_single_account):
     """
     Creates a temporary credentials.json file.
-    
+
     Factory fixture that accepts credentials data.
     """
+
     def _create_file(credentials_data=None):
         if credentials_data is None:
             credentials_data = sample_credentials_single_account
-        
+
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps(credentials_data, indent=2))
         return str(creds_file)
-    
+
     return _create_file
 
 
@@ -1607,17 +1522,18 @@ def temp_credentials_json(tmp_path, sample_credentials_single_account):
 def temp_state_json(tmp_path, sample_state_empty):
     """
     Creates a temporary state.json file.
-    
+
     Factory fixture that accepts state data.
     """
+
     def _create_file(state_data=None):
         if state_data is None:
             state_data = sample_state_empty
-        
+
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data, indent=2))
         return str(state_file)
-    
+
     return _create_file
 
 
@@ -1625,39 +1541,47 @@ def temp_state_json(tmp_path, sample_state_empty):
 def temp_credentials_folder(tmp_path):
     """
     Creates a temporary folder with multiple credential files.
-    
+
     Returns tuple: (folder_path, list_of_created_files)
     """
     folder = tmp_path / "kiro-accounts"
     folder.mkdir()
-    
+
     # Create valid JSON credentials
     valid_file1 = folder / "account1.json"
-    valid_file1.write_text(json.dumps({
-        "accessToken": "token1",
-        "refreshToken": "refresh1",
-        "expiresAt": "2099-01-01T00:00:00.000Z",
-        "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test1",
-        "region": "us-east-1"
-    }))
-    
+    valid_file1.write_text(
+        json.dumps(
+            {
+                "accessToken": "token1",
+                "refreshToken": "refresh1",
+                "expiresAt": "2099-01-01T00:00:00.000Z",
+                "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test1",
+                "region": "us-east-1",
+            }
+        )
+    )
+
     valid_file2 = folder / "account2.json"
-    valid_file2.write_text(json.dumps({
-        "accessToken": "token2",
-        "refreshToken": "refresh2",
-        "expiresAt": "2099-01-01T00:00:00.000Z",
-        "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test2",
-        "region": "us-east-1"
-    }))
-    
+    valid_file2.write_text(
+        json.dumps(
+            {
+                "accessToken": "token2",
+                "refreshToken": "refresh2",
+                "expiresAt": "2099-01-01T00:00:00.000Z",
+                "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test2",
+                "region": "us-east-1",
+            }
+        )
+    )
+
     # Create invalid file (should be skipped)
     invalid_file = folder / "invalid.json"
     invalid_file.write_text("not a valid json {{{")
-    
+
     # Create non-JSON file (should be skipped)
     text_file = folder / "readme.txt"
     text_file.write_text("This is not a credentials file")
-    
+
     return (str(folder), [str(valid_file1), str(valid_file2)])
 
 
@@ -1670,27 +1594,22 @@ def mock_account():
     from kiro.auth import KiroAuthManager
     from kiro.cache import ModelInfoCache
     from kiro.model_resolver import ModelResolver
-    
+
     # Create mock auth_manager
     auth_manager = KiroAuthManager(
         refresh_token="test_refresh_token",
         profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-        region="us-east-1"
+        region="us-east-1",
     )
     auth_manager._access_token = "test_access_token"
     auth_manager._expires_at = datetime(2099, 1, 1, tzinfo=timezone.utc)
-    
+
     # Create mock model_cache
     model_cache = ModelInfoCache()
-    
+
     # Create mock model_resolver
-    model_resolver = ModelResolver(
-        cache=model_cache,
-        hidden_models={},
-        aliases={},
-        hidden_from_list=set()
-    )
-    
+    model_resolver = ModelResolver(cache=model_cache, hidden_models={}, aliases={}, hidden_from_list=set())
+
     # Create Account
     account = Account(
         id="/home/user/.aws/sso/cache/test.json",
@@ -1700,9 +1619,9 @@ def mock_account():
         failures=0,
         last_failure_time=0.0,
         models_cached_at=time.time(),
-        stats=AccountStats()
+        stats=AccountStats(),
     )
-    
+
     return account
 
 
@@ -1710,47 +1629,43 @@ def mock_account():
 def mock_account_manager(tmp_path):
     """
     Creates a mock AccountManager with temporary files.
-    
+
     Factory fixture that accepts credentials and state data.
     """
+
     async def _create_manager(credentials_data=None, state_data=None):
         from kiro.account_manager import AccountManager
-        
+
         # Create temporary files
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         if credentials_data is None:
-            credentials_data = [
-                {
-                    "type": "json",
-                    "path": str(tmp_path / "test.json"),
-                    "enabled": True
-                }
-            ]
+            credentials_data = [{"type": "json", "path": str(tmp_path / "test.json"), "enabled": True}]
             # Create the test.json file
             test_creds = tmp_path / "test.json"
-            test_creds.write_text(json.dumps({
-                "accessToken": "test_token",
-                "refreshToken": "test_refresh",
-                "expiresAt": "2099-01-01T00:00:00.000Z",
-                "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-                "region": "us-east-1"
-            }))
-        
+            test_creds.write_text(
+                json.dumps(
+                    {
+                        "accessToken": "test_token",
+                        "refreshToken": "test_refresh",
+                        "expiresAt": "2099-01-01T00:00:00.000Z",
+                        "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
+                        "region": "us-east-1",
+                    }
+                )
+            )
+
         creds_file.write_text(json.dumps(credentials_data, indent=2))
-        
+
         if state_data is not None:
             state_file.write_text(json.dumps(state_data, indent=2))
-        
+
         # Create AccountManager
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(state_file)
-        )
-        
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(state_file))
+
         return manager
-    
+
     return _create_manager
 
 
@@ -1758,7 +1673,7 @@ def mock_account_manager(tmp_path):
 def mock_list_models_response():
     """
     Mock response from Kiro API /ListAvailableModels endpoint.
-    
+
     Returns list of models for account initialization.
     """
     return {
@@ -1766,27 +1681,18 @@ def mock_list_models_response():
             {
                 "modelId": "claude-opus-4.5",
                 "displayName": "Claude Opus 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-sonnet-4.5",
                 "displayName": "Claude Sonnet 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 200000,
-                    "maxOutputTokens": 8192
-                }
+                "tokenLimits": {"maxInputTokens": 200000, "maxOutputTokens": 8192},
             },
             {
                 "modelId": "claude-haiku-4.5",
                 "displayName": "Claude Haiku 4.5",
-                "tokenLimits": {
-                    "maxInputTokens": 100000,
-                    "maxOutputTokens": 4096
-                }
-            }
+                "tokenLimits": {"maxInputTokens": 100000, "maxOutputTokens": 4096},
+            },
         ]
     }
 
@@ -1796,19 +1702,14 @@ def mock_kiro_error_response():
     """
     Factory for creating mock Kiro API error responses.
     """
+
     def _create_error(status_code: int, reason: str = None, message: str = None):
-        error_data = {
-            "message": message or "Improperly formed request."
-        }
+        error_data = {"message": message or "Improperly formed request."}
         if reason:
             error_data["reason"] = reason
-        
-        return {
-            "status_code": status_code,
-            "json": error_data,
-            "text": json.dumps(error_data)
-        }
-    
+
+        return {"status_code": status_code, "json": error_data, "text": json.dumps(error_data)}
+
     return _create_error
 
 
@@ -1816,36 +1717,45 @@ def mock_kiro_error_response():
 def temp_account_credentials_files(tmp_path):
     """
     Creates multiple temporary credential files for multi-account testing.
-    
+
     Returns dict with account_id -> file_path mapping.
     """
     files = {}
-    
+
     # Account 1: JSON (Kiro Desktop)
     account1 = tmp_path / "account1.json"
-    account1.write_text(json.dumps({
-        "accessToken": "token1",
-        "refreshToken": "refresh1",
-        "expiresAt": "2099-01-01T00:00:00.000Z",
-        "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test1",
-        "region": "us-east-1"
-    }))
+    account1.write_text(
+        json.dumps(
+            {
+                "accessToken": "token1",
+                "refreshToken": "refresh1",
+                "expiresAt": "2099-01-01T00:00:00.000Z",
+                "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test1",
+                "region": "us-east-1",
+            }
+        )
+    )
     files["account1"] = str(account1)
-    
+
     # Account 2: JSON (AWS SSO OIDC)
     account2 = tmp_path / "account2.json"
-    account2.write_text(json.dumps({
-        "accessToken": "token2",
-        "refreshToken": "refresh2",
-        "expiresAt": "2099-01-01T00:00:00.000Z",
-        "region": "us-east-1",
-        "clientId": "client_id_2",
-        "clientSecret": "client_secret_2"
-    }))
+    account2.write_text(
+        json.dumps(
+            {
+                "accessToken": "token2",
+                "refreshToken": "refresh2",
+                "expiresAt": "2099-01-01T00:00:00.000Z",
+                "region": "us-east-1",
+                "clientId": "client_id_2",
+                "clientSecret": "client_secret_2",
+            }
+        )
+    )
     files["account2"] = str(account2)
-    
+
     # Account 3: SQLite
     import sqlite3
+
     account3 = tmp_path / "account3.sqlite3"
     conn = sqlite3.connect(str(account3))
     cursor = conn.cursor()
@@ -1859,23 +1769,18 @@ def temp_account_credentials_files(tmp_path):
         "access_token": "token3",
         "refresh_token": "refresh3",
         "expires_at": "2099-01-01T00:00:00Z",
-        "region": "us-east-1"
+        "region": "us-east-1",
     }
     cursor.execute(
-        "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:token", json.dumps(token_data))
+        "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
     )
-    registration_data = {
-        "client_id": "client_id_3",
-        "client_secret": "client_secret_3",
-        "region": "us-east-1"
-    }
+    registration_data = {"client_id": "client_id_3", "client_secret": "client_secret_3", "region": "us-east-1"}
     cursor.execute(
         "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-        ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+        ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
     )
     conn.commit()
     conn.close()
     files["account3"] = str(account3)
-    
+
     return files

--- a/tests/integration/debug_capture_probe.py
+++ b/tests/integration/debug_capture_probe.py
@@ -31,12 +31,11 @@ async def _run_probe(output: Path) -> None:
 
     app = FastAPI(lifespan=lifespan)
     app.add_middleware(DebugLoggerMiddleware)
+
     async def invalid_stream():
         begin_anthropic_stream()
         try:
-            debug_logger.log_kiro_request_body(
-                b'{"conversationState":{"currentMessage":{"content":"private"}}}'
-            )
+            debug_logger.log_kiro_request_body(b'{"conversationState":{"currentMessage":{"content":"private"}}}')
             debug_logger.log_raw_chunk(b'{"content":"answer"}')
             yield format_sse_event(
                 "message_start",
@@ -73,9 +72,7 @@ async def _run_probe(output: Path) -> None:
     listener.bind(("127.0.0.1", 0))
     listener.listen()
     port = listener.getsockname()[1]
-    server = uvicorn.Server(
-        uvicorn.Config(app, log_level="error", lifespan="on")
-    )
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="on"))
     server_task = asyncio.create_task(server.serve(sockets=[listener]))
     await asyncio.wait_for(started.wait(), timeout=5)
 
@@ -93,9 +90,7 @@ async def _run_probe(output: Path) -> None:
                 json={
                     "model": "claude-opus-5",
                     "max_tokens": 128,
-                    "messages": [
-                        {"role": "user", "content": "original private prompt"}
-                    ],
+                    "messages": [{"role": "user", "content": "original private prompt"}],
                 },
             ) as response:
                 http_status = response.status_code
@@ -109,11 +104,7 @@ async def _run_probe(output: Path) -> None:
         listener.close()
 
     failures_dir = debug_logger.debug_dir / "failures"
-    captures = sorted(
-        path
-        for path in failures_dir.iterdir()
-        if path.is_dir() and not path.name.startswith(".tmp-")
-    )
+    captures = sorted(path for path in failures_dir.iterdir() if path.is_dir() and not path.name.startswith(".tmp-"))
     replay_exit_code = 0
     if captures:
         try:
@@ -122,13 +113,18 @@ async def _run_probe(output: Path) -> None:
             failure = str(exc)
             replay_exit_code = 3
 
-    output.write_text(json.dumps({
-        "http_status": http_status,
-        "failure": failure,
-        "capture_count": len(captures),
-        "replay_exit_code": replay_exit_code,
-        "capture_dir": str(captures[-1]) if captures else None,
-    }, indent=2))
+    output.write_text(
+        json.dumps(
+            {
+                "http_status": http_status,
+                "failure": failure,
+                "capture_count": len(captures),
+                "replay_exit_code": replay_exit_code,
+                "capture_dir": str(captures[-1]) if captures else None,
+            },
+            indent=2,
+        )
+    )
 
 
 def main() -> None:

--- a/tests/integration/parser_integrity_probe.py
+++ b/tests/integration/parser_integrity_probe.py
@@ -10,9 +10,9 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 
+from kiro.sse_validation import AnthropicSSEValidator
 from kiro.streaming_anthropic import stream_kiro_to_anthropic
 from kiro.streaming_openai import stream_kiro_to_openai_internal
-from kiro.sse_validation import AnthropicSSEValidator
 
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
@@ -141,9 +141,7 @@ async def _run() -> dict[str, bool]:
     listener.bind(("127.0.0.1", 0))
     listener.listen()
     port = listener.getsockname()[1]
-    server = uvicorn.Server(
-        uvicorn.Config(app, log_level="error", lifespan="on")
-    )
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="on"))
     server_task = asyncio.create_task(server.serve(sockets=[listener]))
     await asyncio.wait_for(started.wait(), timeout=5)
 
@@ -152,9 +150,7 @@ async def _run() -> dict[str, bool]:
         async with httpx.AsyncClient(timeout=10) as client:
             for protocol in ("anthropic", "openai"):
                 for scenario in ("unicode", "tools"):
-                    response = await client.get(
-                        f"http://127.0.0.1:{port}/{protocol}/{scenario}"
-                    )
+                    response = await client.get(f"http://127.0.0.1:{port}/{protocol}/{scenario}")
                     results[f"{protocol}_{scenario}"] = {
                         "status": response.status_code,
                         "body": response.text,
@@ -170,9 +166,7 @@ async def _run() -> dict[str, bool]:
                 except httpx.RemoteProtocolError:
                     malformed_clean = False
                 results[f"{protocol}_malformed_clean"] = malformed_clean
-            chronology = await client.get(
-                f"http://127.0.0.1:{port}/anthropic/chronology"
-            )
+            chronology = await client.get(f"http://127.0.0.1:{port}/anthropic/chronology")
             results["anthropic_chronology"] = {
                 "status": chronology.status_code,
                 "body": chronology.text,
@@ -184,15 +178,12 @@ async def _run() -> dict[str, bool]:
             ]
 
             async def fetch_marker(protocol: str, marker: str):
-                response = await client.get(
-                    f"http://127.0.0.1:{port}/{protocol}/{marker}"
-                )
+                response = await client.get(f"http://127.0.0.1:{port}/{protocol}/{marker}")
                 return protocol, marker, response.status_code, response.text
 
-            results["parallel"] = await asyncio.gather(*(
-                fetch_marker(protocol, marker)
-                for protocol, marker in parallel_requests
-            ))
+            results["parallel"] = await asyncio.gather(
+                *(fetch_marker(protocol, marker) for protocol, marker in parallel_requests)
+            )
     finally:
         server.should_exit = True
         await asyncio.wait_for(server_task, timeout=5)
@@ -227,13 +218,15 @@ def _marker_chunks(marker: str) -> list[bytes]:
     position = 0
     width = 1
     while position < len(payload):
-        chunks.append(payload[position:position + width])
+        chunks.append(payload[position : position + width])
         position += width
         width = 1 if width == 4 else width + 1
-    chunks.extend([
-        b'{"stopReason":"END_TURN"}',
-        b'{"contextUsagePercentage":1}',
-    ])
+    chunks.extend(
+        [
+            b'{"stopReason":"END_TURN"}',
+            b'{"contextUsagePercentage":1}',
+        ]
+    )
     return chunks
 
 
@@ -248,52 +241,40 @@ def _summarize(results: dict[str, object]) -> dict[str, bool]:
     assert isinstance(openai_tools, dict)
     chronology = results["anthropic_chronology"]
     assert isinstance(chronology, dict)
-    chronology_valid, chronology_tools, chronology_signatures = (
-        _validate_chronology(str(chronology["body"]))
-    )
+    chronology_valid, chronology_tools, chronology_signatures = _validate_chronology(str(chronology["body"]))
     summary = {
         "anthropic_unicode": "你好🌍" in str(anthropic_unicode["body"]),
         "openai_unicode": "你好🌍" in str(openai_unicode["body"]),
-        "anthropic_tool_ids": all(
-            tool_id in str(anthropic_tools["body"])
-            for tool_id in ("toolu_A", "toolu_B")
-        ),
-        "openai_tool_ids": all(
-            tool_id in str(openai_tools["body"])
-            for tool_id in ("toolu_A", "toolu_B")
-        ),
-        "anthropic_malformed_clean": bool(
-            results["anthropic_malformed_clean"]
-        ),
+        "anthropic_tool_ids": all(tool_id in str(anthropic_tools["body"]) for tool_id in ("toolu_A", "toolu_B")),
+        "openai_tool_ids": all(tool_id in str(openai_tools["body"]) for tool_id in ("toolu_A", "toolu_B")),
+        "anthropic_malformed_clean": bool(results["anthropic_malformed_clean"]),
         "openai_malformed_clean": bool(results["openai_malformed_clean"]),
         "anthropic_chronology": chronology_valid,
         "anthropic_chronology_tools": chronology_tools,
         "anthropic_chronology_signatures": chronology_signatures,
         "parallel_isolated": _parallel_isolated(results["parallel"]),
     }
-    assert all([
-        summary["anthropic_unicode"],
-        summary["openai_unicode"],
-        summary["anthropic_tool_ids"],
-        summary["openai_tool_ids"],
-        not summary["anthropic_malformed_clean"],
-        not summary["openai_malformed_clean"],
-        summary["anthropic_chronology"],
-        summary["anthropic_chronology_tools"],
-        summary["anthropic_chronology_signatures"],
-        summary["parallel_isolated"],
-    ])
+    assert all(
+        [
+            summary["anthropic_unicode"],
+            summary["openai_unicode"],
+            summary["anthropic_tool_ids"],
+            summary["openai_tool_ids"],
+            not summary["anthropic_malformed_clean"],
+            not summary["openai_malformed_clean"],
+            summary["anthropic_chronology"],
+            summary["anthropic_chronology_tools"],
+            summary["anthropic_chronology_signatures"],
+            summary["parallel_isolated"],
+        ]
+    )
     return summary
 
 
 def _parallel_isolated(value: object) -> bool:
     assert isinstance(value, list)
     identifiers = {"anthropic": [], "openai": []}
-    all_markers = {
-        f"{protocol}-marker-{index:02d}"
-        for protocol in ("anthropic", "openai")
-        for index in range(16)
-    }
+    all_markers = {f"{protocol}-marker-{index:02d}" for protocol in ("anthropic", "openai") for index in range(16)}
     for item in value:
         protocol, marker, status, body = item
         if status != 200 or body.count(marker) != 1:
@@ -305,18 +286,13 @@ def _parallel_isolated(value: object) -> bool:
             if "chatcmpl-" in body:
                 return False
         else:
-            matches = set(
-                re.findall(r'"id":\s*"(chatcmpl-[^"]+)"', body)
-            )
+            matches = set(re.findall(r'"id":\s*"(chatcmpl-[^"]+)"', body))
             if re.search(r'"id":\s*"msg_', body):
                 return False
         if len(matches) != 1:
             return False
         identifiers[protocol].append(matches.pop())
-    return all(
-        len(protocol_ids) == 16 and len(set(protocol_ids)) == 16
-        for protocol_ids in identifiers.values()
-    )
+    return all(len(protocol_ids) == 16 and len(set(protocol_ids)) == 16 for protocol_ids in identifiers.values())
 
 
 def _validate_chronology(body: str) -> tuple[bool, bool, bool]:
@@ -340,11 +316,10 @@ def _validate_chronology(body: str) -> tuple[bool, bool, bool]:
             signatures.append((data["index"], data["delta"]["signature"]))
     validator.finish()
     types = [block["type"] for block in starts]
-    tool_ids = [
-        block["id"] for block in starts if block["type"] == "tool_use"
-    ]
+    tool_ids = [block["id"] for block in starts if block["type"] == "tool_use"]
     return (
-        types == [
+        types
+        == [
             "thinking",
             "text",
             "tool_use",

--- a/tests/integration/test_account_system_flow.py
+++ b/tests/integration/test_account_system_flow.py
@@ -12,184 +12,166 @@ Tests cover:
 - TTL refresh on usage
 """
 
-import asyncio
 import json
-import pytest
 import time
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
-from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import HTTPException
 
-from kiro.account_manager import AccountManager, Account, AccountStats, account_label
 from kiro.account_errors import ErrorType
+from kiro.account_manager import Account, AccountManager, account_label
 from kiro.config import ACCOUNT_RECOVERY_TIMEOUT
-
 
 # =============================================================================
 # Integration Tests: Full Failover Flow
 # =============================================================================
 
+
 class TestAccountSystemFullFlow:
     """
     Integration tests for complete Account System flow.
-    
+
     What it does: Tests end-to-end failover scenarios with multiple accounts
     Purpose: Verify Account System works correctly in realistic scenarios
     """
-    
+
     @pytest.mark.asyncio
     async def test_full_failover_flow_two_accounts(
-        self,
-        tmp_path,
-        temp_account_credentials_files,
-        mock_list_models_response
+        self, tmp_path, temp_account_credentials_files, mock_list_models_response
     ):
         """
         Test 137: Полный failover между двумя аккаунтами
-        
+
         What it does: Simulates complete failover from broken account to working one
         Purpose: Verify failover loop works end-to-end
         """
         print("\n=== Test 137: Full failover flow between two accounts ===")
-        
+
         # Arrange: Create credentials.json with two accounts
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         account1_path = temp_account_credentials_files["account1"]
         account2_path = temp_account_credentials_files["account2"]
-        
+
         credentials = [
             {"type": "json", "path": account1_path, "enabled": True},
-            {"type": "json", "path": account2_path, "enabled": True}
+            {"type": "json", "path": account2_path, "enabled": True},
         ]
         creds_file.write_text(json.dumps(credentials))
-        
+
         # Create AccountManager
         manager = AccountManager(str(creds_file), str(state_file))
         await manager.load_credentials()
         await manager.load_state()
-        
+
         print(f"Loaded {len(manager._accounts)} accounts")
-        
+
         # Mock initialization for both accounts
-        with patch.object(manager, '_initialize_account') as mock_init:
+        with patch.object(manager, "_initialize_account") as mock_init:
+
             async def mock_initialize(account_id):
                 # Create mock components
                 from kiro.auth import KiroAuthManager
                 from kiro.cache import ModelInfoCache
                 from kiro.model_resolver import ModelResolver
-                
+
                 account = manager._accounts[account_id]
-                
+
                 # Mock auth_manager
                 auth_manager = MagicMock(spec=KiroAuthManager)
                 auth_manager._access_token = f"token_{account_id}"
                 auth_manager.q_host = "https://api.example.com"
                 auth_manager.api_host = "https://api.example.com"
-                
+
                 # Mock model_cache with models
                 model_cache = ModelInfoCache()
                 await model_cache.update(mock_list_models_response["models"])
-                
+
                 # Mock model_resolver
-                model_resolver = ModelResolver(
-                    cache=model_cache,
-                    hidden_models={},
-                    aliases={},
-                    hidden_from_list=set()
-                )
-                
+                model_resolver = ModelResolver(cache=model_cache, hidden_models={}, aliases={}, hidden_from_list=set())
+
                 account.auth_manager = auth_manager
                 account.model_cache = model_cache
                 account.model_resolver = model_resolver
                 account.models_cached_at = time.time()
-                
+
                 # Update model_to_accounts
                 for model in model_resolver.get_available_models():
                     if model not in manager._model_to_accounts:
                         from kiro.account_manager import ModelAccountList
+
                         manager._model_to_accounts[model] = ModelAccountList()
                     if account_id not in manager._model_to_accounts[model].accounts:
                         manager._model_to_accounts[model].accounts.append(account_id)
-                
+
                 return True
-            
+
             mock_init.side_effect = mock_initialize
-            
+
             # Initialize both accounts
             for account_id in list(manager._accounts.keys()):
                 await manager._initialize_account(account_id)
-        
+
         print(f"Initialized accounts: {list(manager._accounts.keys())}")
-        
+
         # Act: Simulate failover scenario
         # 1. First account fails with RECOVERABLE error
         account1_id = list(manager._accounts.keys())[0]
-        await manager.report_failure(
-            account1_id,
-            "claude-opus-4.5",
-            ErrorType.RECOVERABLE,
-            429,
-            None
-        )
+        await manager.report_failure(account1_id, "claude-opus-4.5", ErrorType.RECOVERABLE, 429, None)
         print(f"Account 1 failed: failures={manager._accounts[account1_id].failures}")
-        
+
         # 2. Get next account (should return account2)
         # Mock random.random() to disable probabilistic retry (make test deterministic)
-        with patch('random.random', return_value=0.5):  # > 0.1 = no probabilistic retry
+        with patch("random.random", return_value=0.5):  # > 0.1 = no probabilistic retry
             next_account = await manager.get_next_account("claude-opus-4.5")
         account2_id = list(manager._accounts.keys())[1]
-        
+
         print(f"Next account: {next_account.id if next_account else None}")
         assert next_account is not None
         assert next_account.id == account2_id
-        
+
         # 3. Second account succeeds
         await manager.report_success(account2_id, "claude-opus-4.5")
         print(f"Account 2 succeeded: failures={manager._accounts[account2_id].failures}")
-        
+
         # 4. Verify sticky behavior - should prefer account2 now
         next_account_again = await manager.get_next_account("claude-opus-4.5")
         print(f"Next account (sticky): {next_account_again.id if next_account_again else None}")
         assert next_account_again.id == account2_id
-        
+
         print("✓ Full failover flow completed successfully")
-    
+
     @pytest.mark.asyncio
     async def test_sticky_behavior_success_updates_index(
-        self,
-        tmp_path,
-        temp_account_credentials_files,
-        mock_list_models_response
+        self, tmp_path, temp_account_credentials_files, mock_list_models_response
     ):
         """
         Test 138: Sticky behavior обновляет global index
-        
+
         What it does: Verifies global current_account_index is updated on success
         Purpose: Ensure sticky behavior works across all models
         """
         print("\n=== Test 138: Sticky behavior updates global index ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         account1_path = temp_account_credentials_files["account1"]
         account2_path = temp_account_credentials_files["account2"]
-        
+
         credentials = [
             {"type": "json", "path": account1_path, "enabled": True},
-            {"type": "json", "path": account2_path, "enabled": True}
+            {"type": "json", "path": account2_path, "enabled": True},
         ]
         creds_file.write_text(json.dumps(credentials))
-        
+
         manager = AccountManager(str(creds_file), str(state_file))
         await manager.load_credentials()
         await manager.load_state()
-        
+
         # Initialize accounts (simplified)
         for account_id in list(manager._accounts.keys()):
             account = manager._accounts[account_id]
@@ -198,56 +180,52 @@ class TestAccountSystemFullFlow:
             account.model_resolver = MagicMock()
             account.model_resolver.get_available_models.return_value = ["claude-opus-4.5"]
             account.models_cached_at = time.time()
-            
+
             from kiro.account_manager import ModelAccountList
+
             if "claude-opus-4.5" not in manager._model_to_accounts:
                 manager._model_to_accounts["claude-opus-4.5"] = ModelAccountList()
             manager._model_to_accounts["claude-opus-4.5"].accounts.append(account_id)
-        
+
         print(f"Initial global index: {manager._current_account_index}")
         assert manager._current_account_index == 0
-        
+
         # Act: Report success on second account
         account2_id = list(manager._accounts.keys())[1]
         await manager.report_success(account2_id, "claude-opus-4.5")
-        
+
         # Assert: Global index updated to 1
         print(f"Updated global index: {manager._current_account_index}")
         assert manager._current_account_index == 1
         print("✓ Global index was updated on success")
-    
+
     @pytest.mark.asyncio
-    async def test_circuit_breaker_blocks_broken_account(
-        self,
-        tmp_path,
-        temp_account_credentials_files,
-        mock_time
-    ):
+    async def test_circuit_breaker_blocks_broken_account(self, tmp_path, temp_account_credentials_files, mock_time):
         """
         Test 139: Circuit Breaker блокирует сломанный аккаунт
-        
+
         What it does: Verifies broken account is skipped during cooldown
         Purpose: Ensure Circuit Breaker prevents using broken accounts
         """
         print("\n=== Test 139: Circuit Breaker blocks broken account ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         account1_path = temp_account_credentials_files["account1"]
         account2_path = temp_account_credentials_files["account2"]
-        
+
         credentials = [
             {"type": "json", "path": account1_path, "enabled": True},
-            {"type": "json", "path": account2_path, "enabled": True}
+            {"type": "json", "path": account2_path, "enabled": True},
         ]
         creds_file.write_text(json.dumps(credentials))
-        
+
         manager = AccountManager(str(creds_file), str(state_file))
         await manager.load_credentials()
         await manager.load_state()
-        
+
         # Initialize accounts
         for account_id in list(manager._accounts.keys()):
             account = manager._accounts[account_id]
@@ -256,64 +234,53 @@ class TestAccountSystemFullFlow:
             account.model_resolver = MagicMock()
             account.model_resolver.get_available_models.return_value = ["claude-opus-4.5"]
             account.models_cached_at = time.time()
-            
+
             from kiro.account_manager import ModelAccountList
+
             if "claude-opus-4.5" not in manager._model_to_accounts:
                 manager._model_to_accounts["claude-opus-4.5"] = ModelAccountList()
             manager._model_to_accounts["claude-opus-4.5"].accounts.append(account_id)
-        
+
         # Act: Break first account (5 failures)
         account1_id = list(manager._accounts.keys())[0]
         for i in range(5):
-            await manager.report_failure(
-                account1_id,
-                "claude-opus-4.5",
-                ErrorType.RECOVERABLE,
-                429,
-                None
-            )
-        
+            await manager.report_failure(account1_id, "claude-opus-4.5", ErrorType.RECOVERABLE, 429, None)
+
         print(f"Account 1 failures: {manager._accounts[account1_id].failures}")
         print(f"Last failure time: {manager._accounts[account1_id].last_failure_time}")
-        
+
         # Get next account - should skip account1 (in cooldown)
-        with patch('random.random', return_value=0.5):  # Disable probabilistic retry
+        with patch("random.random", return_value=0.5):  # Disable probabilistic retry
             next_account = await manager.get_next_account("claude-opus-4.5")
-        
+
         account2_id = list(manager._accounts.keys())[1]
         print(f"Next account: {next_account.id if next_account else None}")
         assert next_account.id == account2_id
         print("✓ Broken account was skipped (Circuit Breaker)")
-    
+
     @pytest.mark.asyncio
-    async def test_half_open_recovery_after_timeout(
-        self,
-        tmp_path,
-        temp_account_credentials_files
-    ):
+    async def test_half_open_recovery_after_timeout(self, tmp_path, temp_account_credentials_files):
         """
         Test 140: Half-Open восстанавливает аккаунт после timeout
-        
+
         What it does: Verifies broken account is retried after recovery timeout
         Purpose: Ensure accounts can recover from broken state
         """
         print("\n=== Test 140: Half-Open recovery after timeout ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         account1_path = temp_account_credentials_files["account1"]
-        
-        credentials = [
-            {"type": "json", "path": account1_path, "enabled": True}
-        ]
+
+        credentials = [{"type": "json", "path": account1_path, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
-        
+
         manager = AccountManager(str(creds_file), str(state_file))
         await manager.load_credentials()
         await manager.load_state()
-        
+
         # Initialize account
         account_id = list(manager._accounts.keys())[0]
         account = manager._accounts[account_id]
@@ -322,70 +289,60 @@ class TestAccountSystemFullFlow:
         account.model_resolver = MagicMock()
         account.model_resolver.get_available_models.return_value = ["claude-opus-4.5"]
         account.models_cached_at = time.time()
-        
+
         from kiro.account_manager import ModelAccountList
+
         manager._model_to_accounts["claude-opus-4.5"] = ModelAccountList()
         manager._model_to_accounts["claude-opus-4.5"].accounts.append(account_id)
-        
+
         # Act: Break account
         for i in range(3):
-            await manager.report_failure(
-                account_id,
-                "claude-opus-4.5",
-                ErrorType.RECOVERABLE,
-                429,
-                None
-            )
-        
+            await manager.report_failure(account_id, "claude-opus-4.5", ErrorType.RECOVERABLE, 429, None)
+
         print(f"Account failures: {account.failures}")
         print(f"Last failure time: {account.last_failure_time}")
-        
+
         # Simulate time passing (recovery timeout)
-        from kiro.config import ACCOUNT_RECOVERY_TIMEOUT, ACCOUNT_MAX_BACKOFF_MULTIPLIER
+        from kiro.config import ACCOUNT_MAX_BACKOFF_MULTIPLIER
+
         backoff_multiplier = min(2 ** (account.failures - 1), ACCOUNT_MAX_BACKOFF_MULTIPLIER)
         effective_timeout = ACCOUNT_RECOVERY_TIMEOUT * backoff_multiplier
-        
+
         account.last_failure_time = time.time() - effective_timeout - 1
         print(f"Simulated time passing: {effective_timeout + 1}s")
-        
+
         # Get next account - should return account (Half-Open)
         next_account = await manager.get_next_account("claude-opus-4.5")
-        
+
         print(f"Next account (Half-Open): {next_account.id if next_account else None}")
         assert next_account is not None
         assert next_account.id == account_id
         print("✓ Account recovered via Half-Open state")
-    
+
     @pytest.mark.asyncio
-    async def test_state_persistence_across_restarts(
-        self,
-        tmp_path,
-        temp_account_credentials_files
-    ):
+    async def test_state_persistence_across_restarts(self, tmp_path, temp_account_credentials_files):
         """
         Test 141: state.json сохраняется и восстанавливается
-        
+
         What it does: Verifies state persists across manager restarts
         Purpose: Ensure runtime state survives restarts
         """
         print("\n=== Test 141: State persistence across restarts ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         account1_path = temp_account_credentials_files["account1"]
-        
-        credentials = [
-            {"type": "json", "path": account1_path, "enabled": True}
-        ]
+
+        credentials = [{"type": "json", "path": account1_path, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
-        
+
         # First manager instance
         manager1 = AccountManager(str(creds_file), str(state_file))
         await manager1.load_credentials()
         await manager1.load_state()
-        
+
         # Initialize account
         account_id = list(manager1._accounts.keys())[0]
         account = manager1._accounts[account_id]
@@ -394,11 +351,12 @@ class TestAccountSystemFullFlow:
         account.model_resolver = MagicMock()
         account.model_resolver.get_available_models.return_value = ["claude-opus-4.5"]
         account.models_cached_at = 1704110400.0
-        
+
         from kiro.account_manager import ModelAccountList
+
         manager1._model_to_accounts["claude-opus-4.5"] = ModelAccountList()
         manager1._model_to_accounts["claude-opus-4.5"].accounts.append(account_id)
-        
+
         # Modify state
         account.failures = 3
         account.last_failure_time = 1704114000.0
@@ -406,20 +364,20 @@ class TestAccountSystemFullFlow:
         account.stats.successful_requests = 97
         account.stats.failed_requests = 3
         manager1._current_account_index = 0
-        
+
         # Save state
         await manager1._save_state()
         print(f"Saved state: failures={account.failures}, stats={account.stats.total_requests}")
-        
+
         # Second manager instance (restart simulation)
         manager2 = AccountManager(str(creds_file), str(state_file))
         await manager2.load_credentials()
         await manager2.load_state()
-        
+
         # Assert: State was restored
         account2 = manager2._accounts[account_id]
         print(f"Restored state: failures={account2.failures}, stats={account2.stats.total_requests}")
-        
+
         assert account2.failures == 3
         assert account2.last_failure_time == 1704114000.0
         assert account2.models_cached_at == 1704110400.0
@@ -427,39 +385,32 @@ class TestAccountSystemFullFlow:
         assert account2.stats.successful_requests == 97
         assert account2.stats.failed_requests == 3
         assert manager2._current_account_index == 0
-        
+
         print("✓ State was persisted and restored correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_ttl_refresh_on_usage(
-        self,
-        tmp_path,
-        temp_account_credentials_files,
-        mock_list_models_response
-    ):
+    async def test_ttl_refresh_on_usage(self, tmp_path, temp_account_credentials_files, mock_list_models_response):
         """
         Test 142: TTL обновляется только при использовании аккаунта
-        
+
         What it does: Verifies model cache is refreshed when TTL expires during usage
         Purpose: Ensure cache stays fresh without background tasks
         """
         print("\n=== Test 142: TTL refresh on usage ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         account1_path = temp_account_credentials_files["account1"]
-        
-        credentials = [
-            {"type": "json", "path": account1_path, "enabled": True}
-        ]
+
+        credentials = [{"type": "json", "path": account1_path, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
-        
+
         manager = AccountManager(str(creds_file), str(state_file))
         await manager.load_credentials()
         await manager.load_state()
-        
+
         # Initialize account
         account_id = list(manager._accounts.keys())[0]
         account = manager._accounts[account_id]
@@ -467,34 +418,36 @@ class TestAccountSystemFullFlow:
         account.model_cache = MagicMock()
         account.model_resolver = MagicMock()
         account.model_resolver.get_available_models.return_value = ["claude-opus-4.5"]
-        
+
         # Set old cache timestamp (expired TTL)
         from kiro.config import ACCOUNT_CACHE_TTL
+
         account.models_cached_at = time.time() - ACCOUNT_CACHE_TTL - 1
         print(f"Cache age: {time.time() - account.models_cached_at}s (TTL: {ACCOUNT_CACHE_TTL}s)")
-        
+
         from kiro.account_manager import ModelAccountList
+
         manager._model_to_accounts["claude-opus-4.5"] = ModelAccountList()
         manager._model_to_accounts["claude-opus-4.5"].accounts.append(account_id)
-        
+
         # Mock refresh method
         refresh_called = False
         original_cached_at = account.models_cached_at
-        
+
         async def mock_refresh(acc_id):
             nonlocal refresh_called
             refresh_called = True
             manager._accounts[acc_id].models_cached_at = time.time()
-        
-        with patch.object(manager, '_refresh_account_models', side_effect=mock_refresh):
+
+        with patch.object(manager, "_refresh_account_models", side_effect=mock_refresh):
             # Act: Get account (should trigger TTL refresh)
-            next_account = await manager.get_next_account("claude-opus-4.5")
-        
+            await manager.get_next_account("claude-opus-4.5")
+
         # Assert: Refresh was called and timestamp updated
         print(f"Refresh called: {refresh_called}")
         print(f"Old timestamp: {original_cached_at}")
         print(f"New timestamp: {account.models_cached_at}")
-        
+
         assert refresh_called is True
         assert account.models_cached_at > original_cached_at
         print("✓ Cache was refreshed on usage when TTL expired")
@@ -503,6 +456,7 @@ class TestAccountSystemFullFlow:
 # =============================================================================
 # Integration Tests: 503 Diagnostics When The Pool Is Exhausted
 # =============================================================================
+
 
 class TestAccountSystemExhaustedPoolDiagnostics:
     """
@@ -517,8 +471,7 @@ class TestAccountSystemExhaustedPoolDiagnostics:
     def _exhausted_manager(self, tmp_path, account_count: int = 3) -> AccountManager:
         """Build a manager whose every account is inside its cooldown window."""
         manager = AccountManager(
-            credentials_file=str(tmp_path / "credentials.json"),
-            state_file=str(tmp_path / "state.json")
+            credentials_file=str(tmp_path / "credentials.json"), state_file=str(tmp_path / "state.json")
         )
         now = time.time()
         for index in range(account_count):
@@ -558,9 +511,7 @@ class TestAccountSystemExhaustedPoolDiagnostics:
 
         manager = self._exhausted_manager(tmp_path)
         request_data = ChatCompletionRequest(
-            model="claude-sonnet-4-5",
-            messages=[{"role": "user", "content": "hi"}],
-            stream=False
+            model="claude-sonnet-4-5", messages=[{"role": "user", "content": "hi"}], stream=False
         )
 
         with self._no_probabilistic_retry():
@@ -591,10 +542,7 @@ class TestAccountSystemExhaustedPoolDiagnostics:
 
         manager = self._exhausted_manager(tmp_path)
         request_data = AnthropicMessagesRequest(
-            model="claude-sonnet-4-5",
-            max_tokens=64,
-            messages=[{"role": "user", "content": "hi"}],
-            stream=False
+            model="claude-sonnet-4-5", max_tokens=64, messages=[{"role": "user", "content": "hi"}], stream=False
         )
 
         with self._no_probabilistic_retry():
@@ -631,12 +579,11 @@ class TestAccountSystemExhaustedPoolDiagnostics:
         # Initialization failure keeps auth_manager None, so the account is
         # reported as not initialized rather than rate-limited.
         request_data = ChatCompletionRequest(
-            model="claude-sonnet-4-5",
-            messages=[{"role": "user", "content": "hi"}],
-            stream=False
+            model="claude-sonnet-4-5", messages=[{"role": "user", "content": "hi"}], stream=False
         )
-        with self._no_probabilistic_retry(), patch.object(
-            manager, "_initialize_account", AsyncMock(return_value=False)
+        with (
+            self._no_probabilistic_retry(),
+            patch.object(manager, "_initialize_account", AsyncMock(return_value=False)),
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await chat_completions(self._request(manager), request_data)

--- a/tests/integration/test_debug_capture_replay.py
+++ b/tests/integration/test_debug_capture_replay.py
@@ -1,14 +1,14 @@
 import asyncio
-import json
 import base64
+import json
 from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import patch
 
-from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from loguru import logger as app_logger
 
 from kiro.debug_logger import DebugLogger
@@ -36,22 +36,16 @@ def test_real_http_stream_failure_produces_replayable_capture(tmp_path: Path) ->
         app.add_middleware(DebugLoggerMiddleware)
 
         async def invalid_stream() -> AsyncIterator[str]:
-            logger.log_kiro_request_body(
-                b'{"conversationState":{"currentMessage":{"content":"private"}}}'
-            )
+            logger.log_kiro_request_body(b'{"conversationState":{"currentMessage":{"content":"private"}}}')
             logger.log_raw_chunk(b'{"content":"answer"}')
             chunks = [
-                'event: message_start\n'
-                'data: {"type":"message_start","message":{"content":[]}}\n\n'
-                ,
-                'event: content_block_start\n'
+                'event: message_start\ndata: {"type":"message_start","message":{"content":[]}}\n\n',
+                "event: content_block_start\n"
                 'data: {"type":"content_block_start","index":0,'
-                '"content_block":{"type":"text","text":""}}\n\n'
-                ,
-                'event: content_block_start\n'
+                '"content_block":{"type":"text","text":""}}\n\n',
+                "event: content_block_start\n"
                 'data: {"type":"content_block_start","index":0,'
-                '"content_block":{"type":"thinking","thinking":"","signature":""}}\n\n'
-                ,
+                '"content_block":{"type":"thinking","thinking":"","signature":""}}\n\n',
             ]
             for chunk in chunks:
                 logger.log_modified_chunk(chunk.encode())
@@ -75,9 +69,7 @@ def test_real_http_stream_failure_produces_replayable_capture(tmp_path: Path) ->
                 json={
                     "model": "claude-opus-5",
                     "max_tokens": 128,
-                    "messages": [
-                        {"role": "user", "content": "original private prompt"}
-                    ],
+                    "messages": [{"role": "user", "content": "original private prompt"}],
                 },
             )
 
@@ -86,11 +78,7 @@ def test_real_http_stream_failure_produces_replayable_capture(tmp_path: Path) ->
 
         failures_dir = debug_dir / "failures"
         assert failures_dir.is_dir()
-        captures = [
-            path
-            for path in failures_dir.iterdir()
-            if path.is_dir() and not path.name.startswith(".tmp-")
-        ]
+        captures = [path for path in failures_dir.iterdir() if path.is_dir() and not path.name.startswith(".tmp-")]
         assert len(captures) == 1
 
         capture = captures[0]
@@ -129,25 +117,16 @@ def test_parallel_real_http_failures_produce_independent_bundles(
             async def failed_stream() -> AsyncIterator[str]:
                 nonlocal entered_streams
                 capture = logger._current_capture()
-                request_ids[marker] = (
-                    capture.request_id if capture is not None else None
-                )
+                request_ids[marker] = capture.request_id if capture is not None else None
                 entered_streams += 1
                 assert both_streams_entered is not None
                 if entered_streams == 2:
                     both_streams_entered.set()
                 await asyncio.wait_for(both_streams_entered.wait(), timeout=2)
-                logger.log_kiro_request_body(
-                    json.dumps({"marker": marker}).encode()
-                )
-                logger.log_raw_chunk(
-                    json.dumps({"content": marker}).encode()
-                )
+                logger.log_kiro_request_body(json.dumps({"marker": marker}).encode())
+                logger.log_raw_chunk(json.dumps({"content": marker}).encode())
                 app_logger.info(f"private-log-{marker}")
-                chunk = (
-                    "event: message_start\n"
-                    f'data: {{"type":"message_start","marker":"{marker}"}}\n\n'
-                )
+                chunk = f'event: message_start\ndata: {{"type":"message_start","marker":"{marker}"}}\n\n'
                 logger.log_modified_chunk(chunk.encode())
                 yield chunk
                 capture_paths[marker] = logger.flush_on_error(
@@ -168,15 +147,14 @@ def test_parallel_real_http_failures_produce_independent_bundles(
                 transport=transport,
                 base_url="http://testserver",
             ) as client:
+
                 async def send(marker: str) -> int:
                     response = await client.post(
                         f"/v1/messages?marker={marker}",
                         json={
                             "model": "claude-opus-5",
                             "max_tokens": 128,
-                            "messages": [
-                                {"role": "user", "content": marker}
-                            ],
+                            "messages": [{"role": "user", "content": marker}],
                         },
                     )
                     return response.status_code
@@ -196,9 +174,7 @@ def test_parallel_real_http_failures_produce_independent_bundles(
     assert set(capture_paths) == {"request-alpha", "request-beta"}
     assert None not in capture_paths.values()
     captures = sorted(
-        path
-        for path in (debug_dir / "failures").iterdir()
-        if path.is_dir() and not path.name.startswith(".tmp-")
+        path for path in (debug_dir / "failures").iterdir() if path.is_dir() and not path.name.startswith(".tmp-")
     )
     assert len(captures) == 2
     artifacts = [
@@ -211,18 +187,10 @@ def test_parallel_real_http_failures_produce_independent_bundles(
     ]
     for marker in ("request-alpha", "request-beta"):
         matching = [
-            pair
-            for pair in artifacts
-            if marker in pair[0]
-            and marker in pair[1]
-            and f"private-log-{marker}" in pair[2]
+            pair for pair in artifacts if marker in pair[0] and marker in pair[1] and f"private-log-{marker}" in pair[2]
         ]
         assert len(matching) == 1
-        other = (
-            "request-beta"
-            if marker == "request-alpha"
-            else "request-alpha"
-        )
+        other = "request-beta" if marker == "request-alpha" else "request-alpha"
         assert other not in matching[0][0]
         assert other not in matching[0][1]
         assert f"private-log-{other}" not in matching[0][2]
@@ -241,18 +209,15 @@ def test_successful_stream_retains_sanitized_rolling_capture(tmp_path: Path) -> 
         app.add_middleware(DebugLoggerMiddleware)
 
         async def successful_stream() -> AsyncIterator[str]:
-            logger.log_kiro_request_body(
-                b'{"authorization":"Bearer upstream-secret","model":"claude-opus-5"}'
-            )
+            logger.log_kiro_request_body(b'{"authorization":"Bearer upstream-secret","model":"claude-opus-5"}')
             logger.log_raw_chunk(b'{"content":"private upstream output"}')
-            logger.log_parsed_event({
-                "type": "content",
-                "content": "private upstream output",
-            })
-            chunk = (
-                'data: {"choices":[{"delta":{"content":"answer"},'
-                '"finish_reason":"stop"}]}\n\n'
+            logger.log_parsed_event(
+                {
+                    "type": "content",
+                    "content": "private upstream output",
+                }
             )
+            chunk = 'data: {"choices":[{"delta":{"content":"answer"},"finish_reason":"stop"}]}\n\n'
             logger.log_modified_chunk(chunk.encode())
             yield chunk
             done = "data: [DONE]\n\n"
@@ -284,22 +249,12 @@ def test_successful_stream_retains_sanitized_rolling_capture(tmp_path: Path) -> 
         assert response.text.endswith("data: [DONE]\n\n")
         captures = list((debug_dir / "requests").iterdir())
         assert len(captures) == 1
-        stored = b"\n".join(
-            path.read_bytes()
-            for path in captures[0].iterdir()
-            if path.is_file()
-        )
+        stored = b"\n".join(path.read_bytes() for path in captures[0].iterdir() if path.is_file())
         assert b"private prompt" not in stored
         assert b"client-secret" not in stored
         assert b"upstream-secret" not in stored
         assert b"claude-opus-5" in stored
         replay = json.loads((captures[0] / "replay.json").read_text())
         assert replay["validation"] == {"valid": True, "failure": None}
-        decoded_upstream = [
-            base64.b64decode(item["payload_base64"])
-            for item in replay["upstream_chunks"]
-        ]
-        assert any(
-            b"parsed_kiro_event" in item
-            for item in decoded_upstream
-        )
+        decoded_upstream = [base64.b64decode(item["payload_base64"]) for item in replay["upstream_chunks"]]
+        assert any(b"parsed_kiro_event" in item for item in decoded_upstream)

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -5,20 +5,12 @@ Integration tests for complete end-to-end flow.
 Checks interaction of all system components.
 """
 
-import pytest
-import json
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone, timedelta
-
-from fastapi.testclient import TestClient
-import httpx
-
-from kiro.config import PROXY_API_KEY
+from unittest.mock import AsyncMock, patch
 
 
 class TestFullChatCompletionFlow:
     """Integration tests for complete chat completions flow."""
-    
+
     def test_full_flow_health_to_models_to_chat(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks complete flow from health check to chat completions.
@@ -29,30 +21,24 @@ class TestFullChatCompletionFlow:
         assert health_response.status_code == 200
         assert health_response.json()["status"] == "healthy"
         print(f"Health: {health_response.json()}")
-        
+
         print("Step 2: Getting models list...")
-        models_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
+        models_response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
         assert models_response.status_code == 200
         assert len(models_response.json()["data"]) > 0
         print(f"Models: {[m['id'] for m in models_response.json()['data']]}")
-        
+
         print("Step 3: Validating chat completions request...")
         # This request will pass validation but fail on HTTP due to network blocking
         chat_response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
         # Request should pass validation (not 422)
         assert chat_response.status_code != 422
         print(f"Chat response status: {chat_response.status_code}")
-    
+
     def test_authentication_flow(self, test_client, valid_proxy_api_key, invalid_proxy_api_key):
         """
         What it does: Checks authentication flow.
@@ -62,43 +48,36 @@ class TestFullChatCompletionFlow:
         no_auth_response = test_client.get("/v1/models")
         assert no_auth_response.status_code == 401
         print(f"Without authorization: {no_auth_response.status_code}")
-        
+
         print("Step 2: Request with invalid key...")
         wrong_auth_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
+            "/v1/models", headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
         )
         assert wrong_auth_response.status_code == 401
         print(f"Invalid key: {wrong_auth_response.status_code}")
-        
+
         print("Step 3: Request with valid key...")
-        valid_auth_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
+        valid_auth_response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
         assert valid_auth_response.status_code == 200
         print(f"Valid key: {valid_auth_response.status_code}")
-    
+
     def test_openai_compatibility_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks response format compatibility with OpenAI API.
         Goal: Ensure responses conform to OpenAI specification.
         """
         print("Checking /v1/models format...")
-        models_response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        models_response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         assert models_response.status_code == 200
         data = models_response.json()
-        
+
         # Check OpenAI response structure
         assert "object" in data
         assert data["object"] == "list"
         assert "data" in data
         assert isinstance(data["data"], list)
-        
+
         # Check structure of each model
         for model in data["data"]:
             assert "id" in model
@@ -106,13 +85,13 @@ class TestFullChatCompletionFlow:
             assert model["object"] == "model"
             assert "owned_by" in model
             assert "created" in model
-        
+
         print(f"Format conforms to OpenAI API: {len(data['data'])} models")
 
 
 class TestRequestValidationFlow:
     """Integration tests for request validation."""
-    
+
     def test_chat_completions_request_validation(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks validation of various request formats.
@@ -122,42 +101,39 @@ class TestRequestValidationFlow:
         empty_messages = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={"model": "claude-sonnet-4-5", "messages": []}
+            json={"model": "claude-sonnet-4-5", "messages": []},
         )
         assert empty_messages.status_code == 422
         print(f"Empty messages: {empty_messages.status_code}")
-        
+
         print("Test 2: Missing model...")
         no_model = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={"messages": [{"role": "user", "content": "Hello"}]}
+            json={"messages": [{"role": "user", "content": "Hello"}]},
         )
         assert no_model.status_code == 422
         print(f"Without model: {no_model.status_code}")
-        
+
         print("Test 3: Missing messages...")
         no_messages = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={"model": "claude-sonnet-4-5"}
+            json={"model": "claude-sonnet-4-5"},
         )
         assert no_messages.status_code == 422
         print(f"Without messages: {no_messages.status_code}")
-        
+
         print("Test 4: Valid request...")
         valid_request = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
         # Validation should pass (not 422)
         assert valid_request.status_code != 422
         print(f"Valid request: {valid_request.status_code}")
-    
+
     def test_complex_message_formats(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks handling of complex message formats.
@@ -169,15 +145,12 @@ class TestRequestValidationFlow:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [
-                    {"role": "system", "content": "You are helpful"},
-                    {"role": "user", "content": "Hello"}
-                ]
-            }
+                "messages": [{"role": "system", "content": "You are helpful"}, {"role": "user", "content": "Hello"}],
+            },
         )
         assert system_user.status_code != 422
         print(f"System + User: {system_user.status_code}")
-        
+
         print("Test 2: Multi-turn conversation...")
         multi_turn = test_client.post(
             "/v1/chat/completions",
@@ -187,13 +160,13 @@ class TestRequestValidationFlow:
                 "messages": [
                     {"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi there!"},
-                    {"role": "user", "content": "How are you?"}
-                ]
-            }
+                    {"role": "user", "content": "How are you?"},
+                ],
+            },
         )
         assert multi_turn.status_code != 422
         print(f"Multi-turn: {multi_turn.status_code}")
-        
+
         print("Test 3: With tools...")
         with_tools = test_client.post(
             "/v1/chat/completions",
@@ -201,15 +174,17 @@ class TestRequestValidationFlow:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "What's the weather?"}],
-                "tools": [{
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "description": "Get weather",
-                        "parameters": {"type": "object", "properties": {}}
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
                     }
-                }]
-            }
+                ],
+            },
         )
         assert with_tools.status_code != 422
         print(f"With tools: {with_tools.status_code}")
@@ -217,7 +192,7 @@ class TestRequestValidationFlow:
 
 class TestErrorHandlingFlow:
     """Integration tests for error handling."""
-    
+
     def test_invalid_json_handling(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks handling of invalid JSON.
@@ -226,16 +201,13 @@ class TestErrorHandlingFlow:
         print("Sending invalid JSON...")
         response = test_client.post(
             "/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {valid_proxy_api_key}",
-                "Content-Type": "application/json"
-            },
-            content=b"not valid json"
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}", "Content-Type": "application/json"},
+            content=b"not valid json",
         )
-        
+
         assert response.status_code == 422
         print(f"Invalid JSON: {response.status_code}")
-    
+
     def test_wrong_content_type_handling(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks handling of wrong Content-Type.
@@ -244,13 +216,10 @@ class TestErrorHandlingFlow:
         print("Sending with wrong Content-Type...")
         response = test_client.post(
             "/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {valid_proxy_api_key}",
-                "Content-Type": "text/plain"
-            },
-            content=b"Hello"
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}", "Content-Type": "text/plain"},
+            content=b"Hello",
         )
-        
+
         # Should be validation error
         assert response.status_code == 422
         print(f"Wrong Content-Type: {response.status_code}")
@@ -258,46 +227,37 @@ class TestErrorHandlingFlow:
 
 class TestModelsEndpointIntegration:
     """Integration tests for /v1/models endpoint."""
-    
+
     def test_models_returns_all_available_models(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks that all models from config are returned.
         Goal: Ensure completeness of models list.
         """
         print("Getting models list...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         assert response.status_code == 200
-        
+
         returned_ids = {m["id"] for m in response.json()["data"]}
-        
+
         print(f"Returned models: {returned_ids}")
-        
+
         # At minimum, hidden models should be available
         assert len(returned_ids) >= 1, "Expected at least one model (hidden models)"
-    
+
     def test_models_caching_behavior(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks models caching behavior.
         Goal: Ensure repeated requests work correctly.
         """
         print("First models request...")
-        response1 = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
+        response1 = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
         assert response1.status_code == 200
-        
+
         print("Second models request...")
-        response2 = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
+        response2 = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
         assert response2.status_code == 200
-        
+
         # Responses should be identical
         assert response1.json()["data"] == response2.json()["data"]
         print("Caching works correctly")
@@ -305,50 +265,46 @@ class TestModelsEndpointIntegration:
 
 class TestStreamingFlagHandling:
     """Integration tests for stream flag handling."""
-    
+
     def test_stream_true_accepted(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks that stream=true is accepted.
         Goal: Ensure streaming mode is available.
-        
+
         Note: Streaming mode requires HTTP client mock,
         as request is executed inside generator.
         """
         print("Request with stream=true...")
-        
+
         # Create mock response for streaming
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         async def mock_aiter_bytes():
             yield b'{"content":"Hello"}'
             yield b'{"usage":0.5}'
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
         mock_response.aclose = AsyncMock()
-        
+
         # Mock request_with_retry to return our mock response
-        with patch('kiro.routes_openai.KiroHttpClient') as MockHttpClient:
+        with patch("kiro.routes_openai.KiroHttpClient") as MockHttpClient:
             mock_client_instance = AsyncMock()
             mock_client_instance.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client_instance.client = AsyncMock()
             mock_client_instance.close = AsyncMock()
             MockHttpClient.return_value = mock_client_instance
-            
+
             response = test_client.post(
                 "/v1/chat/completions",
                 headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-                json={
-                    "model": "claude-sonnet-4-5",
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True
-                }
+                json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "stream": True},
             )
-        
+
         # Validation should pass and streaming should work
         assert response.status_code == 200
         print(f"stream=true: {response.status_code}")
-    
+
     def test_stream_false_accepted(self, test_client, valid_proxy_api_key):
         """
         What it does: Checks that stream=false is accepted.
@@ -358,13 +314,9 @@ class TestStreamingFlagHandling:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "stream": False
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "stream": False},
         )
-        
+
         # Validation should pass
         assert response.status_code != 422
         print(f"stream=false: {response.status_code}")
@@ -372,7 +324,7 @@ class TestStreamingFlagHandling:
 
 class TestHealthEndpointIntegration:
     """Integration tests for health endpoints."""
-    
+
     def test_root_and_health_consistency(self, test_client):
         """
         What it does: Checks consistency of / and /health.
@@ -380,16 +332,16 @@ class TestHealthEndpointIntegration:
         """
         print("Request to /...")
         root_response = test_client.get("/")
-        
+
         print("Request to /health...")
         health_response = test_client.get("/health")
-        
+
         assert root_response.status_code == 200
         assert health_response.status_code == 200
-        
+
         assert root_response.headers["content-type"].startswith("text/html")
         assert "Kiro" in root_response.text
         assert health_response.json()["status"] == "healthy"
         assert health_response.json()["version"]
-        
+
         print("Health endpoints are consistent")

--- a/tests/integration/test_stream_isolation.py
+++ b/tests/integration/test_stream_isolation.py
@@ -13,12 +13,7 @@ def test_parallel_streams_are_isolated() -> None:
     completed = subprocess.run(
         [
             sys.executable,
-            str(
-                repository
-                / "tests"
-                / "integration"
-                / "parser_integrity_probe.py"
-            ),
+            str(repository / "tests" / "integration" / "parser_integrity_probe.py"),
         ],
         cwd=repository,
         env=environment,

--- a/tests/unit/test_account_errors.py
+++ b/tests/unit/test_account_errors.py
@@ -8,77 +8,76 @@ Tests the classify_error() function that determines whether an error is:
 - RECOVERABLE: Error with the account → try next account
 """
 
-import pytest
-from kiro.account_errors import classify_error, ErrorType
+from kiro.account_errors import ErrorType, classify_error
 
 
 class TestClassifyErrorRecoverable:
     """
     Tests for RECOVERABLE errors (account-specific issues).
-    
+
     These errors should trigger failover to the next account.
     """
-    
+
     def test_classify_error_402_recoverable(self):
         """
         Test that 402 (payment required) is classified as RECOVERABLE.
-        
+
         What it does: Verifies 402 status code classification
         Purpose: Monthly quota exceeded should trigger account failover
         """
         print("\n=== Test: 402 Payment Required → RECOVERABLE ===")
-        
+
         # Act
         result = classify_error(status_code=402, reason="MONTHLY_REQUEST_COUNT")
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.RECOVERABLE, "402 should be RECOVERABLE (quota exceeded)"
-    
+
     def test_classify_error_402_no_reason_recoverable(self):
         """
         Test that 402 without reason is still RECOVERABLE.
-        
+
         What it does: Verifies 402 classification regardless of reason
         Purpose: Any payment issue is account-specific
         """
         print("\n=== Test: 402 without reason → RECOVERABLE ===")
-        
+
         # Act
         result = classify_error(status_code=402, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.RECOVERABLE, "402 should always be RECOVERABLE"
-    
+
     def test_classify_error_403_recoverable(self):
         """
         Test that 403 (token expired) is classified as RECOVERABLE.
-        
+
         What it does: Verifies 403 status code classification
         Purpose: Token expiration is account-specific, should try next account
         """
         print("\n=== Test: 403 Forbidden → RECOVERABLE ===")
-        
+
         # Act
         result = classify_error(status_code=403, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.RECOVERABLE, "403 should be RECOVERABLE (token expired)"
-    
+
     def test_classify_error_429_recoverable(self):
         """
         Test that 429 (rate limit) is classified as RECOVERABLE.
-        
+
         What it does: Verifies 429 status code classification
         Purpose: Rate limit is account-specific, should try next account
         """
         print("\n=== Test: 429 Rate Limit → RECOVERABLE ===")
-        
+
         # Act
         result = classify_error(status_code=429, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.RECOVERABLE, "429 should be RECOVERABLE (rate limit)"
@@ -87,105 +86,102 @@ class TestClassifyErrorRecoverable:
 class TestClassifyErrorFatal:
     """
     Tests for FATAL errors (request-specific issues).
-    
+
     These errors should be returned to client immediately without failover.
     """
-    
+
     def test_classify_error_400_content_length_fatal(self):
         """
         Test that 400 + CONTENT_LENGTH_EXCEEDS_THRESHOLD is FATAL.
-        
+
         What it does: Verifies context overflow classification
         Purpose: Context overflow will fail on all accounts
         """
         print("\n=== Test: 400 + CONTENT_LENGTH_EXCEEDS_THRESHOLD → FATAL ===")
-        
+
         # Act
-        result = classify_error(
-            status_code=400,
-            reason="CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        )
-        
+        result = classify_error(status_code=400, reason="CONTENT_LENGTH_EXCEEDS_THRESHOLD")
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "Context overflow should be FATAL"
-    
+
     def test_classify_error_400_null_reason_fatal(self):
         """
         Test that 400 + reason=None is FATAL.
-        
+
         What it does: Verifies generic bad request classification
         Purpose: "Improperly formed request" is request issue, not account issue
         """
         print("\n=== Test: 400 + reason=None → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=400, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "400 with null reason should be FATAL"
-    
+
     def test_classify_error_400_unknown_reason_fatal(self):
         """
         Test that 400 + unknown reason is FATAL.
-        
+
         What it does: Verifies unknown 400 reason classification
         Purpose: Unknown validation errors are request issues
         """
         print("\n=== Test: 400 + unknown reason → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=400, reason="UNKNOWN_VALIDATION_ERROR")
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "400 with unknown reason should be FATAL"
-    
+
     def test_classify_error_422_fatal(self):
         """
         Test that 422 (validation error) is FATAL.
-        
+
         What it does: Verifies 422 status code classification
         Purpose: Validation errors are request issues, not account issues
         """
         print("\n=== Test: 422 Validation Error → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=422, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "422 should be FATAL (validation error)"
-    
+
     def test_classify_error_500_fatal(self):
         """
         Test that 500 (server error) is FATAL.
-        
+
         What it does: Verifies 5xx status code classification
         Purpose: Kiro API server errors won't be fixed by trying another account
         """
         print("\n=== Test: 500 Server Error → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=500, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "500 should be FATAL (server error)"
-    
+
     def test_classify_error_503_fatal(self):
         """
         Test that 503 (service unavailable) is FATAL.
-        
+
         What it does: Verifies 503 status code classification
         Purpose: Service unavailable affects all accounts
         """
         print("\n=== Test: 503 Service Unavailable → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=503, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "503 should be FATAL (service unavailable)"
@@ -195,58 +191,58 @@ class TestClassifyErrorEdgeCases:
     """
     Tests for edge cases and unknown error codes.
     """
-    
+
     def test_classify_error_unknown_status_fatal(self):
         """
         Test that unknown status codes default to FATAL.
-        
+
         What it does: Verifies default classification for unknown codes
         Purpose: Conservative approach - don't waste retries on unknown errors
         """
         print("\n=== Test: Unknown status code → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=418, reason=None)  # I'm a teapot
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "Unknown status codes should default to FATAL"
-    
+
     def test_classify_error_401_fatal(self):
         """
         Test that 401 (unauthorized) is FATAL.
-        
+
         What it does: Verifies 401 classification
         Purpose: 401 is not explicitly handled, should default to FATAL
         """
         print("\n=== Test: 401 Unauthorized → FATAL ===")
-        
+
         # Act
         result = classify_error(status_code=401, reason=None)
-        
+
         # Assert
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "401 should be FATAL (not explicitly RECOVERABLE)"
-    
+
     def test_classify_error_with_reason_string(self):
         """
         Test classification with various reason strings.
-        
+
         What it does: Verifies reason parameter handling
         Purpose: Ensure reason strings are properly evaluated
         """
         print("\n=== Test: Various reason strings ===")
-        
+
         # Test CONTENT_LENGTH_EXCEEDS_THRESHOLD
         result1 = classify_error(400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD")
         print(f"400 + CONTENT_LENGTH: {result1}")
         assert result1 == ErrorType.FATAL
-        
+
         # Test other reason
         result2 = classify_error(400, "SOME_OTHER_REASON")
         print(f"400 + SOME_OTHER_REASON: {result2}")
         assert result2 == ErrorType.FATAL
-        
+
         # Test empty string (treated as truthy)
         result3 = classify_error(400, "")
         print(f"400 + empty string: {result3}")
@@ -257,57 +253,51 @@ class TestClassifyErrorComprehensive:
     """
     Comprehensive tests covering all documented error scenarios.
     """
-    
+
     def test_all_recoverable_codes(self):
         """
         Test all RECOVERABLE status codes in one test.
-        
+
         What it does: Batch verification of all RECOVERABLE codes
         Purpose: Ensure complete coverage of account-specific errors
         """
         print("\n=== Test: All RECOVERABLE codes ===")
-        
+
         recoverable_codes = [402, 403, 429]
-        
+
         for code in recoverable_codes:
             result = classify_error(code, None)
             print(f"Status {code}: {result}")
             assert result == ErrorType.RECOVERABLE, f"{code} should be RECOVERABLE"
-    
+
     def test_all_fatal_5xx_codes(self):
         """
         Test that all 5xx codes are FATAL.
-        
+
         What it does: Batch verification of server error codes
         Purpose: Ensure all server errors are classified as FATAL
         """
         print("\n=== Test: All 5xx codes → FATAL ===")
-        
+
         server_error_codes = [500, 501, 502, 503, 504, 505]
-        
+
         for code in server_error_codes:
             result = classify_error(code, None)
             print(f"Status {code}: {result}")
             assert result == ErrorType.FATAL, f"{code} should be FATAL"
-    
+
     def test_400_with_different_reasons(self):
         """
         Test 400 classification with various reason codes.
-        
+
         What it does: Comprehensive 400 reason testing
         Purpose: Verify correct classification based on reason
         """
         print("\n=== Test: 400 with different reasons ===")
-        
+
         # FATAL reasons
-        fatal_reasons = [
-            "CONTENT_LENGTH_EXCEEDS_THRESHOLD",
-            None,
-            "UNKNOWN",
-            "VALIDATION_ERROR",
-            ""
-        ]
-        
+        fatal_reasons = ["CONTENT_LENGTH_EXCEEDS_THRESHOLD", None, "UNKNOWN", "VALIDATION_ERROR", ""]
+
         for reason in fatal_reasons:
             result = classify_error(400, reason)
             print(f"400 + reason={reason}: {result}")

--- a/tests/unit/test_account_manager.py
+++ b/tests/unit/test_account_manager.py
@@ -11,55 +11,45 @@ Tests the AccountManager class that manages multiple Kiro accounts with:
 - State persistence
 """
 
-import asyncio
 import json
-import pytest
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from kiro.account_manager import (
-    Account,
-    AccountStats,
-    ModelAccountList,
-    AccountManager,
-    account_label,
-    _format_duration
-)
+import pytest
+
 from kiro.account_errors import ErrorType
+from kiro.account_manager import Account, AccountManager, AccountStats, _format_duration, account_label
 from kiro.config import (
     ACCOUNT_QUOTA_QUARANTINE,
     ACCOUNT_RATE_LIMIT_COOLDOWN,
     ACCOUNT_RECOVERY_TIMEOUT,
 )
-from kiro.auth import KiroAuthManager, AuthType
-from kiro.cache import ModelInfoCache
-from kiro.model_resolver import ModelResolver
 
 
 class TestAccountDataclass:
     """
     Tests for Account and AccountStats dataclasses.
     """
-    
+
     def test_account_creation_with_defaults(self):
         """
         Test Account creation with default values.
-        
+
         What it does: Verifies Account dataclass initialization
         Purpose: Ensure default values are set correctly
         """
         print("\n=== Test: Account creation with defaults ===")
-        
+
         # Act
         account = Account(id="/test/path.json")
-        
+
         # Assert
         print(f"Account ID: {account.id}")
         print(f"Auth manager: {account.auth_manager}")
         print(f"Failures: {account.failures}")
         print(f"Last failure time: {account.last_failure_time}")
-        
+
         assert account.id == "/test/path.json"
         assert account.auth_manager is None
         assert account.model_cache is None
@@ -68,24 +58,24 @@ class TestAccountDataclass:
         assert account.last_failure_time == 0.0
         assert account.models_cached_at == 0.0
         assert isinstance(account.stats, AccountStats)
-    
+
     def test_account_stats_initialization(self):
         """
         Test AccountStats initialization with zeros.
-        
+
         What it does: Verifies AccountStats default values
         Purpose: Ensure statistics start at zero
         """
         print("\n=== Test: AccountStats initialization ===")
-        
+
         # Act
         stats = AccountStats()
-        
+
         # Assert
         print(f"Total requests: {stats.total_requests}")
         print(f"Successful requests: {stats.successful_requests}")
         print(f"Failed requests: {stats.failed_requests}")
-        
+
         assert stats.total_requests == 0
         assert stats.successful_requests == 0
         assert stats.failed_requests == 0
@@ -95,95 +85,77 @@ class TestAccountManagerLoadCredentials:
     """
     Tests for AccountManager.load_credentials() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_json_type(self, tmp_path):
         """
         Test loading credentials with type=json.
-        
+
         What it does: Loads single JSON credential file
         Purpose: Verify JSON type credential loading
         """
         print("\n=== Test: load_credentials with type=json ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        credentials = [
-            {
-                "type": "json",
-                "path": str(test_json),
-                "enabled": True
-            }
-        ]
-        creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        credentials = [{"type": "json", "path": str(test_json), "enabled": True}]
+        creds_file.write_text(json.dumps(credentials))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
         print(f"Account IDs: {list(manager._accounts.keys())}")
-        
+
         assert len(manager._accounts) == 1
         assert str(test_json.resolve()) in manager._accounts
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_sqlite_type(self, tmp_path, temp_sqlite_db):
         """
         Test loading credentials with type=sqlite.
-        
+
         What it does: Loads SQLite database credential
         Purpose: Verify SQLite type credential loading
         """
         print("\n=== Test: load_credentials with type=sqlite ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
-        credentials = [
-            {
-                "type": "sqlite",
-                "path": temp_sqlite_db,
-                "enabled": True
-            }
-        ]
+        credentials = [{"type": "sqlite", "path": temp_sqlite_db, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 1
         assert str(Path(temp_sqlite_db).resolve()) in manager._accounts
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_refresh_token_type(self, tmp_path):
         """
         Test loading credentials with type=refresh_token.
-        
+
         What it does: Loads refresh token credential
         Purpose: Verify refresh_token type credential loading
         """
         print("\n=== Test: load_credentials with type=refresh_token ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         credentials = [
@@ -192,303 +164,261 @@ class TestAccountManagerLoadCredentials:
                 "refresh_token": "test_refresh_token_abc123",
                 "profile_arn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
                 "region": "us-east-1",
-                "enabled": True
+                "enabled": True,
             }
         ]
         creds_file.write_text(json.dumps(credentials))
-        
+
         # Create state file to avoid errors
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps({"current_account_index": 0, "model_to_accounts": {}, "accounts": {}}))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(state_file)
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(state_file))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
         print(f"Account IDs: {list(manager._accounts.keys())}")
-        
+
         assert len(manager._accounts) == 1
         # refresh_token type uses deterministic hash as ID
         account_id = list(manager._accounts.keys())[0]
         assert account_id.startswith("refresh_token_")
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_folder_scanning(self, tmp_path):
         """
         Test folder scanning for credential files.
-        
+
         What it does: Scans folder and loads all valid credential files
         Purpose: Verify folder scanning functionality
         """
         print("\n=== Test: load_credentials with folder scanning ===")
-        
+
         # Arrange
         folder = tmp_path / "accounts"
         folder.mkdir()
-        
+
         # Create valid files
         file1 = folder / "account1.json"
-        file1.write_text(json.dumps({
-            "refreshToken": "token1",
-            "accessToken": "access1",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        file2 = folder / "account2.json"
-        file2.write_text(json.dumps({
-            "refreshToken": "token2",
-            "accessToken": "access2",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        credentials = [
-            {
-                "type": "json",
-                "path": str(folder),
-                "enabled": True
-            }
-        ]
-        creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        file1.write_text(
+            json.dumps({"refreshToken": "token1", "accessToken": "access1", "expiresAt": "2099-01-01T00:00:00.000Z"})
         )
-        
+
+        file2 = folder / "account2.json"
+        file2.write_text(
+            json.dumps({"refreshToken": "token2", "accessToken": "access2", "expiresAt": "2099-01-01T00:00:00.000Z"})
+        )
+
+        creds_file = tmp_path / "credentials.json"
+        credentials = [{"type": "json", "path": str(folder), "enabled": True}]
+        creds_file.write_text(json.dumps(credentials))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 2
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_skip_invalid_files(self, tmp_path):
         """
         Test that invalid files are skipped with WARNING.
-        
+
         What it does: Loads folder with invalid files
         Purpose: Verify invalid files are skipped gracefully
         """
         print("\n=== Test: load_credentials skips invalid files ===")
-        
+
         # Arrange
         folder = tmp_path / "accounts"
         folder.mkdir()
-        
+
         # Valid file
         valid_file = folder / "valid.json"
-        valid_file.write_text(json.dumps({
-            "refreshToken": "token",
-            "accessToken": "access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
+        valid_file.write_text(
+            json.dumps({"refreshToken": "token", "accessToken": "access", "expiresAt": "2099-01-01T00:00:00.000Z"})
+        )
+
         # Invalid JSON
         invalid_file = folder / "invalid.json"
         invalid_file.write_text("not a valid json {{{")
-        
+
         # Non-JSON file
         text_file = folder / "readme.txt"
         text_file.write_text("This is not a credential file")
-        
+
         creds_file = tmp_path / "credentials.json"
-        credentials = [
-            {
-                "type": "json",
-                "path": str(folder),
-                "enabled": True
-            }
-        ]
+        credentials = [{"type": "json", "path": str(folder), "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 1  # Only valid file loaded
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_skip_disabled(self, tmp_path):
         """
         Test that entries with enabled=false are skipped.
-        
+
         What it does: Loads credentials with disabled entry
         Purpose: Verify enabled flag is respected
         """
         print("\n=== Test: load_credentials skips disabled entries ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "token",
-            "accessToken": "access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
+        test_json.write_text(
+            json.dumps({"refreshToken": "token", "accessToken": "access", "expiresAt": "2099-01-01T00:00:00.000Z"})
+        )
+
         creds_file = tmp_path / "credentials.json"
         credentials = [
             {
                 "type": "json",
                 "path": str(test_json),
-                "enabled": False  # Disabled
+                "enabled": False,  # Disabled
             }
         ]
         creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 0
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_missing_type(self, tmp_path):
         """
         Test that entries without type are skipped.
-        
+
         What it does: Loads credentials with missing type field
         Purpose: Verify type validation
         """
         print("\n=== Test: load_credentials skips entries without type ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         credentials = [
             {
                 "path": "/some/path.json",
-                "enabled": True
+                "enabled": True,
                 # Missing "type" field
             }
         ]
         creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 0
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_missing_path(self, tmp_path):
         """
         Test that json/sqlite entries without path are skipped.
-        
+
         What it does: Loads credentials with missing path field
         Purpose: Verify path validation for json/sqlite types
         """
         print("\n=== Test: load_credentials skips json/sqlite without path ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         credentials = [
             {
                 "type": "json",
-                "enabled": True
+                "enabled": True,
                 # Missing "path" field
             }
         ]
         creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 0
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_missing_refresh_token(self, tmp_path):
         """
         Test that refresh_token entries without refresh_token field are skipped.
-        
+
         What it does: Loads credentials with missing refresh_token field
         Purpose: Verify refresh_token validation
         """
         print("\n=== Test: load_credentials skips refresh_token without token ===")
-        
+
         # Arrange
         creds_file = tmp_path / "credentials.json"
         credentials = [
             {
                 "type": "refresh_token",
                 "profile_arn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-                "enabled": True
+                "enabled": True,
                 # Missing "refresh_token" field
             }
         ]
         creds_file.write_text(json.dumps(credentials))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 0
-    
+
     @pytest.mark.asyncio
     async def test_load_credentials_file_not_found(self, tmp_path):
         """
         Test handling of non-existent credentials.json.
-        
+
         What it does: Attempts to load non-existent file
         Purpose: Verify graceful handling of missing file
         """
         print("\n=== Test: load_credentials with missing file ===")
-        
+
         # Arrange
         manager = AccountManager(
-            credentials_file=str(tmp_path / "nonexistent.json"),
-            state_file=str(tmp_path / "state.json")
+            credentials_file=str(tmp_path / "nonexistent.json"), state_file=str(tmp_path / "state.json")
         )
-        
+
         # Act
         await manager.load_credentials()
-        
+
         # Assert
         print(f"Loaded accounts: {len(manager._accounts)}")
-        
+
         assert len(manager._accounts) == 0
 
 
@@ -496,133 +426,114 @@ class TestAccountManagerLoadState:
     """
     Tests for AccountManager.load_state() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_load_state_success(self, tmp_path, sample_state_with_data):
         """
         Test loading existing state.json.
-        
+
         What it does: Loads state from file
         Purpose: Verify state restoration
         """
         print("\n=== Test: load_state success ===")
-        
+
         # Arrange
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(sample_state_with_data))
-        
+
         # Create accounts first
         test_json = tmp_path / "test.json"
         test_json.write_text(json.dumps({"refreshToken": "token"}))
-        
+
         creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(state_file)
-        )
-        
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(state_file))
+
         await manager.load_credentials()
-        
+
         # Act
         await manager.load_state()
-        
+
         # Assert
         print(f"Model mappings: {len(manager._model_to_accounts)}")
         print(f"Current account index: {manager._current_account_index}")
-        
+
         assert len(manager._model_to_accounts) > 0
-    
+
     @pytest.mark.asyncio
     async def test_load_state_restore_current_account_index(self, tmp_path):
         """
         Test restoration of global current_account_index.
-        
+
         What it does: Restores sticky index from state
         Purpose: Verify global sticky behavior persistence
         """
         print("\n=== Test: load_state restores current_account_index ===")
-        
+
         # Arrange
-        state_data = {
-            "current_account_index": 2,
-            "model_to_accounts": {},
-            "accounts": {}
-        }
-        
+        state_data = {"current_account_index": 2, "model_to_accounts": {}, "accounts": {}}
+
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data))
-        
-        manager = AccountManager(
-            credentials_file=str(tmp_path / "creds.json"),
-            state_file=str(state_file)
-        )
-        
+
+        manager = AccountManager(credentials_file=str(tmp_path / "creds.json"), state_file=str(state_file))
+
         # Act
         await manager.load_state()
-        
+
         # Assert
         print(f"Current account index: {manager._current_account_index}")
-        
+
         assert manager._current_account_index == 2
-    
+
     @pytest.mark.asyncio
     async def test_load_state_restore_model_to_accounts(self, tmp_path):
         """
         Test restoration of model_to_accounts mapping.
-        
+
         What it does: Restores model mappings from state
         Purpose: Verify model-to-account mapping persistence
         """
         print("\n=== Test: load_state restores model_to_accounts ===")
-        
+
         # Arrange
         state_data = {
             "current_account_index": 0,
-            "model_to_accounts": {
-                "claude-opus-4.5": {
-                    "accounts": ["/test/account1.json", "/test/account2.json"]
-                }
-            },
-            "accounts": {}
+            "model_to_accounts": {"claude-opus-4.5": {"accounts": ["/test/account1.json", "/test/account2.json"]}},
+            "accounts": {},
         }
-        
+
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data))
-        
-        manager = AccountManager(
-            credentials_file=str(tmp_path / "creds.json"),
-            state_file=str(state_file)
-        )
-        
+
+        manager = AccountManager(credentials_file=str(tmp_path / "creds.json"), state_file=str(state_file))
+
         # Act
         await manager.load_state()
-        
+
         # Assert
         print(f"Model mappings: {manager._model_to_accounts}")
-        
+
         assert "claude-opus-4.5" in manager._model_to_accounts
         assert len(manager._model_to_accounts["claude-opus-4.5"].accounts) == 2
-    
+
     @pytest.mark.asyncio
     async def test_load_state_restore_account_runtime_state(self, tmp_path):
         """
         Test restoration of account runtime state (failures, stats, etc).
-        
+
         What it does: Restores account state from file
         Purpose: Verify runtime state persistence
         """
         print("\n=== Test: load_state restores account runtime state ===")
-        
+
         # Arrange
         # Create account first to get correct resolved path
         test_json = tmp_path / "account.json"
         test_json.write_text(json.dumps({"refreshToken": "token"}))
         account_id = str(test_json.resolve())
-        
+
         state_data = {
             "current_account_index": 0,
             "model_to_accounts": {},
@@ -631,138 +542,123 @@ class TestAccountManagerLoadState:
                     "failures": 3,
                     "last_failure_time": 1704110400.0,
                     "models_cached_at": 1704106800.0,
-                    "stats": {
-                        "total_requests": 100,
-                        "successful_requests": 97,
-                        "failed_requests": 3
-                    }
+                    "stats": {"total_requests": 100, "successful_requests": 97, "failed_requests": 3},
                 }
-            }
+            },
         }
-        
+
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data))
-        
+
         creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(state_file)
-        )
-        
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(state_file))
+
         await manager.load_credentials()
-        
+
         # Act
         await manager.load_state()
-        
+
         # Assert
         account = manager._accounts[account_id]
         print(f"Account failures: {account.failures}")
         print(f"Account stats: {account.stats}")
-        
+
         assert account.failures == 3
         assert account.last_failure_time == 1704110400.0
         assert account.models_cached_at == 1704106800.0
         assert account.stats.total_requests == 100
-    
+
     @pytest.mark.asyncio
     async def test_load_state_file_not_found(self, tmp_path):
         """
         Test handling of non-existent state.json (empty state).
-        
+
         What it does: Attempts to load non-existent state file
         Purpose: Verify graceful handling with empty state
         """
         print("\n=== Test: load_state with missing file ===")
-        
+
         # Arrange
         manager = AccountManager(
-            credentials_file=str(tmp_path / "creds.json"),
-            state_file=str(tmp_path / "nonexistent.json")
+            credentials_file=str(tmp_path / "creds.json"), state_file=str(tmp_path / "nonexistent.json")
         )
-        
+
         # Act
         await manager.load_state()
-        
+
         # Assert
         print(f"Model mappings: {len(manager._model_to_accounts)}")
         print(f"Current account index: {manager._current_account_index}")
-        
+
         assert len(manager._model_to_accounts) == 0
         assert manager._current_account_index == 0
-    
+
     @pytest.mark.asyncio
     async def test_load_state_corrupted_json(self, tmp_path):
         """
         Test handling of corrupted state.json.
-        
+
         What it does: Attempts to load invalid JSON
         Purpose: Verify error handling for corrupted state
         """
         print("\n=== Test: load_state with corrupted JSON ===")
-        
+
         # Arrange
         state_file = tmp_path / "state.json"
         state_file.write_text("not a valid json {{{")
-        
-        manager = AccountManager(
-            credentials_file=str(tmp_path / "creds.json"),
-            state_file=str(state_file)
-        )
-        
+
+        manager = AccountManager(credentials_file=str(tmp_path / "creds.json"), state_file=str(state_file))
+
         # Act
         await manager.load_state()
-        
+
         # Assert - should handle gracefully
         print(f"Model mappings: {len(manager._model_to_accounts)}")
-        
-        assert len(manager._model_to_accounts) == 0
 
+        assert len(manager._model_to_accounts) == 0
 
 
 class TestAccountManagerInitializeAccount:
     """
     Tests for AccountManager._initialize_account() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_initialize_account_json_success(self, tmp_path, mock_list_models_response):
         """
         Test successful account initialization with type=json.
-        
+
         What it does: Initializes account with JSON credentials
         Purpose: Verify complete initialization flow
         """
         print("\n=== Test: initialize_account with JSON ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z",
-            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-            "region": "us-east-1"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {
+                    "refreshToken": "test_token",
+                    "accessToken": "test_access",
+                    "expiresAt": "2099-01-01T00:00:00.000Z",
+                    "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/test",
+                    "region": "us-east-1",
+                }
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Mock HTTP client for ListAvailableModels
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -770,58 +666,53 @@ class TestAccountManagerInitializeAccount:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             # Act
             success = await manager._initialize_account(account_id)
-        
+
         # Assert
         print(f"Initialization success: {success}")
         assert success is True
         assert manager._accounts[account_id].auth_manager is not None
         assert manager._accounts[account_id].model_cache is not None
         assert manager._accounts[account_id].model_resolver is not None
-    
+
     @pytest.mark.asyncio
     async def test_initialize_account_fetch_models_fallback(self, tmp_path):
         """
         Test fallback to FALLBACK_MODELS when API fails.
-        
+
         What it does: Initializes account when ListAvailableModels fails
         Purpose: Verify fallback mechanism
         """
         print("\n=== Test: initialize_account with fallback models ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Mock HTTP client to fail
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_client.request_with_retry = AsyncMock(side_effect=Exception("Network error"))
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             # Act
             success = await manager._initialize_account(account_id)
-        
+
         # Assert
         print(f"Initialization success: {success}")
         assert success is True  # Should succeed with fallback
@@ -832,40 +723,35 @@ class TestAccountManagerGetNextAccount:
     """
     Tests for AccountManager.get_next_account() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_get_next_account_single_bypass_circuit_breaker(self, tmp_path, mock_list_models_response):
         """
         Test that single account bypasses Circuit Breaker.
-        
+
         What it does: Gets account when only one exists
         Purpose: Verify single account always returns (no cooldown)
         """
         print("\n=== Test: get_next_account single account bypasses Circuit Breaker ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -873,16 +759,16 @@ class TestAccountManagerGetNextAccount:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Set failures (should be ignored for single account)
         manager._accounts[account_id].failures = 10
         manager._accounts[account_id].last_failure_time = time.time()
-        
+
         # Act
         account = await manager.get_next_account("claude-opus-4.5")
-        
+
         # Assert
         print(f"Got account: {account is not None}")
         assert account is not None  # Single account always returns
@@ -899,8 +785,7 @@ class TestAccountManagerRateLimitCooldown:
 
     def _pool(self, tmp_path, account_count: int = 2) -> AccountManager:
         manager = AccountManager(
-            credentials_file=str(tmp_path / "credentials.json"),
-            state_file=str(tmp_path / "state.json")
+            credentials_file=str(tmp_path / "credentials.json"), state_file=str(tmp_path / "state.json")
         )
         for index in range(account_count):
             account_id = f"/creds/account{index}.json"
@@ -924,8 +809,7 @@ class TestAccountManagerRateLimitCooldown:
 
         for _ in range(5):
             await manager.report_failure(
-                account_id, "claude-sonnet-4-5",
-                ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
+                account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
             )
 
         account = manager._accounts[account_id]
@@ -950,8 +834,7 @@ class TestAccountManagerRateLimitCooldown:
 
         before = time.time()
         await manager.report_failure(
-            account_id, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
+            account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
         )
 
         remaining = manager._accounts[account_id].rate_limited_until - before
@@ -973,8 +856,7 @@ class TestAccountManagerRateLimitCooldown:
         first, second = "/creds/account0.json", "/creds/account1.json"
 
         await manager.report_failure(
-            first, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
+            first, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
         )
 
         # Within the window: rotate to the other account.
@@ -1005,8 +887,7 @@ class TestAccountManagerRateLimitCooldown:
 
         for account_id in (first, second):
             await manager.report_failure(
-                account_id, "claude-sonnet-4-5",
-                ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
+                account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
             )
 
         with patch("kiro.account_manager.random.random", return_value=0.0):
@@ -1028,8 +909,7 @@ class TestAccountManagerRateLimitCooldown:
         account_id = "/creds/account0.json"
 
         await manager.report_failure(
-            account_id, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
+            account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
         )
         assert manager._accounts[account_id].rate_limited_until > time.time()
 
@@ -1050,8 +930,7 @@ class TestAccountManagerQuotaExclusion:
 
     def _pool(self, tmp_path, account_count: int = 2) -> AccountManager:
         manager = AccountManager(
-            credentials_file=str(tmp_path / "credentials.json"),
-            state_file=str(tmp_path / "state.json")
+            credentials_file=str(tmp_path / "credentials.json"), state_file=str(tmp_path / "state.json")
         )
         for index in range(account_count):
             account_id = f"/creds/account{index}.json"
@@ -1075,8 +954,7 @@ class TestAccountManagerQuotaExclusion:
 
         before = time.time()
         await manager.report_failure(
-            account_id, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
+            account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
         )
 
         account = manager._accounts[account_id]
@@ -1099,10 +977,7 @@ class TestAccountManagerQuotaExclusion:
         manager = self._pool(tmp_path, account_count=2)
         dead, alive = "/creds/account0.json", "/creds/account1.json"
 
-        await manager.report_failure(
-            dead, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
-        )
+        await manager.report_failure(dead, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT")
 
         with patch("kiro.account_manager.random.random", return_value=0.0):
             for _ in range(10):
@@ -1124,8 +999,7 @@ class TestAccountManagerQuotaExclusion:
         manager = self._pool(tmp_path, account_count=2)
         for account_id in list(manager._accounts):
             await manager.report_failure(
-                account_id, "claude-sonnet-4-5",
-                ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
+                account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
             )
 
         with patch("kiro.account_manager.random.random", return_value=0.0):
@@ -1146,8 +1020,7 @@ class TestAccountManagerQuotaExclusion:
         recovered = "/creds/account0.json"
 
         await manager.report_failure(
-            recovered, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
+            recovered, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
         )
         manager._accounts[recovered].quota_exhausted_until = time.time() - 1
 
@@ -1169,8 +1042,7 @@ class TestAccountManagerQuotaExclusion:
         account_id = "/creds/account0.json"
 
         await manager.report_failure(
-            account_id, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
+            account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
         )
         assert manager._accounts[account_id].quota_exhausted_until > time.time()
 
@@ -1195,17 +1067,13 @@ class TestAccountManagerQuotaExclusion:
         manager = self._pool(tmp_path, account_count=2)
         manager._state_file = str(state_file)
         await manager.report_failure(
-            account_id, "claude-sonnet-4-5",
-            ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
+            account_id, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
         )
         saved_until = manager._accounts[account_id].quota_exhausted_until
         await manager._save_state()
 
         # Fresh process: same credentials, state reloaded from disk.
-        restarted = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(state_file)
-        )
+        restarted = AccountManager(credentials_file=str(creds_file), state_file=str(state_file))
         restarted._accounts = {
             "/creds/account0.json": Account(id="/creds/account0.json"),
             "/creds/account1.json": Account(id="/creds/account1.json"),
@@ -1226,8 +1094,7 @@ class TestAccountManagerDescribePoolState:
 
     def _manager(self, tmp_path) -> AccountManager:
         return AccountManager(
-            credentials_file=str(tmp_path / "credentials.json"),
-            state_file=str(tmp_path / "state.json")
+            credentials_file=str(tmp_path / "credentials.json"), state_file=str(tmp_path / "state.json")
         )
 
     def test_describe_pool_state_empty_pool(self, tmp_path):
@@ -1346,9 +1213,7 @@ class TestAccountManagerDescribePoolState:
         manager = self._manager(tmp_path)
         manager._accounts = {"/creds/recovered.json": Account(id="/creds/recovered.json")}
         manager._accounts["/creds/recovered.json"].failures = 1
-        manager._accounts["/creds/recovered.json"].last_failure_time = (
-            time.time() - ACCOUNT_RECOVERY_TIMEOUT - 1
-        )
+        manager._accounts["/creds/recovered.json"].last_failure_time = time.time() - ACCOUNT_RECOVERY_TIMEOUT - 1
         manager._accounts["/creds/recovered.json"].auth_manager = MagicMock()
 
         description = manager.describe_pool_state()
@@ -1361,40 +1226,35 @@ class TestAccountManagerReportSuccess:
     """
     Tests for AccountManager.report_success() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_report_success_reset_failures(self, tmp_path, mock_list_models_response):
         """
         Test that report_success resets failures to 0.
-        
+
         What it does: Reports success after failures
         Purpose: Verify failure counter reset
         """
         print("\n=== Test: report_success resets failures ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -1402,52 +1262,47 @@ class TestAccountManagerReportSuccess:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Set failures
         manager._accounts[account_id].failures = 5
-        
+
         # Act
         await manager.report_success(account_id, "claude-opus-4.5")
-        
+
         # Assert
         print(f"Failures after success: {manager._accounts[account_id].failures}")
         assert manager._accounts[account_id].failures == 0
-    
+
     @pytest.mark.asyncio
     async def test_report_success_update_stats(self, tmp_path, mock_list_models_response):
         """
         Test that report_success updates statistics.
-        
+
         What it does: Reports success and checks stats
         Purpose: Verify statistics tracking
         """
         print("\n=== Test: report_success updates stats ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -1455,12 +1310,12 @@ class TestAccountManagerReportSuccess:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Act
         await manager.report_success(account_id, "claude-opus-4.5")
-        
+
         # Assert
         stats = manager._accounts[account_id].stats
         print(f"Stats: total={stats.total_requests}, successful={stats.successful_requests}")
@@ -1472,40 +1327,35 @@ class TestAccountManagerReportFailure:
     """
     Tests for AccountManager.report_failure() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_report_failure_recoverable_increment_failures(self, tmp_path, mock_list_models_response):
         """
         Test that RECOVERABLE errors increment failures.
-        
+
         What it does: Reports RECOVERABLE failure
         Purpose: Verify failure counter increment
         """
         print("\n=== Test: report_failure RECOVERABLE increments failures ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -1513,52 +1363,44 @@ class TestAccountManagerReportFailure:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Act
-        await manager.report_failure(
-            account_id, "claude-opus-4.5",
-            ErrorType.RECOVERABLE, 429, None
-        )
-        
+        await manager.report_failure(account_id, "claude-opus-4.5", ErrorType.RECOVERABLE, 429, None)
+
         # Assert
         print(f"Failures: {manager._accounts[account_id].failures}")
         assert manager._accounts[account_id].failures == 1
-    
+
     @pytest.mark.asyncio
     async def test_report_failure_fatal_no_increment(self, tmp_path, mock_list_models_response):
         """
         Test that FATAL errors do NOT increment failures.
-        
+
         What it does: Reports FATAL failure
         Purpose: Verify failures not incremented for request errors
         """
         print("\n=== Test: report_failure FATAL does not increment failures ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -1566,15 +1408,14 @@ class TestAccountManagerReportFailure:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Act
         await manager.report_failure(
-            account_id, "claude-opus-4.5",
-            ErrorType.FATAL, 400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
+            account_id, "claude-opus-4.5", ErrorType.FATAL, 400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
         )
-        
+
         # Assert
         print(f"Failures: {manager._accounts[account_id].failures}")
         assert manager._accounts[account_id].failures == 0  # Not incremented
@@ -1584,31 +1425,28 @@ class TestAccountManagerSaveState:
     """
     Tests for AccountManager._save_state() and save_state_periodically().
     """
-    
+
     @pytest.mark.asyncio
     async def test_save_state_atomic_write(self, tmp_path):
         """
         Test atomic state saving via tmp file.
-        
+
         What it does: Saves state and checks tmp file usage
         Purpose: Verify atomic write pattern
         """
         print("\n=== Test: save_state atomic write ===")
-        
+
         # Arrange
         state_file = tmp_path / "state.json"
-        manager = AccountManager(
-            credentials_file=str(tmp_path / "creds.json"),
-            state_file=str(state_file)
-        )
-        
+        manager = AccountManager(credentials_file=str(tmp_path / "creds.json"), state_file=str(state_file))
+
         # Act
         await manager._save_state()
-        
+
         # Assert
         print(f"State file exists: {state_file.exists()}")
         assert state_file.exists()
-        
+
         # Verify tmp file was cleaned up
         tmp_file = tmp_path / "state.json.tmp"
         print(f"Tmp file exists: {tmp_file.exists()}")
@@ -1619,40 +1457,35 @@ class TestAccountManagerGetFirstAccount:
     """
     Tests for AccountManager.get_first_account() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_get_first_account_success(self, tmp_path, mock_list_models_response):
         """
         Test getting first initialized account.
-        
+
         What it does: Gets first account for legacy mode
         Purpose: Verify legacy mode support
         """
         print("\n=== Test: get_first_account success ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -1660,32 +1493,29 @@ class TestAccountManagerGetFirstAccount:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Act
         account = manager.get_first_account()
-        
+
         # Assert
         print(f"Got account: {account is not None}")
         assert account is not None
         assert account.auth_manager is not None
-    
+
     def test_get_first_account_no_initialized(self, tmp_path):
         """
         Test RuntimeError when no initialized accounts.
-        
+
         What it does: Attempts to get account when none initialized
         Purpose: Verify error handling
         """
         print("\n=== Test: get_first_account with no initialized accounts ===")
-        
+
         # Arrange
-        manager = AccountManager(
-            credentials_file=str(tmp_path / "creds.json"),
-            state_file=str(tmp_path / "state.json")
-        )
-        
+        manager = AccountManager(credentials_file=str(tmp_path / "creds.json"), state_file=str(tmp_path / "state.json"))
+
         # Act & Assert
         with pytest.raises(RuntimeError, match="No initialized accounts available"):
             manager.get_first_account()
@@ -1695,40 +1525,35 @@ class TestAccountManagerGetAllAvailableModels:
     """
     Tests for AccountManager.get_all_available_models() method.
     """
-    
+
     @pytest.mark.asyncio
     async def test_get_all_available_models_collect_from_all(self, tmp_path, mock_list_models_response):
         """
         Test collecting unique models from all accounts.
-        
+
         What it does: Gets models from multiple accounts
         Purpose: Verify model aggregation for /v1/models endpoint
         """
         print("\n=== Test: get_all_available_models collects from all ===")
-        
+
         # Arrange
         test_json = tmp_path / "test.json"
-        test_json.write_text(json.dumps({
-            "refreshToken": "test_token",
-            "accessToken": "test_access",
-            "expiresAt": "2099-01-01T00:00:00.000Z"
-        }))
-        
-        creds_file = tmp_path / "credentials.json"
-        creds_file.write_text(json.dumps([
-            {"type": "json", "path": str(test_json), "enabled": True}
-        ]))
-        
-        manager = AccountManager(
-            credentials_file=str(creds_file),
-            state_file=str(tmp_path / "state.json")
+        test_json.write_text(
+            json.dumps(
+                {"refreshToken": "test_token", "accessToken": "test_access", "expiresAt": "2099-01-01T00:00:00.000Z"}
+            )
         )
-        
+
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
+
+        manager = AccountManager(credentials_file=str(creds_file), state_file=str(tmp_path / "state.json"))
+
         await manager.load_credentials()
         account_id = str(test_json.resolve())
-        
+
         # Initialize account
-        with patch('kiro.account_manager.KiroHttpClient') as mock_http_class:
+        with patch("kiro.account_manager.KiroHttpClient") as mock_http_class:
             mock_client = AsyncMock()
             mock_response = Mock()  # Response is not async
             mock_response.status_code = 200
@@ -1736,12 +1561,12 @@ class TestAccountManagerGetAllAvailableModels:
             mock_client.request_with_retry = AsyncMock(return_value=mock_response)
             mock_client.close = AsyncMock()
             mock_http_class.return_value = mock_client
-            
+
             await manager._initialize_account(account_id)
-        
+
         # Act
         models = manager.get_all_available_models()
-        
+
         # Assert
         print(f"Available models: {len(models)}")
         assert len(models) > 0
@@ -1753,24 +1578,24 @@ class TestFormatDuration:
     """
     Tests for _format_duration() helper function.
     """
-    
+
     def test_format_duration_seconds(self):
         """Test formatting seconds."""
         assert _format_duration(30) == "30s"
         assert _format_duration(59) == "59s"
-    
+
     def test_format_duration_minutes(self):
         """Test formatting minutes."""
         assert _format_duration(60) == "1m"
         assert _format_duration(300) == "5m"
         assert _format_duration(3599) == "59m"
-    
+
     def test_format_duration_hours(self):
         """Test formatting hours."""
         assert _format_duration(3600) == "1h"
         assert _format_duration(7200) == "2h"
         assert _format_duration(86399) == "23h"
-    
+
     def test_format_duration_days(self):
         """Test formatting days."""
         assert _format_duration(86400) == "1d"

--- a/tests/unit/test_account_rate_series.py
+++ b/tests/unit/test_account_rate_series.py
@@ -225,12 +225,14 @@ async def test_a_rejection_below_served_traffic_does_not_define_the_guide(manage
 @pytest.mark.asyncio
 async def test_the_tightest_informative_rejection_wins(manager):
     now = time.time()
-    manager.load_rate_observations([
-        ("/creds/account0.json", now - 500, 18, 0, "success"),
-        ("/creds/account0.json", now - 400, 40, 1, "rate_limited"),
-        # A lower rejection still above proven-safe traffic: the tighter bound.
-        ("/creds/account0.json", now - 300, 25, 1, "rate_limited"),
-    ])
+    manager.load_rate_observations(
+        [
+            ("/creds/account0.json", now - 500, 18, 0, "success"),
+            ("/creds/account0.json", now - 400, 40, 1, "rate_limited"),
+            # A lower rejection still above proven-safe traffic: the tighter bound.
+            ("/creds/account0.json", now - 300, 25, 1, "rate_limited"),
+        ]
+    )
 
     estimate = manager.estimate_rate_limit("/creds/account0.json")
 
@@ -335,7 +337,6 @@ async def test_observations_survive_a_restart(manager, tmp_path):
     assert after["limitRpm"] == before["limitRpm"]
     assert after["safeRpm"] == before["safeRpm"]
     assert after["limitPrecisionRpm"] == before["limitPrecisionRpm"]
-
 
 
 def test_rate_window_is_reported_so_callers_can_label_the_unit(manager):

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -7,18 +7,19 @@ Tests token management logic for Kiro without real network requests.
 
 import asyncio
 import json
-import pytest
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
-import httpx
 
-from kiro.auth import KiroAuthManager, AuthType
-from kiro.config import TOKEN_REFRESH_THRESHOLD, get_aws_sso_oidc_url
+import httpx
+import pytest
+
+from kiro.auth import AuthType, KiroAuthManager
+from kiro.config import TOKEN_REFRESH_THRESHOLD
 
 
 class TestKiroAuthManagerInitialization:
     """Tests for KiroAuthManager initialization."""
-    
+
     def test_initialization_stores_credentials(self):
         """
         What it does: Verifies correct storage of credentials during initialization.
@@ -28,44 +29,41 @@ class TestKiroAuthManagerInitialization:
         manager = KiroAuthManager(
             refresh_token="test_refresh_123",
             profile_arn="arn:aws:codewhisperer:us-east-1:123456789:profile/test",
-            region="us-east-1"
+            region="us-east-1",
         )
-        
+
         print("Verification: All credentials stored correctly...")
         print(f"Comparing refresh_token: Expected 'test_refresh_123', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "test_refresh_123"
-        
+
         print(f"Comparing profile_arn: Expected 'arn:aws:...', Got '{manager._profile_arn}'")
         assert manager._profile_arn == "arn:aws:codewhisperer:us-east-1:123456789:profile/test"
-        
+
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: Token is initially empty...")
         assert manager._access_token is None
         assert manager._expires_at is None
-    
+
     def test_initialization_sets_correct_urls_for_region(self):
         """
         What it does: Verifies URL formation based on region.
         Purpose: Ensure URLs are dynamically formed with the correct region.
         """
         print("Setup: Creating KiroAuthManager with region eu-west-1...")
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            region="eu-west-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_token", region="eu-west-1")
+
         print("Verification: URLs contain correct region...")
         print(f"Comparing refresh_url: Expected 'eu-west-1' in URL, Got '{manager._refresh_url}'")
         assert "eu-west-1" in manager._refresh_url
-        
+
         print(f"Comparing api_host: Expected 'eu-west-1' in URL, Got '{manager._api_host}'")
         assert "eu-west-1" in manager._api_host
-        
+
         print(f"Comparing q_host: Expected 'eu-west-1' in URL, Got '{manager._q_host}'")
         assert "eu-west-1" in manager._q_host
-    
+
     def test_initialization_generates_fingerprint(self):
         """
         What it does: Verifies unique fingerprint generation.
@@ -73,7 +71,7 @@ class TestKiroAuthManagerInitialization:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="test_token")
-        
+
         print("Verification: Fingerprint generated...")
         print(f"Fingerprint: {manager._fingerprint}")
         assert manager._fingerprint is not None
@@ -82,7 +80,7 @@ class TestKiroAuthManagerInitialization:
 
 class TestKiroAuthManagerCredentialsFile:
     """Tests for loading credentials from file."""
-    
+
     def test_load_credentials_from_file(self, temp_creds_file):
         """
         What it does: Verifies loading credentials from JSON file.
@@ -90,21 +88,21 @@ class TestKiroAuthManagerCredentialsFile:
         """
         print(f"Setup: Creating KiroAuthManager with credentials file: {temp_creds_file}")
         manager = KiroAuthManager(creds_file=temp_creds_file)
-        
+
         print("Verification: Data loaded from file...")
         print(f"Comparing access_token: Expected 'file_access_token', Got '{manager._access_token}'")
         assert manager._access_token == "file_access_token"
-        
+
         print(f"Comparing refresh_token: Expected 'file_refresh_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "file_refresh_token"
-        
+
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: expiresAt parsed correctly...")
         assert manager._expires_at is not None
         assert manager._expires_at.year == 2099
-    
+
     def test_load_credentials_file_not_found(self, tmp_path):
         """
         What it does: Verifies handling of missing credentials file.
@@ -112,12 +110,9 @@ class TestKiroAuthManagerCredentialsFile:
         """
         print("Setup: Creating KiroAuthManager with non-existent file...")
         non_existent_file = str(tmp_path / "non_existent.json")
-        
-        manager = KiroAuthManager(
-            refresh_token="fallback_token",
-            creds_file=non_existent_file
-        )
-        
+
+        manager = KiroAuthManager(refresh_token="fallback_token", creds_file=non_existent_file)
+
         print("Verification: Fallback refresh_token is used...")
         print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "fallback_token"
@@ -125,7 +120,7 @@ class TestKiroAuthManagerCredentialsFile:
 
 class TestKiroAuthManagerTokenExpiration:
     """Tests for token expiration checking."""
-    
+
     def test_is_token_expiring_soon_returns_true_when_no_expires_at(self):
         """
         What it does: Verifies that without expires_at token is considered expiring.
@@ -134,12 +129,12 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager without expires_at...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = None
-        
+
         print("Verification: is_token_expiring_soon returns True...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expiring_soon_returns_true_when_expired(self):
         """
         What it does: Verifies that expired token is correctly identified.
@@ -148,12 +143,12 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager with expired token...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        
+
         print("Verification: is_token_expiring_soon returns True for expired token...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expiring_soon_returns_true_within_threshold(self):
         """
         What it does: Verifies that token within threshold is considered expiring.
@@ -162,13 +157,13 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager with token expiring in 5 minutes...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print(f"TOKEN_REFRESH_THRESHOLD = {TOKEN_REFRESH_THRESHOLD} seconds")
         print("Verification: is_token_expiring_soon returns True (5 min < 10 min threshold)...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expiring_soon_returns_false_when_valid(self):
         """
         What it does: Verifies that valid token is not considered expiring.
@@ -177,7 +172,7 @@ class TestKiroAuthManagerTokenExpiration:
         print("Setup: Creating KiroAuthManager with token expiring in 1 hour...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Verification: is_token_expiring_soon returns False...")
         result = manager.is_token_expiring_soon()
         print(f"Comparing result: Expected False, Got {result}")
@@ -186,7 +181,7 @@ class TestKiroAuthManagerTokenExpiration:
 
 class TestKiroAuthManagerTokenRefresh:
     """Tests for token refresh mechanism."""
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_successful(self, valid_kiro_token, mock_kiro_token_response):
         """
@@ -194,37 +189,34 @@ class TestKiroAuthManagerTokenRefresh:
         Purpose: Verify that on successful response token and expiration time are set.
         """
         print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", region="us-east-1")
+
         print("Setup: Mocking successful response from Kiro...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_request()...")
             await manager._refresh_token_request()
-            
+
             print("Verification: Token set correctly...")
             print(f"Comparing access_token: Expected '{valid_kiro_token}', Got '{manager._access_token}'")
             assert manager._access_token == valid_kiro_token
-            
+
             print("Verification: Expiration time set...")
             assert manager._expires_at is not None
-            
+
             print("Verification: POST request was made...")
             mock_client.post.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_updates_refresh_token(self, mock_kiro_token_response):
         """
@@ -233,27 +225,27 @@ class TestKiroAuthManagerTokenRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="old_refresh_token")
-        
+
         print("Setup: Mocking response with new refresh_token...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Refreshing token...")
             await manager._refresh_token_request()
-            
+
             print("Verification: refresh_token updated...")
             print(f"Comparing refresh_token: Expected 'new_refresh_token_xyz', Got '{manager._refresh_token}'")
             assert manager._refresh_token == "new_refresh_token_xyz"
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_missing_access_token_raises(self):
         """
@@ -262,27 +254,27 @@ class TestKiroAuthManagerTokenRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="test_refresh")
-        
+
         print("Setup: Mocking response without accessToken...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value={"expiresIn": 3600})  # No accessToken!
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Attempting token refresh...")
             with pytest.raises(ValueError) as exc_info:
                 await manager._refresh_token_request()
-            
+
             print(f"Verification: ValueError raised with message: {exc_info.value}")
             assert "accessToken" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_no_refresh_token_raises(self):
         """
@@ -292,18 +284,18 @@ class TestKiroAuthManagerTokenRefresh:
         print("Setup: Creating KiroAuthManager without refresh_token...")
         manager = KiroAuthManager()
         manager._refresh_token = None
-        
+
         print("Action: Attempting token refresh without refresh_token...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_request()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Refresh token" in str(exc_info.value)
 
 
 class TestKiroAuthManagerGetAccessToken:
     """Tests for public get_access_token method."""
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_refreshes_when_expired(self, valid_kiro_token, mock_kiro_token_response):
         """
@@ -314,31 +306,31 @@ class TestKiroAuthManagerGetAccessToken:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = "old_expired_token"
         manager._expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        
+
         print("Setup: Mocking successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Requesting token via get_access_token()...")
             token = await manager.get_access_token()
-            
+
             print("Verification: Got new token, not expired one...")
             print(f"Comparing token: Expected '{valid_kiro_token}', Got '{token}'")
             assert token == valid_kiro_token
             assert token != "old_expired_token"
-            
+
             print("Verification: _refresh_token_request was called...")
             mock_client.post.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_returns_valid_without_refresh(self, valid_kiro_token):
         """
@@ -349,23 +341,23 @@ class TestKiroAuthManagerGetAccessToken:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = valid_kiro_token
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Setup: Mocking httpx to track calls...")
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock()
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Requesting valid token...")
             token = await manager.get_access_token()
-            
+
             print("Verification: Existing token returned...")
             print(f"Comparing token: Expected '{valid_kiro_token}', Got '{token}'")
             assert token == valid_kiro_token
-            
+
             print("Verification: _refresh_token was NOT called (no network requests)...")
             mock_client.post.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_thread_safety(self, valid_kiro_token, mock_kiro_token_response):
         """
@@ -376,34 +368,32 @@ class TestKiroAuthManagerGetAccessToken:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = None
         manager._expires_at = None
-        
+
         refresh_call_count = 0
-        
+
         async def mock_refresh():
             nonlocal refresh_call_count
             refresh_call_count += 1
             await asyncio.sleep(0.1)  # Simulate delay
             manager._access_token = valid_kiro_token
             manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Setup: Patching _refresh_token_request to track calls...")
-        with patch.object(manager, '_refresh_token_request', side_effect=mock_refresh):
+        with patch.object(manager, "_refresh_token_request", side_effect=mock_refresh):
             print("Action: 5 parallel get_access_token() calls...")
-            tokens = await asyncio.gather(*[
-                manager.get_access_token() for _ in range(5)
-            ])
-            
+            tokens = await asyncio.gather(*[manager.get_access_token() for _ in range(5)])
+
             print("Verification: All calls got the same token...")
             assert all(token == valid_kiro_token for token in tokens)
-            
-            print(f"Verification: _refresh_token called ONLY ONCE (thanks to lock)...")
+
+            print("Verification: _refresh_token called ONLY ONCE (thanks to lock)...")
             print(f"Comparing call count: Expected 1, Got {refresh_call_count}")
             assert refresh_call_count == 1
 
 
 class TestKiroAuthManagerForceRefresh:
     """Tests for forced token refresh."""
-    
+
     @pytest.mark.asyncio
     async def test_force_refresh_updates_token(self, valid_kiro_token, mock_kiro_token_response):
         """
@@ -414,80 +404,71 @@ class TestKiroAuthManagerForceRefresh:
         manager = KiroAuthManager(refresh_token="test_refresh")
         manager._access_token = "old_but_valid_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Setup: Mocking refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Force refreshing token...")
             token = await manager.force_refresh()
-            
+
             print("Verification: Token refreshed despite old one being valid...")
             print(f"Comparing token: Expected '{valid_kiro_token}', Got '{token}'")
             assert token == valid_kiro_token
-            
+
             print("Verification: POST request was made...")
             mock_client.post.assert_called_once()
 
 
 class TestKiroAuthManagerProperties:
     """Tests for KiroAuthManager properties."""
-    
+
     def test_profile_arn_property(self):
         """
         What it does: Verifies profile_arn property.
         Purpose: Ensure profile_arn is accessible via property.
         """
         print("Setup: Creating KiroAuthManager with profile_arn...")
-        manager = KiroAuthManager(
-            refresh_token="test",
-            profile_arn="arn:aws:test:profile"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test", profile_arn="arn:aws:test:profile")
+
         print("Verification: profile_arn accessible...")
         print(f"Comparing profile_arn: Expected 'arn:aws:test:profile', Got '{manager.profile_arn}'")
         assert manager.profile_arn == "arn:aws:test:profile"
-    
+
     def test_region_property(self):
         """
         What it does: Verifies region property.
         Purpose: Ensure region is accessible via property.
         """
         print("Setup: Creating KiroAuthManager with region...")
-        manager = KiroAuthManager(
-            refresh_token="test",
-            region="eu-west-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test", region="eu-west-1")
+
         print("Verification: region accessible...")
         print(f"Comparing region: Expected 'eu-west-1', Got '{manager.region}'")
         assert manager.region == "eu-west-1"
-    
+
     def test_api_host_property(self):
         """
         What it does: Verifies api_host property.
         Purpose: Ensure api_host is formed correctly.
         """
         print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(
-            refresh_token="test",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test", region="us-east-1")
+
         print("Verification: api_host contains runtime.{region}.kiro.dev pattern...")
         print(f"api_host: {manager.api_host}")
         assert "runtime.us-east-1.kiro.dev" in manager.api_host
         assert "us-east-1" in manager.api_host
-    
+
     def test_fingerprint_property(self):
         """
         What it does: Verifies fingerprint property.
@@ -495,7 +476,7 @@ class TestKiroAuthManagerProperties:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(refresh_token="test")
-        
+
         print("Verification: fingerprint accessible and has correct length...")
         print(f"fingerprint: {manager.fingerprint}")
         assert len(manager.fingerprint) == 64
@@ -505,9 +486,10 @@ class TestKiroAuthManagerProperties:
 # Tests for AuthType enum
 # =============================================================================
 
+
 class TestAuthTypeEnum:
     """Tests for AuthType enum."""
-    
+
     def test_auth_type_enum_values(self):
         """
         What it does: Verifies AuthType enum values.
@@ -515,10 +497,10 @@ class TestAuthTypeEnum:
         """
         print("Verification: AuthType contains KIRO_DESKTOP...")
         assert AuthType.KIRO_DESKTOP.value == "kiro_desktop"
-        
+
         print("Verification: AuthType contains AWS_SSO_OIDC...")
         assert AuthType.AWS_SSO_OIDC.value == "aws_sso_oidc"
-        
+
         print(f"Comparing value count: Expected 2, Got {len(AuthType)}")
         assert len(AuthType) == 2
 
@@ -527,9 +509,10 @@ class TestAuthTypeEnum:
 # Tests for _detect_auth_type()
 # =============================================================================
 
+
 class TestKiroAuthManagerDetectAuthType:
     """Tests for _detect_auth_type() method."""
-    
+
     def test_detect_auth_type_kiro_desktop_when_no_client_credentials(self):
         """
         What it does: Verifies KIRO_DESKTOP type detection without client credentials.
@@ -537,11 +520,11 @@ class TestKiroAuthManagerDetectAuthType:
         """
         print("Setup: Creating KiroAuthManager without client credentials...")
         manager = KiroAuthManager(refresh_token="test_token")
-        
+
         print("Verification: auth_type = KIRO_DESKTOP...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-    
+
     def test_detect_auth_type_aws_sso_oidc_when_client_credentials_present(self):
         """
         What it does: Verifies AWS_SSO_OIDC type detection with client credentials.
@@ -549,26 +532,21 @@ class TestKiroAuthManagerDetectAuthType:
         """
         print("Setup: Creating KiroAuthManager with client credentials...")
         manager = KiroAuthManager(
-            refresh_token="test_token",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_token", client_id="test_client_id", client_secret="test_client_secret"
         )
-        
+
         print("Verification: auth_type = AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_detect_auth_type_kiro_desktop_when_only_client_id(self):
         """
         What it does: Verifies type detection with only clientId (no secret).
         Purpose: Ensure KIRO_DESKTOP is used without clientSecret.
         """
         print("Setup: Creating KiroAuthManager with only client_id...")
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            client_id="test_client_id"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_token", client_id="test_client_id")
+
         print("Verification: auth_type = KIRO_DESKTOP (both id and secret required)...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
@@ -578,9 +556,10 @@ class TestKiroAuthManagerDetectAuthType:
 # Tests for loading AWS SSO credentials from JSON file
 # =============================================================================
 
+
 class TestKiroAuthManagerAwsSsoCredentialsFile:
     """Tests for loading AWS SSO OIDC credentials from JSON file."""
-    
+
     def test_load_credentials_from_file_with_client_id_and_secret(self, temp_aws_sso_creds_file):
         """
         What it does: Verifies loading clientId and clientSecret from JSON file.
@@ -588,15 +567,15 @@ class TestKiroAuthManagerAwsSsoCredentialsFile:
         """
         print(f"Setup: Creating KiroAuthManager with AWS SSO file: {temp_aws_sso_creds_file}")
         manager = KiroAuthManager(creds_file=temp_aws_sso_creds_file)
-        
+
         print("Verification: clientId loaded...")
         print(f"Comparing client_id: Expected 'test_client_id_12345', Got '{manager._client_id}'")
         assert manager._client_id == "test_client_id_12345"
-        
+
         print("Verification: clientSecret loaded...")
         print(f"Comparing client_secret: Expected 'test_client_secret_67890', Got '{manager._client_secret}'")
         assert manager._client_secret == "test_client_secret_67890"
-    
+
     def test_load_credentials_from_file_auto_detects_aws_sso_oidc(self, temp_aws_sso_creds_file):
         """
         What it does: Verifies auto-detection of auth type after loading from file.
@@ -604,11 +583,11 @@ class TestKiroAuthManagerAwsSsoCredentialsFile:
         """
         print(f"Setup: Creating KiroAuthManager with AWS SSO file: {temp_aws_sso_creds_file}")
         manager = KiroAuthManager(creds_file=temp_aws_sso_creds_file)
-        
+
         print("Verification: auth_type automatically detected as AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_load_kiro_desktop_file_stays_kiro_desktop(self, temp_creds_file):
         """
         What it does: Verifies that Kiro Desktop file doesn't change type to AWS SSO.
@@ -616,7 +595,7 @@ class TestKiroAuthManagerAwsSsoCredentialsFile:
         """
         print(f"Setup: Creating KiroAuthManager with Kiro Desktop file: {temp_creds_file}")
         manager = KiroAuthManager(creds_file=temp_creds_file)
-        
+
         print("Verification: auth_type stays KIRO_DESKTOP...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
@@ -626,9 +605,10 @@ class TestKiroAuthManagerAwsSsoCredentialsFile:
 # Tests for loading credentials from SQLite
 # =============================================================================
 
+
 class TestKiroAuthManagerSqliteCredentials:
     """Tests for loading credentials from SQLite database (kiro-cli format)."""
-    
+
     def test_load_credentials_from_sqlite_success(self, temp_sqlite_db):
         """
         What it does: Verifies successful loading of credentials from SQLite.
@@ -636,15 +616,15 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: access_token loaded...")
         print(f"Comparing access_token: Expected 'sqlite_access_token', Got '{manager._access_token}'")
         assert manager._access_token == "sqlite_access_token"
-        
+
         print("Verification: refresh_token loaded...")
         print(f"Comparing refresh_token: Expected 'sqlite_refresh_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "sqlite_refresh_token"
-    
+
     def test_load_credentials_from_sqlite_file_not_found(self, tmp_path):
         """
         What it does: Verifies handling of missing SQLite file.
@@ -652,16 +632,13 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print("Setup: Creating KiroAuthManager with non-existent SQLite file...")
         non_existent_db = str(tmp_path / "non_existent.sqlite3")
-        
-        manager = KiroAuthManager(
-            refresh_token="fallback_token",
-            sqlite_db=non_existent_db
-        )
-        
+
+        manager = KiroAuthManager(refresh_token="fallback_token", sqlite_db=non_existent_db)
+
         print("Verification: Fallback refresh_token is used...")
         print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "fallback_token"
-    
+
     def test_load_credentials_from_sqlite_loads_token_data(self, temp_sqlite_db):
         """
         What it does: Verifies loading token data from SQLite.
@@ -671,19 +648,19 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: SSO region loaded from SQLite...")
         print(f"Comparing sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region stays at us-east-1...")
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
-        
+
         print("Verification: expires_at parsed...")
         assert manager._expires_at is not None
         assert manager._expires_at.year == 2099
-    
+
     def test_load_credentials_from_sqlite_loads_device_registration(self, temp_sqlite_db):
         """
         What it does: Verifies loading device registration from SQLite.
@@ -691,15 +668,15 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: client_id loaded...")
         print(f"Comparing client_id: Expected 'sqlite_client_id', Got '{manager._client_id}'")
         assert manager._client_id == "sqlite_client_id"
-        
+
         print("Verification: client_secret loaded...")
         print(f"Comparing client_secret: Expected 'sqlite_client_secret', Got '{manager._client_secret}'")
         assert manager._client_secret == "sqlite_client_secret"
-    
+
     def test_load_credentials_from_sqlite_auto_detects_aws_sso_oidc(self, temp_sqlite_db):
         """
         What it does: Verifies auto-detection of auth type after loading from SQLite.
@@ -707,62 +684,56 @@ class TestKiroAuthManagerSqliteCredentials:
         """
         print(f"Setup: Creating KiroAuthManager with SQLite: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: auth_type automatically detected as AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_load_credentials_from_sqlite_handles_missing_registration_key(self, temp_sqlite_db_token_only):
         """
         What it does: Verifies handling of missing device-registration key.
         Purpose: Ensure application doesn't crash without device-registration.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite without device-registration...")
+        print("Setup: Creating KiroAuthManager with SQLite without device-registration...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_token_only)
-        
+
         print("Verification: refresh_token loaded...")
         assert manager._refresh_token == "partial_refresh_token"
-        
+
         print("Verification: client_id stayed None...")
         assert manager._client_id is None
-        
+
         print("Verification: auth_type = KIRO_DESKTOP (no client credentials)...")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-    
+
     def test_load_credentials_from_sqlite_handles_invalid_json(self, temp_sqlite_db_invalid_json):
         """
         What it does: Verifies handling of invalid JSON in SQLite.
         Purpose: Ensure application doesn't crash on invalid JSON.
         """
         print("Setup: Creating KiroAuthManager with SQLite with invalid JSON...")
-        manager = KiroAuthManager(
-            refresh_token="fallback_token",
-            sqlite_db=temp_sqlite_db_invalid_json
-        )
-        
+        manager = KiroAuthManager(refresh_token="fallback_token", sqlite_db=temp_sqlite_db_invalid_json)
+
         print("Verification: Fallback refresh_token is used...")
         print(f"Comparing refresh_token: Expected 'fallback_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "fallback_token"
-    
+
     def test_sqlite_takes_priority_over_json_file(self, temp_sqlite_db, temp_creds_file):
         """
         What it does: Verifies SQLite priority over JSON file.
         Purpose: Ensure SQLite is loaded instead of JSON when both specified.
         """
         print("Setup: Creating KiroAuthManager with SQLite and JSON file...")
-        manager = KiroAuthManager(
-            sqlite_db=temp_sqlite_db,
-            creds_file=temp_creds_file
-        )
-        
+        manager = KiroAuthManager(sqlite_db=temp_sqlite_db, creds_file=temp_creds_file)
+
         print("Verification: Data from SQLite (not from JSON)...")
         print(f"Comparing access_token: Expected 'sqlite_access_token', Got '{manager._access_token}'")
         assert manager._access_token == "sqlite_access_token"
-        
+
         print("Verification: SSO region from SQLite...")
         print(f"Comparing sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region stays at us-east-1...")
         print(f"Comparing region: Expected 'us-east-1', Got '{manager._region}'")
         assert manager._region == "us-east-1"
@@ -772,9 +743,10 @@ class TestKiroAuthManagerSqliteCredentials:
 # Tests for _refresh_token_request() routing
 # =============================================================================
 
+
 class TestKiroAuthManagerRefreshTokenRouting:
     """Tests for _refresh_token_request() routing based on auth_type."""
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_request_routes_to_kiro_desktop(self):
         """
@@ -784,18 +756,18 @@ class TestKiroAuthManagerRefreshTokenRouting:
         print("Setup: Creating KiroAuthManager with KIRO_DESKTOP...")
         manager = KiroAuthManager(refresh_token="test_refresh")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-        
+
         print("Setup: Mocking _refresh_token_kiro_desktop...")
-        with patch.object(manager, '_refresh_token_kiro_desktop', new_callable=AsyncMock) as mock_desktop:
-            with patch.object(manager, '_refresh_token_aws_sso_oidc', new_callable=AsyncMock) as mock_sso:
+        with patch.object(manager, "_refresh_token_kiro_desktop", new_callable=AsyncMock) as mock_desktop:
+            with patch.object(manager, "_refresh_token_aws_sso_oidc", new_callable=AsyncMock) as mock_sso:
                 await manager._refresh_token_request()
-                
+
                 print("Verification: _refresh_token_kiro_desktop was called...")
                 mock_desktop.assert_called_once()
-                
+
                 print("Verification: _refresh_token_aws_sso_oidc was NOT called...")
                 mock_sso.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_request_routes_to_aws_sso_oidc(self):
         """
@@ -804,20 +776,18 @@ class TestKiroAuthManagerRefreshTokenRouting:
         """
         print("Setup: Creating KiroAuthManager with AWS_SSO_OIDC...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-        
+
         print("Setup: Mocking _refresh_token_aws_sso_oidc...")
-        with patch.object(manager, '_refresh_token_kiro_desktop', new_callable=AsyncMock) as mock_desktop:
-            with patch.object(manager, '_refresh_token_aws_sso_oidc', new_callable=AsyncMock) as mock_sso:
+        with patch.object(manager, "_refresh_token_kiro_desktop", new_callable=AsyncMock) as mock_desktop:
+            with patch.object(manager, "_refresh_token_aws_sso_oidc", new_callable=AsyncMock) as mock_sso:
                 await manager._refresh_token_request()
-                
+
                 print("Verification: _refresh_token_aws_sso_oidc was called...")
                 mock_sso.assert_called_once()
-                
+
                 print("Verification: _refresh_token_kiro_desktop was NOT called...")
                 mock_desktop.assert_not_called()
 
@@ -826,9 +796,10 @@ class TestKiroAuthManagerRefreshTokenRouting:
 # Tests for _refresh_token_aws_sso_oidc()
 # =============================================================================
 
+
 class TestKiroAuthManagerAwsSsoOidcRefresh:
     """Tests for _refresh_token_aws_sso_oidc() method."""
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_success(self, mock_aws_sso_oidc_token_response):
         """
@@ -840,32 +811,32 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="us-east-1"
+            region="us-east-1",
         )
-        
+
         print("Setup: Mocking successful response from AWS SSO OIDC...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc()...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Token set correctly...")
             print(f"Comparing access_token: Expected 'new_aws_sso_access_token', Got '{manager._access_token}'")
             assert manager._access_token == "new_aws_sso_access_token"
-            
+
             print("Verification: Expiration time set...")
             assert manager._expires_at is not None
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_raises_without_refresh_token(self):
         """
@@ -873,19 +844,16 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         Purpose: Ensure ValueError is raised without refresh_token.
         """
         print("Setup: Creating KiroAuthManager without refresh_token...")
-        manager = KiroAuthManager(
-            client_id="test_client_id",
-            client_secret="test_client_secret"
-        )
+        manager = KiroAuthManager(client_id="test_client_id", client_secret="test_client_secret")
         manager._refresh_token = None
-        
+
         print("Action: Attempting token refresh without refresh_token...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_aws_sso_oidc()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Refresh token" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_raises_without_client_id(self):
         """
@@ -893,20 +861,17 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         Purpose: Ensure ValueError is raised without client_id.
         """
         print("Setup: Creating KiroAuthManager without client_id...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_secret="test_client_secret"
-        )
+        manager = KiroAuthManager(refresh_token="test_refresh", client_secret="test_client_secret")
         manager._client_id = None
         manager._auth_type = AuthType.AWS_SSO_OIDC
-        
+
         print("Action: Attempting token refresh without client_id...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_aws_sso_oidc()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Client ID" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_raises_without_client_secret(self):
         """
@@ -914,20 +879,17 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         Purpose: Ensure ValueError is raised without client_secret.
         """
         print("Setup: Creating KiroAuthManager without client_secret...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id"
-        )
+        manager = KiroAuthManager(refresh_token="test_refresh", client_id="test_client_id")
         manager._client_secret = None
         manager._auth_type = AuthType.AWS_SSO_OIDC
-        
+
         print("Action: Attempting token refresh without client_secret...")
         with pytest.raises(ValueError) as exc_info:
             await manager._refresh_token_aws_sso_oidc()
-        
+
         print(f"Verification: ValueError raised: {exc_info.value}")
         assert "Client secret" in str(exc_info.value)
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_uses_correct_endpoint(self, mock_aws_sso_oidc_token_response):
         """
@@ -939,31 +901,31 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="eu-west-1"
+            region="eu-west-1",
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: POST request to correct URL...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
             expected_url = "https://oidc.eu-west-1.amazonaws.com/token"
             print(f"Comparing URL: Expected '{expected_url}', Got '{url}'")
             assert url == expected_url
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_uses_json_format(self, mock_aws_sso_oidc_token_response):
         """
@@ -972,32 +934,30 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Content-Type = application/json...")
             call_args = mock_client.post.call_args
-            headers = call_args[1].get('headers', {})
+            headers = call_args[1].get("headers", {})
             print(f"Comparing Content-Type: Expected 'application/json', Got '{headers.get('Content-Type')}'")
-            assert headers.get('Content-Type') == 'application/json'
-    
+            assert headers.get("Content-Type") == "application/json"
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_sends_correct_grant_type(self, mock_aws_sso_oidc_token_response):
         """
@@ -1006,32 +966,30 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: grantType = refresh_token (camelCase in JSON)...")
             call_args = mock_client.post.call_args
-            json_payload = call_args[1].get('json', {})
+            json_payload = call_args[1].get("json", {})
             print(f"Comparing grantType: Expected 'refresh_token', Got '{json_payload.get('grantType')}'")
-            assert json_payload.get('grantType') == 'refresh_token'
-    
+            assert json_payload.get("grantType") == "refresh_token"
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_updates_tokens(self, mock_aws_sso_oidc_token_response):
         """
@@ -1040,32 +998,30 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(
-            refresh_token="old_refresh_token",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="old_refresh_token", client_id="test_client_id", client_secret="test_client_secret"
         )
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: access_token updated...")
             assert manager._access_token == "new_aws_sso_access_token"
-            
+
             print("Verification: refresh_token updated...")
             assert manager._refresh_token == "new_aws_sso_refresh_token"
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_calculates_expiration(self, mock_aws_sso_oidc_token_response):
         """
@@ -1074,34 +1030,33 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
-        
+
         print("Setup: Mocking HTTP client with expiresIn=7200...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response(expires_in=7200))
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: expires_at set...")
             assert manager._expires_at is not None
-            
+
             print("Verification: expires_at in the future...")
             from datetime import datetime, timezone
+
             now = datetime.now(timezone.utc)
             assert manager._expires_at > now
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_does_not_send_scopes(self, mock_aws_sso_oidc_token_response):
         """
@@ -1111,39 +1066,37 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager with scopes...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
         # Simulate scopes loaded from SQLite (this is what caused the bug)
         manager._scopes = ["codewhisperer:completions", "codewhisperer:analysis"]
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: scope NOT in JSON payload...")
             call_args = mock_client.post.call_args
-            json_payload = call_args[1].get('json', {})
+            json_payload = call_args[1].get("json", {})
             print(f"Request JSON keys: {list(json_payload.keys())}")
-            assert 'scope' not in json_payload, "scope should NOT be sent in refresh request"
-            
+            assert "scope" not in json_payload, "scope should NOT be sent in refresh request"
+
             print("Verification: only required fields sent (camelCase)...")
-            expected_keys = {'grantType', 'clientId', 'clientSecret', 'refreshToken'}
+            expected_keys = {"grantType", "clientId", "clientSecret", "refreshToken"}
             print(f"Comparing keys: Expected {expected_keys}, Got {set(json_payload.keys())}")
             assert set(json_payload.keys()) == expected_keys
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_works_without_scopes(self, mock_aws_sso_oidc_token_response):
         """
@@ -1152,44 +1105,43 @@ class TestKiroAuthManagerAwsSsoOidcRefresh:
         """
         print("Setup: Creating KiroAuthManager without scopes...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
         # Explicitly set scopes to None (default state)
         manager._scopes = None
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Token refreshed successfully...")
             assert manager._access_token == "new_aws_sso_access_token"
-            
+
             print("Verification: scope NOT in request JSON payload...")
             call_args = mock_client.post.call_args
-            json_payload = call_args[1].get('json', {})
-            assert 'scope' not in json_payload
+            json_payload = call_args[1].get("json", {})
+            assert "scope" not in json_payload
 
 
 # =============================================================================
 # Tests for auth_type property and constructor with new parameters
 # =============================================================================
 
+
 class TestKiroAuthManagerAuthTypeProperty:
     """Tests for auth_type property and constructor."""
-    
+
     def test_auth_type_property_returns_correct_value(self):
         """
         What it does: Verifies that auth_type property returns correct value.
@@ -1197,38 +1149,30 @@ class TestKiroAuthManagerAuthTypeProperty:
         """
         print("Setup: Creating KiroAuthManager with KIRO_DESKTOP...")
         manager_desktop = KiroAuthManager(refresh_token="test")
-        
+
         print("Verification: auth_type = KIRO_DESKTOP...")
         assert manager_desktop.auth_type == AuthType.KIRO_DESKTOP
-        
+
         print("Setup: Creating KiroAuthManager with AWS_SSO_OIDC...")
-        manager_sso = KiroAuthManager(
-            refresh_token="test",
-            client_id="id",
-            client_secret="secret"
-        )
-        
+        manager_sso = KiroAuthManager(refresh_token="test", client_id="id", client_secret="secret")
+
         print("Verification: auth_type = AWS_SSO_OIDC...")
         assert manager_sso.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_init_with_client_id_and_secret(self):
         """
         What it does: Verifies initialization with client_id and client_secret.
         Purpose: Ensure parameters are stored in private fields.
         """
         print("Setup: Creating KiroAuthManager with client credentials...")
-        manager = KiroAuthManager(
-            refresh_token="test",
-            client_id="my_client_id",
-            client_secret="my_client_secret"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test", client_id="my_client_id", client_secret="my_client_secret")
+
         print("Verification: client_id stored...")
         assert manager._client_id == "my_client_id"
-        
+
         print("Verification: client_secret stored...")
         assert manager._client_secret == "my_client_secret"
-    
+
     def test_init_with_sqlite_db_parameter(self, temp_sqlite_db):
         """
         What it does: Verifies initialization with sqlite_db parameter.
@@ -1236,22 +1180,19 @@ class TestKiroAuthManagerAuthTypeProperty:
         """
         print(f"Setup: Creating KiroAuthManager with sqlite_db: {temp_sqlite_db}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: Data loaded from SQLite...")
         assert manager._access_token == "sqlite_access_token"
         assert manager._refresh_token == "sqlite_refresh_token"
-    
+
     def test_detect_auth_type_kiro_desktop_when_only_client_secret(self):
         """
         What it does: Verifies type detection with only clientSecret (no id).
         Purpose: Ensure KIRO_DESKTOP is used without clientId.
         """
         print("Setup: Creating KiroAuthManager with only client_secret...")
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            client_secret="test_client_secret"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_token", client_secret="test_client_secret")
+
         print("Verification: auth_type = KIRO_DESKTOP (both id and secret required)...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
@@ -1261,67 +1202,65 @@ class TestKiroAuthManagerAuthTypeProperty:
 # Tests for SSO region separation (Issue #16)
 # =============================================================================
 
+
 class TestKiroAuthManagerSsoRegionSeparation:
     """Tests for SSO region separation from API region (Issue #16 fix).
-    
+
     Background: CodeWhisperer API only exists in us-east-1, but users may have
     SSO credentials from other regions (e.g., ap-southeast-1 for Singapore).
     The fix separates SSO region (for OIDC token refresh) from API region.
     """
-    
+
     def test_api_region_uses_sso_region_as_fallback_when_no_profile_arn(self, temp_sqlite_db):
         """
         What it does: Verifies API region uses SSO region as fallback when profile ARN is not available.
         Purpose: Ensure graceful fallback when state table doesn't exist or profile key is missing.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite (SSO region=eu-west-1, no profile ARN)...")
+        print("Setup: Creating KiroAuthManager with SQLite (SSO region=eu-west-1, no profile ARN)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: SSO region loaded from SQLite...")
         print(f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: No API region detected from profile ARN...")
         print(f"Comparing _detected_api_region: Expected None, Got '{manager._detected_api_region}'")
         assert manager._detected_api_region is None
-        
+
         print("Verification: API region uses SSO region as fallback...")
         print(f"api_host: {manager._api_host}")
         assert "eu-west-1" in manager._api_host
-        
+
         print(f"q_host: {manager._q_host}")
         assert "eu-west-1" in manager._q_host
-    
+
     def test_sso_region_stored_separately_from_api_region(self, temp_sqlite_db):
         """
         What it does: Verifies SSO region is stored in _sso_region field.
         Purpose: Ensure SSO region is available for OIDC token refresh.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
+        print("Setup: Creating KiroAuthManager with SQLite (region=eu-west-1)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: SSO region stored in _sso_region...")
         print(f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region is different from SSO region...")
         assert manager._region != manager._sso_region
-    
+
     def test_sso_region_none_when_not_loaded_from_sqlite(self):
         """
         What it does: Verifies _sso_region is None when not loading from SQLite.
         Purpose: Ensure backward compatibility with direct credential initialization.
         """
         print("Setup: Creating KiroAuthManager with direct credentials...")
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_token", region="us-east-1")
+
         print("Verification: _sso_region is None...")
         print(f"Comparing _sso_region: Expected None, Got '{manager._sso_region}'")
         assert manager._sso_region is None
-    
+
     @pytest.mark.asyncio
     async def test_oidc_refresh_uses_sso_region(self, mock_aws_sso_oidc_token_response):
         """
@@ -1333,26 +1272,26 @@ class TestKiroAuthManagerSsoRegionSeparation:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="us-east-1"  # API region
+            region="us-east-1",  # API region
         )
         # Simulate SSO region loaded from SQLite
         manager._sso_region = "ap-southeast-1"
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: OIDC request went to SSO region (ap-southeast-1)...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
@@ -1361,7 +1300,7 @@ class TestKiroAuthManagerSsoRegionSeparation:
             assert url == expected_url
             assert "ap-southeast-1" in url
             assert "us-east-1" not in url
-    
+
     @pytest.mark.asyncio
     async def test_oidc_refresh_falls_back_to_api_region_when_no_sso_region(self, mock_aws_sso_oidc_token_response):
         """
@@ -1373,96 +1312,92 @@ class TestKiroAuthManagerSsoRegionSeparation:
             refresh_token="test_refresh",
             client_id="test_client_id",
             client_secret="test_client_secret",
-            region="eu-west-1"  # API region (also used for OIDC when no SSO region)
+            region="eu-west-1",  # API region (also used for OIDC when no SSO region)
         )
         # Ensure _sso_region is None
         manager._sso_region = None
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: OIDC request fell back to API region (eu-west-1)...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
             expected_url = "https://oidc.eu-west-1.amazonaws.com/token"
             print(f"Comparing URL: Expected '{expected_url}', Got '{url}'")
             assert url == expected_url
-    
+
     def test_refresh_url_uses_sso_region_when_loading_from_sqlite(self, temp_sqlite_db):
         """
         What it does: Verifies refresh_url uses SSO region for OIDC token refresh.
         Purpose: Ensure OIDC token refresh goes to correct regional endpoint.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite (SSO region=eu-west-1)...")
+        print("Setup: Creating KiroAuthManager with SQLite (SSO region=eu-west-1)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: SSO region loaded...")
         print(f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: _refresh_url uses SSO region for OIDC...")
         print(f"_refresh_url: {manager._refresh_url}")
         assert "eu-west-1" in manager._refresh_url
-        
+
         print("Verification: API hosts use SSO region as fallback (no profile ARN)...")
         assert "eu-west-1" in manager._api_host
         assert "eu-west-1" in manager._q_host
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_uses_memory_token_first(
-        self, mock_aws_sso_oidc_token_response
-    ):
+    async def test_refresh_token_aws_sso_oidc_uses_memory_token_first(self, mock_aws_sso_oidc_token_response):
         """
         What it does: Verifies that in-memory token is used first, not SQLite.
         Purpose: Ensure container's successfully refreshed token is used (not overwritten by SQLite).
         """
         print("Setup: Creating KiroAuthManager with in-memory credentials...")
         manager = KiroAuthManager(
-            refresh_token="memory_refresh_token",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="memory_refresh_token", client_id="test_client_id", client_secret="test_client_secret"
         )
         # Simulate SQLite path being set (but we won't actually use it)
         manager._sqlite_db = "/fake/path/data.sqlite3"
-        
+
         print("Setup: Mocking HTTP client for successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             # Patch _load_credentials_from_sqlite to track if it's called
-            with patch.object(manager, '_load_credentials_from_sqlite') as mock_load:
+            with patch.object(manager, "_load_credentials_from_sqlite") as mock_load:
                 await manager._refresh_token_aws_sso_oidc()
-                
+
                 print("Verification: SQLite was NOT reloaded (success on first try)...")
                 mock_load.assert_not_called()
-                
+
                 print("Verification: Request used in-memory token...")
                 call_args = mock_client.post.call_args
-                json_payload = call_args[1].get('json', {})
+                json_payload = call_args[1].get("json", {})
                 print(f"Refresh token sent: {json_payload.get('refreshToken')}")
-                assert json_payload.get('refreshToken') == "memory_refresh_token"
-    
+                assert json_payload.get("refreshToken") == "memory_refresh_token"
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_reloads_sqlite_on_400_error(
         self, tmp_path, mock_aws_sso_oidc_token_response
@@ -1471,220 +1406,199 @@ class TestKiroAuthManagerSsoRegionSeparation:
         What it does: Verifies SQLite is reloaded and retry happens on 400 error.
         Purpose: Pick up fresh tokens after kiro-cli re-login when in-memory token is stale.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         # Setup: Create initial SQLite database
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Initial token data (will become stale)
         initial_token_data = {
             "access_token": "old_access_token",
             "refresh_token": "old_refresh_token",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data))
+            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
-        
+
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Initial refresh_token loaded...")
         assert manager._refresh_token == "old_refresh_token"
-        
+
         # Simulate kiro-cli updating the SQLite with fresh tokens
         print("Action: Simulating kiro-cli token refresh (updating SQLite)...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         new_token_data = {
             "access_token": "new_access_token",
             "refresh_token": "new_refresh_token_from_kiro_cli",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "UPDATE auth_kv SET value = ? WHERE key = ?",
-            (json.dumps(new_token_data), "codewhisperer:odic:token")
+            "UPDATE auth_kv SET value = ? WHERE key = ?", (json.dumps(new_token_data), "codewhisperer:odic:token")
         )
         conn.commit()
         conn.close()
-        
+
         # Manager still has old token in memory
         print("Verification: Manager still has old refresh_token in memory...")
         assert manager._refresh_token == "old_refresh_token"
-        
+
         # Mock HTTP client: first call fails with 400, second succeeds
         print("Setup: Mocking HTTP client (first=400, second=200)...")
-        
+
         # First response: 400 error (stale token)
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
         mock_error_response.text = '{"error":"invalid_request","error_description":"Invalid request"}'
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
-            side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
-            )
+            side_effect=httpx.HTTPStatusError("400 Bad Request", request=Mock(), response=mock_error_response)
         )
-        
+
         # Second response: success
         mock_success_response = AsyncMock()
         mock_success_response.status_code = 200
         mock_success_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_success_response.raise_for_status = Mock()
-        
+
         call_count = 0
         sent_tokens = []
-        
+
         async def mock_post(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            sent_tokens.append(kwargs.get('json', {}).get('refreshToken'))
+            sent_tokens.append(kwargs.get("json", {}).get("refreshToken"))
             if call_count == 1:
                 return mock_error_response
             return mock_success_response
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = mock_post
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Two requests were made (retry on 400)...")
             print(f"Call count: {call_count}")
             assert call_count == 2, "Should retry after 400 error"
-            
+
             print("Verification: First request used OLD token from memory...")
             print(f"First token sent: {sent_tokens[0]}")
             assert sent_tokens[0] == "old_refresh_token"
-            
+
             print("Verification: Second request used NEW token from SQLite...")
             print(f"Second token sent: {sent_tokens[1]}")
             assert sent_tokens[1] == "new_refresh_token_from_kiro_cli"
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_no_retry_on_non_400_error(
-        self, mock_aws_sso_oidc_token_response
-    ):
+    async def test_refresh_token_aws_sso_oidc_no_retry_on_non_400_error(self, mock_aws_sso_oidc_token_response):
         """
         What it does: Verifies that non-400 errors are not retried.
         Purpose: Ensure only 400 (invalid_request) triggers SQLite reload.
         """
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
         manager._sqlite_db = "/fake/path/data.sqlite3"
-        
+
         print("Setup: Mocking HTTP client with 500 error...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 500
         mock_error_response.text = "Internal Server Error"
         mock_error_response.json = Mock(side_effect=Exception("Not JSON"))
         mock_error_response.raise_for_status = Mock(
-            side_effect=httpx.HTTPStatusError(
-                "500 Internal Server Error",
-                request=Mock(),
-                response=mock_error_response
-            )
+            side_effect=httpx.HTTPStatusError("500 Internal Server Error", request=Mock(), response=mock_error_response)
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
-            with patch.object(manager, '_load_credentials_from_sqlite') as mock_load:
+
+            with patch.object(manager, "_load_credentials_from_sqlite") as mock_load:
                 print("Action: Calling _refresh_token_aws_sso_oidc (expecting 500 error)...")
                 with pytest.raises(httpx.HTTPStatusError) as exc_info:
                     await manager._refresh_token_aws_sso_oidc()
-                
+
                 print("Verification: 500 error was raised (not retried)...")
                 assert exc_info.value.response.status_code == 500
-                
+
                 print("Verification: SQLite was NOT reloaded (500 != 400)...")
                 mock_load.assert_not_called()
-    
+
     @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_no_retry_without_sqlite_db(
-        self, mock_aws_sso_oidc_token_response
-    ):
+    async def test_refresh_token_aws_sso_oidc_no_retry_without_sqlite_db(self, mock_aws_sso_oidc_token_response):
         """
         What it does: Verifies that 400 error is not retried when sqlite_db is not set.
         Purpose: Ensure retry only happens when SQLite source is available.
         """
         print("Setup: Creating KiroAuthManager WITHOUT sqlite_db...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
         # Explicitly ensure no sqlite_db
         manager._sqlite_db = None
-        
+
         print("Setup: Mocking HTTP client with 400 error...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
         mock_error_response.text = '{"error":"invalid_request"}'
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
-            side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
-            )
+            side_effect=httpx.HTTPStatusError("400 Bad Request", request=Mock(), response=mock_error_response)
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc (expecting 400 error)...")
             with pytest.raises(httpx.HTTPStatusError) as exc_info:
                 await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: 400 error was raised (no retry without sqlite_db)...")
             assert exc_info.value.response.status_code == 400
-            
+
             print("Verification: Only one request was made...")
             assert mock_client.post.call_count == 1
 
@@ -1693,13 +1607,14 @@ class TestKiroAuthManagerSsoRegionSeparation:
 # Tests for is_token_expired() method
 # =============================================================================
 
+
 class TestKiroAuthManagerIsTokenExpired:
     """Tests for is_token_expired() method.
-    
+
     This method checks if the token has actually expired (not just expiring soon).
     Used for graceful degradation when refresh fails.
     """
-    
+
     def test_is_token_expired_returns_true_when_no_expires_at(self):
         """
         What it does: Verifies that without expires_at token is considered expired.
@@ -1708,12 +1623,12 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager without expires_at...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = None
-        
+
         print("Verification: is_token_expired returns True...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expired_returns_true_when_expired(self):
         """
         What it does: Verifies that expired token is correctly identified.
@@ -1722,12 +1637,12 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager with expired token...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-        
+
         print("Verification: is_token_expired returns True for expired token...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     def test_is_token_expired_returns_false_when_valid(self):
         """
         What it does: Verifies that valid token is not considered expired.
@@ -1736,12 +1651,12 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager with valid token...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Verification: is_token_expired returns False...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
-    
+
     def test_is_token_expired_returns_false_when_expiring_soon_but_not_expired(self):
         """
         What it does: Verifies difference between expiring soon and actually expired.
@@ -1750,10 +1665,10 @@ class TestKiroAuthManagerIsTokenExpired:
         print("Setup: Creating KiroAuthManager with token expiring in 5 minutes...")
         manager = KiroAuthManager(refresh_token="test_token")
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print("Verification: is_token_expiring_soon returns True (within threshold)...")
         assert manager.is_token_expiring_soon() is True
-        
+
         print("Verification: is_token_expired returns False (not actually expired)...")
         result = manager.is_token_expired()
         print(f"Comparing result: Expected False, Got {result}")
@@ -1764,236 +1679,222 @@ class TestKiroAuthManagerIsTokenExpired:
 # Tests for graceful degradation in get_access_token() (SQLite mode)
 # =============================================================================
 
+
 class TestKiroAuthManagerGracefulDegradation:
     """Tests for graceful degradation when refresh fails in SQLite mode.
-    
+
     Background: When kiro-cli refreshes tokens in memory without persisting to SQLite,
     the refresh_token in SQLite becomes stale. The gateway should gracefully fall back
     to using the access_token directly until it actually expires.
     """
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_reloads_sqlite_when_expiring_soon(self, tmp_path):
         """
         What it does: Verifies SQLite is reloaded when token is expiring soon.
         Purpose: Pick up fresh tokens from kiro-cli before attempting refresh.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database with fresh token...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Token that expires in 1 hour (fresh)
         fresh_token_data = {
             "access_token": "fresh_access_token",
             "refresh_token": "fresh_refresh_token",
             "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(fresh_token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(fresh_token_data))
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with expiring token...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
         # Simulate token expiring soon (within threshold)
         manager._access_token = "old_expiring_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print("Verification: Token is expiring soon...")
         assert manager.is_token_expiring_soon() is True
-        
+
         print("Action: Calling get_access_token()...")
         token = await manager.get_access_token()
-        
+
         print("Verification: Got fresh token from SQLite reload...")
         print(f"Comparing token: Expected 'fresh_access_token', Got '{token}'")
         assert token == "fresh_access_token"
-    
+
     @pytest.mark.asyncio
-    async def test_get_access_token_graceful_fallback_when_refresh_fails_but_token_valid(
-        self, tmp_path
-    ):
+    async def test_get_access_token_graceful_fallback_when_refresh_fails_but_token_valid(self, tmp_path):
         """
         What it does: Verifies graceful fallback when refresh fails with 400 but access_token still valid.
         Purpose: Use existing access_token until it actually expires when kiro-cli owns refresh.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Token that is expiring soon but NOT expired yet
         token_data = {
             "access_token": "still_valid_access_token",
             "refresh_token": "stale_refresh_token",
             "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Token is expiring soon but NOT expired...")
         assert manager.is_token_expiring_soon() is True
         assert manager.is_token_expired() is False
-        
+
         print("Setup: Mocking HTTP client to return 400 twice (stale refresh token)...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
         mock_error_response.text = '{"error":"invalid_request"}'
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
-            side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
-            )
+            side_effect=httpx.HTTPStatusError("400 Bad Request", request=Mock(), response=mock_error_response)
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling get_access_token() (expecting graceful fallback)...")
             token = await manager.get_access_token()
-            
+
             print("Verification: Got existing access_token (graceful fallback)...")
             print(f"Comparing token: Expected 'still_valid_access_token', Got '{token}'")
             assert token == "still_valid_access_token"
-    
+
     @pytest.mark.asyncio
-    async def test_get_access_token_raises_when_refresh_fails_and_token_expired(
-        self, tmp_path
-    ):
+    async def test_get_access_token_raises_when_refresh_fails_and_token_expired(self, tmp_path):
         """
         What it does: Verifies error is raised when refresh fails and access_token is expired.
         Purpose: Clear error message when user needs to run 'kiro-cli login'.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database with expired token...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Token that is already expired
         token_data = {
             "access_token": "expired_access_token",
             "refresh_token": "stale_refresh_token",
             "expires_at": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("codewhisperer:odic:token", json.dumps(token_data))
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Token is expired...")
         assert manager.is_token_expired() is True
-        
+
         print("Setup: Mocking HTTP client to return 400 (stale refresh token)...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
         mock_error_response.text = '{"error":"invalid_request"}'
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
-            side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
-            )
+            side_effect=httpx.HTTPStatusError("400 Bad Request", request=Mock(), response=mock_error_response)
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling get_access_token() (expecting ValueError)...")
             with pytest.raises(ValueError) as exc_info:
                 await manager.get_access_token()
-            
+
             print(f"Verification: ValueError raised with helpful message: {exc_info.value}")
             assert "kiro-cli login" in str(exc_info.value).lower()
-    
+
     @pytest.mark.asyncio
     async def test_get_access_token_non_sqlite_mode_propagates_400_error(self):
         """
@@ -2002,40 +1903,34 @@ class TestKiroAuthManagerGracefulDegradation:
         """
         print("Setup: Creating KiroAuthManager WITHOUT sqlite_db...")
         manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            client_id="test_client_id",
-            client_secret="test_client_secret"
+            refresh_token="test_refresh", client_id="test_client_id", client_secret="test_client_secret"
         )
         manager._access_token = "expiring_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
-        
+
         print("Verification: No sqlite_db set...")
         assert manager._sqlite_db is None
-        
+
         print("Setup: Mocking HTTP client to return 400...")
         mock_error_response = AsyncMock()
         mock_error_response.status_code = 400
         mock_error_response.text = '{"error":"invalid_request"}'
         mock_error_response.json = Mock(return_value={"error": "invalid_request"})
         mock_error_response.raise_for_status = Mock(
-            side_effect=httpx.HTTPStatusError(
-                "400 Bad Request",
-                request=Mock(),
-                response=mock_error_response
-            )
+            side_effect=httpx.HTTPStatusError("400 Bad Request", request=Mock(), response=mock_error_response)
         )
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_error_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling get_access_token() (expecting HTTPStatusError)...")
             with pytest.raises(httpx.HTTPStatusError) as exc_info:
                 await manager.get_access_token()
-            
+
             print("Verification: 400 error was propagated (no graceful degradation)...")
             assert exc_info.value.response.status_code == 400
 
@@ -2044,74 +1939,75 @@ class TestKiroAuthManagerGracefulDegradation:
 # Tests for _save_credentials_to_sqlite() - NEW FUNCTIONALITY
 # =============================================================================
 
+
 class TestKiroAuthManagerSaveCredentialsToSqlite:
     """Tests for _save_credentials_to_sqlite() method (Issue #43 fix).
-    
+
     Background: Gateway was not persisting refreshed tokens back to SQLite,
     causing stale tokens to be reloaded after 1-2 hours.
     """
-    
+
     def test_save_credentials_to_sqlite_writes_token_data(self, tmp_path):
         """
         What it does: Verifies that _save_credentials_to_sqlite writes token data.
         Purpose: Ensure tokens are persisted to SQLite after refresh.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Initial token data
         initial_token_data = {
             "access_token": "old_access_token",
             "refresh_token": "old_refresh_token",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data))
+            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating tokens in memory...")
         manager._access_token = "new_access_token"
         manager._refresh_token = "new_refresh_token"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _save_credentials_to_sqlite()...")
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite to check saved data...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print(f"Comparing access_token: Expected 'new_access_token', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "new_access_token"
-        
+        assert saved_data["access_token"] == "new_access_token"
+
         print(f"Comparing refresh_token: Expected 'new_refresh_token', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "new_refresh_token"
-    
+        assert saved_data["refresh_token"] == "new_refresh_token"
+
     def test_save_credentials_to_sqlite_handles_missing_database(self, tmp_path):
         """
         What it does: Verifies handling of missing SQLite file.
@@ -2119,20 +2015,17 @@ class TestKiroAuthManagerSaveCredentialsToSqlite:
         """
         print("Setup: Creating KiroAuthManager with non-existent SQLite...")
         non_existent_db = str(tmp_path / "non_existent.sqlite3")
-        
-        manager = KiroAuthManager(
-            refresh_token="test_token",
-            sqlite_db=non_existent_db
-        )
+
+        manager = KiroAuthManager(refresh_token="test_token", sqlite_db=non_existent_db)
         manager._access_token = "new_token"
-        
+
         print("Action: Calling _save_credentials_to_sqlite() with missing database...")
         # Should not raise exception
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: No exception raised...")
         assert True
-    
+
     def test_save_credentials_to_sqlite_returns_early_when_no_sqlite_db(self):
         """
         What it does: Verifies early return when sqlite_db is None.
@@ -2142,11 +2035,11 @@ class TestKiroAuthManagerSaveCredentialsToSqlite:
         manager = KiroAuthManager(refresh_token="test_token")
         manager._sqlite_db = None
         manager._access_token = "new_token"
-        
+
         print("Action: Calling _save_credentials_to_sqlite()...")
         # Should return early without doing anything
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: No exception raised...")
         assert True
 
@@ -2155,179 +2048,184 @@ class TestKiroAuthManagerSaveCredentialsToSqlite:
 # Tests for token persistence after refresh (Issue #43 fix)
 # =============================================================================
 
+
 class TestKiroAuthManagerTokenPersistence:
     """Tests for token persistence after refresh.
-    
+
     Background: After refresh, tokens must be saved to SQLite so they're
     available after gateway restart or when reloaded.
     """
-    
+
     @pytest.mark.asyncio
     async def test_refresh_token_aws_sso_oidc_saves_to_sqlite(self, tmp_path, mock_aws_sso_oidc_token_response):
         """
         What it does: Verifies tokens are saved to SQLite after AWS SSO OIDC refresh.
         Purpose: Ensure refreshed tokens are persisted (Issue #43 fix).
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         initial_token_data = {
             "access_token": "old_access_token",
             "refresh_token": "old_refresh_token",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data))
+            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
         )
-        
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data))
+            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Setup: Mocking HTTP client for successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _do_aws_sso_oidc_refresh()...")
             await manager._do_aws_sso_oidc_refresh()
-            
+
             print("Verification: Tokens updated in memory...")
             assert manager._access_token == "new_aws_sso_access_token"
             assert manager._refresh_token == "new_aws_sso_refresh_token"
-            
+
             print("Verification: Reading SQLite to check persistence...")
             conn = sqlite3.connect(str(db_file))
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
             row = cursor.fetchone()
             conn.close()
-            
+
             assert row is not None
             saved_data = json.loads(row[0])
-            
-            print(f"Comparing saved access_token: Expected 'new_aws_sso_access_token', Got '{saved_data['access_token']}'")
-            assert saved_data['access_token'] == "new_aws_sso_access_token"
-            
-            print(f"Comparing saved refresh_token: Expected 'new_aws_sso_refresh_token', Got '{saved_data['refresh_token']}'")
-            assert saved_data['refresh_token'] == "new_aws_sso_refresh_token"
-    
+
+            print(
+                f"Comparing saved access_token: Expected 'new_aws_sso_access_token', Got '{saved_data['access_token']}'"
+            )
+            assert saved_data["access_token"] == "new_aws_sso_access_token"
+
+            print(
+                f"Comparing saved refresh_token: Expected 'new_aws_sso_refresh_token', Got '{saved_data['refresh_token']}'"
+            )
+            assert saved_data["refresh_token"] == "new_aws_sso_refresh_token"
+
     @pytest.mark.asyncio
     async def test_refresh_token_kiro_desktop_saves_to_sqlite(self, tmp_path, mock_kiro_token_response):
         """
         What it does: Verifies tokens are saved to SQLite after Kiro Desktop refresh.
         Purpose: Ensure consistency between both refresh methods.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database...")
         db_file = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         initial_token_data = {
             "access_token": "old_access_token",
             "refresh_token": "old_refresh_token",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data))
+            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite and Kiro Desktop auth...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            sqlite_db=str(db_file)
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
+
         print("Setup: Mocking HTTP client for successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_kiro_desktop()...")
             await manager._refresh_token_kiro_desktop()
-            
+
             print("Verification: Reading SQLite to check persistence...")
             conn = sqlite3.connect(str(db_file))
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
             row = cursor.fetchone()
             conn.close()
-            
+
             assert row is not None
             saved_data = json.loads(row[0])
-            
-            print(f"Comparing saved refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'")
-            assert saved_data['refresh_token'] == "new_refresh_token_xyz"
+
+            print(
+                f"Comparing saved refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'"
+            )
+            assert saved_data["refresh_token"] == "new_refresh_token_xyz"
 
 
 # =============================================================================
 # Tests for Social Login Support (kirocli:social:token)
 # =============================================================================
 
+
 class TestKiroAuthManagerSocialLogin:
     """Tests for social login support (Google, GitHub, etc.).
-    
+
     Background: kiro-cli supports social login (Google, GitHub) for free-tier users.
     These credentials are stored in SQLite with key 'kirocli:social:token' instead of
     'kirocli:odic:token'. Social login uses the same Kiro Desktop Auth endpoint
     (no client_id/client_secret required).
     """
-    
+
     def test_load_credentials_from_sqlite_social_token(self, temp_sqlite_db_social):
         """
         What it does: Verifies loading credentials from kirocli:social:token key.
@@ -2335,36 +2233,36 @@ class TestKiroAuthManagerSocialLogin:
         """
         print(f"Setup: Creating KiroAuthManager with social login SQLite: {temp_sqlite_db_social}")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Verification: access_token loaded from social key...")
         print(f"Comparing access_token: Expected 'social_access_token', Got '{manager._access_token}'")
         assert manager._access_token == "social_access_token"
-        
+
         print("Verification: refresh_token loaded from social key...")
         print(f"Comparing refresh_token: Expected 'social_refresh_token', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "social_refresh_token"
-        
+
         print("Verification: profile_arn loaded...")
         assert manager._profile_arn == "arn:aws:codewhisperer:us-east-1:123456789:profile/social"
-    
+
     def test_social_login_detected_as_kiro_desktop(self, temp_sqlite_db_social):
         """
         What it does: Verifies social login is detected as KIRO_DESKTOP auth type.
         Purpose: Ensure social login uses Kiro Desktop Auth endpoint (no AWS SSO OIDC).
         """
-        print(f"Setup: Creating KiroAuthManager with social login SQLite...")
+        print("Setup: Creating KiroAuthManager with social login SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Verification: No client_id loaded (social login doesn't have it)...")
         assert manager._client_id is None
-        
+
         print("Verification: No client_secret loaded...")
         assert manager._client_secret is None
-        
+
         print("Verification: auth_type = KIRO_DESKTOP...")
         print(f"Comparing auth_type: Expected KIRO_DESKTOP, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-    
+
     def test_social_token_key_has_highest_priority(self, temp_sqlite_db_all_keys):
         """
         What it does: Verifies kirocli:social:token has highest priority.
@@ -2372,18 +2270,18 @@ class TestKiroAuthManagerSocialLogin:
         """
         print("Setup: Creating KiroAuthManager with database containing all three keys...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_all_keys)
-        
+
         print("Verification: Loaded from kirocli:social:token (highest priority)...")
         print(f"Comparing access_token: Expected 'social_token', Got '{manager._access_token}'")
         assert manager._access_token == "social_token"
-        
+
         print(f"Comparing refresh_token: Expected 'social_refresh', Got '{manager._refresh_token}'")
         assert manager._refresh_token == "social_refresh"
-        
+
         print("Verification: _sqlite_token_key tracks source...")
         print(f"Comparing _sqlite_token_key: Expected 'kirocli:social:token', Got '{manager._sqlite_token_key}'")
         assert manager._sqlite_token_key == "kirocli:social:token"
-    
+
     def test_sqlite_token_key_tracked_for_social_login(self, temp_sqlite_db_social):
         """
         What it does: Verifies _sqlite_token_key is set when loading from social key.
@@ -2391,11 +2289,11 @@ class TestKiroAuthManagerSocialLogin:
         """
         print("Setup: Creating KiroAuthManager with social login SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Verification: _sqlite_token_key set to kirocli:social:token...")
         print(f"Comparing _sqlite_token_key: Expected 'kirocli:social:token', Got '{manager._sqlite_token_key}'")
         assert manager._sqlite_token_key == "kirocli:social:token"
-    
+
     def test_sqlite_token_key_tracked_for_odic(self, temp_sqlite_db):
         """
         What it does: Verifies _sqlite_token_key is set when loading from OIDC key.
@@ -2403,51 +2301,51 @@ class TestKiroAuthManagerSocialLogin:
         """
         print("Setup: Creating KiroAuthManager with OIDC SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: _sqlite_token_key set to codewhisperer:odic:token...")
         print(f"Comparing _sqlite_token_key: Expected 'codewhisperer:odic:token', Got '{manager._sqlite_token_key}'")
         assert manager._sqlite_token_key == "codewhisperer:odic:token"
-    
+
     def test_save_credentials_to_sqlite_uses_source_key(self, temp_sqlite_db_social):
         """
         What it does: Verifies tokens are saved back to the same key they were loaded from.
         Purpose: Ensure social login tokens go to kirocli:social:token, not OIDC keys.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating KiroAuthManager with social login SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Verification: Loaded from kirocli:social:token...")
         assert manager._sqlite_token_key == "kirocli:social:token"
-        
+
         print("Action: Updating tokens in memory...")
         manager._access_token = "updated_social_access"
         manager._refresh_token = "updated_social_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _save_credentials_to_sqlite()...")
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite to check saved data...")
         conn = sqlite3.connect(temp_sqlite_db_social)
         cursor = conn.cursor()
-        
+
         # Check that kirocli:social:token was updated
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print(f"Comparing saved access_token: Expected 'updated_social_access', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "updated_social_access"
-        
+        assert saved_data["access_token"] == "updated_social_access"
+
         print(f"Comparing saved refresh_token: Expected 'updated_social_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "updated_social_refresh"
-    
+        assert saved_data["refresh_token"] == "updated_social_refresh"
+
     @pytest.mark.asyncio
     async def test_refresh_token_kiro_desktop_saves_to_social_key(
         self, temp_sqlite_db_social, mock_kiro_token_response
@@ -2456,237 +2354,232 @@ class TestKiroAuthManagerSocialLogin:
         What it does: Verifies tokens are saved to kirocli:social:token after Kiro Desktop refresh.
         Purpose: Ensure social login tokens persist correctly after refresh.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating KiroAuthManager with social login SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Verification: Loaded from kirocli:social:token...")
         assert manager._sqlite_token_key == "kirocli:social:token"
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-        
+
         print("Setup: Mocking HTTP client for successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_kiro_desktop()...")
             await manager._refresh_token_kiro_desktop()
-            
+
             print("Verification: Reading SQLite to check persistence...")
             conn = sqlite3.connect(temp_sqlite_db_social)
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
             row = cursor.fetchone()
             conn.close()
-            
+
             assert row is not None
             saved_data = json.loads(row[0])
-            
-            print(f"Comparing saved refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'")
-            assert saved_data['refresh_token'] == "new_refresh_token_xyz"
-    
+
+            print(
+                f"Comparing saved refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'"
+            )
+            assert saved_data["refresh_token"] == "new_refresh_token_xyz"
+
     def test_save_credentials_fallback_when_source_key_unknown(self, tmp_path):
         """
         What it does: Verifies fallback behavior when _sqlite_token_key is None.
         Purpose: Ensure robustness when source key is not tracked.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database with kirocli:social:token...")
         db_file = tmp_path / "data_fallback.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
-        token_data = {
-            "access_token": "old_token",
-            "refresh_token": "old_refresh",
-            "expires_at": "2099-01-01T00:00:00Z"
-        }
+
+        token_data = {"access_token": "old_token", "refresh_token": "old_refresh", "expires_at": "2099-01-01T00:00:00Z"}
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with direct credentials (not from SQLite)...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            sqlite_db=str(db_file)
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
+
         # Simulate scenario where _sqlite_token_key is None (edge case)
         manager._sqlite_token_key = None
         manager._access_token = "new_fallback_token"
         manager._refresh_token = "new_fallback_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _save_credentials_to_sqlite() with unknown source key...")
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Fallback should try all keys and update first match...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print(f"Comparing saved access_token: Expected 'new_fallback_token', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "new_fallback_token"
-    
+        assert saved_data["access_token"] == "new_fallback_token"
+
     def test_social_login_no_device_registration_key(self, temp_sqlite_db_social):
         """
         What it does: Verifies social login works without device-registration key.
         Purpose: Ensure social login doesn't require AWS SSO OIDC device registration.
         """
         import sqlite3
-        
+
         print("Setup: Verifying database has no device-registration key...")
         conn = sqlite3.connect(temp_sqlite_db_social)
         cursor = conn.cursor()
         cursor.execute("SELECT COUNT(*) FROM auth_kv WHERE key LIKE '%device-registration%'")
         count = cursor.fetchone()[0]
         conn.close()
-        
+
         print(f"Verification: No device-registration keys found (count={count})...")
         assert count == 0
-        
+
         print("Setup: Creating KiroAuthManager with social login SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Verification: Manager initialized successfully without device-registration...")
         assert manager._access_token == "social_access_token"
         assert manager._client_id is None
         assert manager._client_secret is None
-    
+
     def test_provider_field_preserved_in_social_token(self, temp_sqlite_db_social):
         """
         What it does: Verifies provider field is preserved when saving social tokens.
         Purpose: Ensure metadata like 'provider: google' is not lost.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating KiroAuthManager with social login SQLite...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-        
+
         print("Action: Updating tokens and saving...")
         manager._access_token = "new_social_token"
         manager._refresh_token = "new_social_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite to check provider field...")
         conn = sqlite3.connect(temp_sqlite_db_social)
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         saved_data = json.loads(row[0])
-        
+
         # Note: provider field is NOT explicitly saved by gateway (it's metadata from kiro-cli)
         # Gateway only saves: access_token, refresh_token, expires_at, region, scopes
         # This is acceptable because provider is not needed for token refresh
         print("Verification: Core token fields saved correctly...")
-        assert saved_data['access_token'] == "new_social_token"
-        assert saved_data['refresh_token'] == "new_social_refresh"
+        assert saved_data["access_token"] == "new_social_token"
+        assert saved_data["refresh_token"] == "new_social_refresh"
 
 
 # =============================================================================
 # Tests for Enterprise Kiro IDE Support (Issue #45)
 # =============================================================================
 
+
 class TestKiroAuthManagerEnterpriseIDE:
     """Tests for Enterprise Kiro IDE support (IdC login with clientIdHash).
-    
+
     Background: Enterprise Kiro IDE uses AWS IAM Identity Center (IdC) for authentication.
     Credentials are stored in JSON file with clientIdHash field that points to a separate
     device registration file containing clientId and clientSecret.
-    
+
     This is different from:
     - Personal Kiro IDE (social login): Uses Kiro Desktop Auth, no clientId/clientSecret
     - kiro-cli (SQLite): Uses AWS SSO OIDC, credentials in SQLite database
     """
-    
+
     def test_load_credentials_from_file_with_client_id_hash(self, temp_enterprise_ide_complete):
         """
         What it does: Verifies loading credentials from JSON file with clientIdHash.
         Purpose: Ensure clientIdHash is detected and stored.
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print(f"Setup: Creating KiroAuthManager with Enterprise IDE credentials: {creds_file}")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Verification: clientIdHash loaded...")
         print(f"Comparing _client_id_hash: Expected 'abc123def456', Got '{manager._client_id_hash}'")
         assert manager._client_id_hash == "abc123def456"
-        
+
         print("Verification: Basic credentials loaded...")
         assert manager._access_token == "enterprise_access_token"
         assert manager._refresh_token == "enterprise_refresh_token"
-    
+
     def test_load_enterprise_device_registration_success(self, temp_enterprise_ide_complete):
         """
         What it does: Verifies successful loading of device registration.
         Purpose: Ensure clientId and clientSecret are loaded from device registration file.
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print("Setup: Creating KiroAuthManager with Enterprise IDE credentials...")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Verification: clientId loaded from device registration...")
         print(f"Comparing _client_id: Expected 'enterprise_client_id_12345', Got '{manager._client_id}'")
         assert manager._client_id == "enterprise_client_id_12345"
-        
+
         print("Verification: clientSecret loaded from device registration...")
         print(f"Comparing _client_secret: Expected 'enterprise_client_secret_67890', Got '{manager._client_secret}'")
         assert manager._client_secret == "enterprise_client_secret_67890"
-    
+
     def test_enterprise_ide_detected_as_aws_sso_oidc(self, temp_enterprise_ide_complete):
         """
         What it does: Verifies Enterprise IDE is detected as AWS_SSO_OIDC auth type.
         Purpose: Ensure correct authentication method is used (not Kiro Desktop Auth).
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print("Setup: Creating KiroAuthManager with Enterprise IDE credentials...")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Verification: auth_type = AWS_SSO_OIDC...")
         print(f"Comparing auth_type: Expected AWS_SSO_OIDC, Got {manager.auth_type}")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-    
+
     def test_load_enterprise_device_registration_file_not_found(self, tmp_path, monkeypatch):
         """
         What it does: Verifies handling of missing device registration file.
         Purpose: Ensure application doesn't crash when device registration is missing.
         """
-        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
-        
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
         print("Setup: Creating credentials file with clientIdHash but no device registration...")
         creds_file = tmp_path / "kiro-auth-token.json"
         creds_data = {
@@ -2694,37 +2587,37 @@ class TestKiroAuthManagerEnterpriseIDE:
             "refreshToken": "enterprise_refresh_token",
             "expiresAt": "2099-01-01T00:00:00.000Z",
             "region": "us-east-1",
-            "clientIdHash": "nonexistent_hash"
+            "clientIdHash": "nonexistent_hash",
         }
         creds_file.write_text(json.dumps(creds_data))
-        
+
         print("Action: Creating KiroAuthManager...")
         manager = KiroAuthManager(creds_file=str(creds_file))
-        
+
         print("Verification: clientIdHash stored...")
         assert manager._client_id_hash == "nonexistent_hash"
-        
+
         print("Verification: clientId and clientSecret are None (file not found)...")
         assert manager._client_id is None
         assert manager._client_secret is None
-        
+
         print("Verification: auth_type = KIRO_DESKTOP (no client credentials)...")
         assert manager.auth_type == AuthType.KIRO_DESKTOP
-    
+
     def test_load_enterprise_device_registration_invalid_json(self, tmp_path, monkeypatch):
         """
         What it does: Verifies handling of invalid JSON in device registration file.
         Purpose: Ensure application doesn't crash on corrupted device registration.
         """
-        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
-        
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
         print("Setup: Creating device registration file with invalid JSON...")
         aws_dir = tmp_path / ".aws" / "sso" / "cache"
         aws_dir.mkdir(parents=True, exist_ok=True)
-        
+
         device_reg_file = aws_dir / "invalid_hash.json"
         device_reg_file.write_text("not a valid json {{{")
-        
+
         print("Setup: Creating credentials file...")
         creds_file = tmp_path / "kiro-auth-token.json"
         creds_data = {
@@ -2732,35 +2625,32 @@ class TestKiroAuthManagerEnterpriseIDE:
             "refreshToken": "enterprise_refresh_token",
             "expiresAt": "2099-01-01T00:00:00.000Z",
             "region": "us-east-1",
-            "clientIdHash": "invalid_hash"
+            "clientIdHash": "invalid_hash",
         }
         creds_file.write_text(json.dumps(creds_data))
-        
+
         print("Action: Creating KiroAuthManager (should handle error gracefully)...")
         manager = KiroAuthManager(creds_file=str(creds_file))
-        
+
         print("Verification: clientId and clientSecret are None (JSON parse error)...")
         assert manager._client_id is None
         assert manager._client_secret is None
-    
+
     def test_load_enterprise_device_registration_missing_fields(self, tmp_path, monkeypatch):
         """
         What it does: Verifies handling of device registration without clientId/clientSecret.
         Purpose: Ensure partial data doesn't cause crashes.
         """
-        monkeypatch.setattr('pathlib.Path.home', lambda: tmp_path)
-        
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
         print("Setup: Creating device registration file without clientId/clientSecret...")
         aws_dir = tmp_path / ".aws" / "sso" / "cache"
         aws_dir.mkdir(parents=True, exist_ok=True)
-        
+
         device_reg_file = aws_dir / "partial_hash.json"
-        device_reg_data = {
-            "region": "us-east-1",
-            "someOtherField": "value"
-        }
+        device_reg_data = {"region": "us-east-1", "someOtherField": "value"}
         device_reg_file.write_text(json.dumps(device_reg_data))
-        
+
         print("Setup: Creating credentials file...")
         creds_file = tmp_path / "kiro-auth-token.json"
         creds_data = {
@@ -2768,17 +2658,17 @@ class TestKiroAuthManagerEnterpriseIDE:
             "refreshToken": "enterprise_refresh_token",
             "expiresAt": "2099-01-01T00:00:00.000Z",
             "region": "us-east-1",
-            "clientIdHash": "partial_hash"
+            "clientIdHash": "partial_hash",
         }
         creds_file.write_text(json.dumps(creds_data))
-        
+
         print("Action: Creating KiroAuthManager...")
         manager = KiroAuthManager(creds_file=str(creds_file))
-        
+
         print("Verification: clientId and clientSecret are None (missing in file)...")
         assert manager._client_id is None
         assert manager._client_secret is None
-    
+
     @pytest.mark.asyncio
     async def test_enterprise_ide_refresh_uses_json_format(
         self, temp_enterprise_ide_complete, mock_aws_sso_oidc_token_response
@@ -2788,41 +2678,41 @@ class TestKiroAuthManagerEnterpriseIDE:
         Purpose: Ensure correct request format (not form-urlencoded).
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print("Setup: Creating KiroAuthManager with Enterprise IDE credentials...")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Verification: auth_type = AWS_SSO_OIDC...")
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc()...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: POST request made...")
             mock_client.post.assert_called_once()
-            
+
             print("Verification: Request uses JSON format (not form-urlencoded)...")
             call_args = mock_client.post.call_args
-            assert 'json' in call_args[1], "Request should use json= parameter"
-            assert 'data' not in call_args[1], "Request should NOT use data= parameter"
-            
+            assert "json" in call_args[1], "Request should use json= parameter"
+            assert "data" not in call_args[1], "Request should NOT use data= parameter"
+
             print("Verification: Content-Type = application/json...")
-            headers = call_args[1].get('headers', {})
-            assert headers.get('Content-Type') == 'application/json'
-    
+            headers = call_args[1].get("headers", {})
+            assert headers.get("Content-Type") == "application/json"
+
     @pytest.mark.asyncio
     async def test_enterprise_ide_refresh_uses_camel_case(
         self, temp_enterprise_ide_complete, mock_aws_sso_oidc_token_response
@@ -2832,42 +2722,42 @@ class TestKiroAuthManagerEnterpriseIDE:
         Purpose: Ensure correct parameter naming (not snake_case).
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print("Setup: Creating KiroAuthManager with Enterprise IDE credentials...")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc()...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Request uses camelCase parameters...")
             call_args = mock_client.post.call_args
-            json_payload = call_args[1].get('json', {})
-            
+            json_payload = call_args[1].get("json", {})
+
             print(f"JSON payload keys: {list(json_payload.keys())}")
-            assert 'grantType' in json_payload, "Should use grantType (camelCase)"
-            assert 'clientId' in json_payload, "Should use clientId (camelCase)"
-            assert 'clientSecret' in json_payload, "Should use clientSecret (camelCase)"
-            assert 'refreshToken' in json_payload, "Should use refreshToken (camelCase)"
-            
+            assert "grantType" in json_payload, "Should use grantType (camelCase)"
+            assert "clientId" in json_payload, "Should use clientId (camelCase)"
+            assert "clientSecret" in json_payload, "Should use clientSecret (camelCase)"
+            assert "refreshToken" in json_payload, "Should use refreshToken (camelCase)"
+
             print("Verification: NOT using snake_case...")
-            assert 'grant_type' not in json_payload, "Should NOT use grant_type (snake_case)"
-            assert 'client_id' not in json_payload, "Should NOT use client_id (snake_case)"
-            assert 'client_secret' not in json_payload, "Should NOT use client_secret (snake_case)"
-            assert 'refresh_token' not in json_payload, "Should NOT use refresh_token (snake_case)"
-    
+            assert "grant_type" not in json_payload, "Should NOT use grant_type (snake_case)"
+            assert "client_id" not in json_payload, "Should NOT use client_id (snake_case)"
+            assert "client_secret" not in json_payload, "Should NOT use client_secret (snake_case)"
+            assert "refresh_token" not in json_payload, "Should NOT use refresh_token (snake_case)"
+
     @pytest.mark.asyncio
     async def test_enterprise_ide_refresh_uses_correct_endpoint(
         self, temp_enterprise_ide_complete, mock_aws_sso_oidc_token_response
@@ -2877,38 +2767,38 @@ class TestKiroAuthManagerEnterpriseIDE:
         Purpose: Ensure correct endpoint (not Kiro Desktop Auth).
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print("Setup: Creating KiroAuthManager with Enterprise IDE credentials...")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Setup: Mocking HTTP client...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_aws_sso_oidc()...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Request went to AWS SSO OIDC endpoint...")
             call_args = mock_client.post.call_args
             url = call_args[0][0]
-            
+
             print(f"Comparing URL: Expected AWS SSO OIDC endpoint, Got '{url}'")
             assert "oidc" in url, "Should use AWS SSO OIDC endpoint"
             assert "amazonaws.com" in url, "Should use AWS endpoint"
             assert "/token" in url, "Should use /token endpoint"
-            
+
             print("Verification: NOT using Kiro Desktop Auth endpoint...")
             assert "auth.desktop.kiro.dev" not in url, "Should NOT use Kiro Desktop Auth"
-    
+
     @pytest.mark.asyncio
     async def test_enterprise_ide_full_refresh_flow(
         self, temp_enterprise_ide_complete, mock_aws_sso_oidc_token_response
@@ -2918,40 +2808,40 @@ class TestKiroAuthManagerEnterpriseIDE:
         Purpose: Integration test covering load → refresh → verify.
         """
         creds_file, device_reg_file = temp_enterprise_ide_complete
-        
+
         print("Setup: Creating KiroAuthManager with Enterprise IDE credentials...")
         manager = KiroAuthManager(creds_file=creds_file)
-        
+
         print("Verification: Initial state correct...")
         assert manager._client_id_hash == "abc123def456"
         assert manager._client_id == "enterprise_client_id_12345"
         assert manager._client_secret == "enterprise_client_secret_67890"
         assert manager.auth_type == AuthType.AWS_SSO_OIDC
-        
+
         print("Setup: Mocking HTTP client for successful refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Refreshing token...")
             await manager._refresh_token_aws_sso_oidc()
-            
+
             print("Verification: Tokens updated...")
             assert manager._access_token == "new_aws_sso_access_token"
             assert manager._refresh_token == "new_aws_sso_refresh_token"
-            
+
             print("Verification: Expiration time set...")
             assert manager._expires_at is not None
             assert manager._expires_at > datetime.now(timezone.utc)
-    
+
     def test_enterprise_ide_and_kiro_cli_use_same_format(self):
         """
         What it does: Verifies Enterprise IDE and kiro-cli use identical request format.
@@ -2976,34 +2866,35 @@ class TestKiroAuthManagerEnterpriseIDE:
 # Tests for SQLite write-back preserving unknown fields (Issue #131)
 # =============================================================================
 
+
 class TestKiroAuthManagerSqliteWriteBackPreservation:
     """Tests for _save_credentials_to_sqlite() preserving unknown fields (Issue #131).
-    
+
     Background: kiro-cli stores additional fields in SQLite (startUrl, provider,
     registrationExpiresAt for social login). Gateway must preserve these fields
     when saving refreshed tokens, using Read-Merge-Write strategy.
     """
-    
+
     def test_save_preserves_unknown_fields_social_login(self, tmp_path):
         """
         What it does: Verifies unknown fields are preserved for social login.
         Purpose: Ensure startUrl, provider, registrationExpiresAt are not lost (Issue #131 fix).
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with social login + extra fields...")
         db_file = tmp_path / "data_social_extra.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Social login with extra fields that kiro-cli uses
         token_data = {
             "access_token": "old_social_access",
@@ -3013,76 +2904,77 @@ class TestKiroAuthManagerSqliteWriteBackPreservation:
             "startUrl": "https://example.awsapps.com/start",
             "provider": "google",
             "registrationExpiresAt": "2099-12-31T23:59:59Z",
-            "customField": "custom_value"
+            "customField": "custom_value",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating tokens in memory...")
         manager._access_token = "new_social_access"
         manager._refresh_token = "new_social_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _save_credentials_to_sqlite()...")
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite to check preserved fields...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print("Verification: Tokens updated...")
         print(f"Comparing access_token: Expected 'new_social_access', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "new_social_access"
-        
+        assert saved_data["access_token"] == "new_social_access"
+
         print(f"Comparing refresh_token: Expected 'new_social_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "new_social_refresh"
-        
+        assert saved_data["refresh_token"] == "new_social_refresh"
+
         print("Verification: Extra fields preserved...")
         print(f"Comparing startUrl: Expected 'https://example.awsapps.com/start', Got '{saved_data.get('startUrl')}'")
-        assert saved_data.get('startUrl') == "https://example.awsapps.com/start"
-        
+        assert saved_data.get("startUrl") == "https://example.awsapps.com/start"
+
         print(f"Comparing provider: Expected 'google', Got '{saved_data.get('provider')}'")
-        assert saved_data.get('provider') == "google"
-        
-        print(f"Comparing registrationExpiresAt: Expected '2099-12-31T23:59:59Z', Got '{saved_data.get('registrationExpiresAt')}'")
-        assert saved_data.get('registrationExpiresAt') == "2099-12-31T23:59:59Z"
-        
+        assert saved_data.get("provider") == "google"
+
+        print(
+            f"Comparing registrationExpiresAt: Expected '2099-12-31T23:59:59Z', Got '{saved_data.get('registrationExpiresAt')}'"
+        )
+        assert saved_data.get("registrationExpiresAt") == "2099-12-31T23:59:59Z"
+
         print(f"Comparing customField: Expected 'custom_value', Got '{saved_data.get('customField')}'")
-        assert saved_data.get('customField') == "custom_value"
-    
+        assert saved_data.get("customField") == "custom_value"
+
     def test_save_preserves_unknown_fields_oidc(self, tmp_path):
         """
         What it does: Verifies unknown fields are preserved for AWS SSO OIDC.
         Purpose: Ensure future kiro-cli fields are not lost.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with OIDC + extra fields...")
         db_file = tmp_path / "data_oidc_extra.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # OIDC with unknown fields
         token_data = {
             "access_token": "old_oidc_access",
@@ -3090,544 +2982,522 @@ class TestKiroAuthManagerSqliteWriteBackPreservation:
             "expires_at": "2099-01-01T00:00:00Z",
             "region": "eu-west-1",
             "unknownField1": "value1",
-            "unknownField2": "value2"
+            "unknownField2": "value2",
         }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:token", json.dumps(token_data))
-        )
-        
+        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(token_data)))
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "eu-west-1"
+            "region": "eu-west-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:device-registration", json.dumps(registration_data))
+            ("kirocli:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating tokens and saving...")
         manager._access_token = "new_oidc_access"
         manager._refresh_token = "new_oidc_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite to check preserved fields...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         saved_data = json.loads(row[0])
-        
+
         print("Verification: Unknown fields preserved...")
         print(f"Comparing unknownField1: Expected 'value1', Got '{saved_data.get('unknownField1')}'")
-        assert saved_data.get('unknownField1') == "value1"
-        
+        assert saved_data.get("unknownField1") == "value1"
+
         print(f"Comparing unknownField2: Expected 'value2', Got '{saved_data.get('unknownField2')}'")
-        assert saved_data.get('unknownField2') == "value2"
-    
+        assert saved_data.get("unknownField2") == "value2"
+
     def test_save_updates_only_our_fields(self, tmp_path):
         """
         What it does: Verifies only gateway-managed fields are updated.
         Purpose: Ensure Read-Merge-Write updates only necessary fields.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with mixed fields...")
         db_file = tmp_path / "data_mixed.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         token_data = {
             "access_token": "old_token",
             "refresh_token": "old_refresh",
             "expires_at": "2020-01-01T00:00:00Z",
             "region": "us-west-2",
-            "customField": "original_value"
+            "customField": "original_value",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating tokens to new values...")
         manager._access_token = "new_token"
         manager._refresh_token = "new_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
         manager._sso_region = "eu-central-1"
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         saved_data = json.loads(row[0])
-        
+
         print("Verification: Our fields updated...")
         print(f"Comparing access_token: Expected 'new_token', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "new_token"
-        
+        assert saved_data["access_token"] == "new_token"
+
         print(f"Comparing refresh_token: Expected 'new_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "new_refresh"
-        
+        assert saved_data["refresh_token"] == "new_refresh"
+
         print(f"Comparing region: Expected 'eu-central-1', Got '{saved_data['region']}'")
-        assert saved_data['region'] == "eu-central-1"
-        
+        assert saved_data["region"] == "eu-central-1"
+
         print("Verification: Custom field unchanged...")
         print(f"Comparing customField: Expected 'original_value', Got '{saved_data.get('customField')}'")
-        assert saved_data.get('customField') == "original_value"
-    
+        assert saved_data.get("customField") == "original_value"
+
     def test_save_with_sqlite_readonly_flag(self, tmp_path, monkeypatch):
         """
         What it does: Verifies SQLITE_READONLY flag prevents write-back.
         Purpose: Ensure read-only mode works correctly (Issue #131 feature).
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite database...")
         db_file = tmp_path / "data_readonly.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         token_data = {
             "access_token": "original_access",
             "refresh_token": "original_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Enabling SQLITE_READONLY flag...")
-        monkeypatch.setattr('kiro.auth.SQLITE_READONLY', True)
-        
+        monkeypatch.setattr("kiro.auth.SQLITE_READONLY", True)
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating tokens in memory...")
         manager._access_token = "new_access"
         manager._refresh_token = "new_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _save_credentials_to_sqlite() with READONLY=True...")
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite to check data NOT changed...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         saved_data = json.loads(row[0])
-        
+
         print("Verification: Tokens NOT updated (read-only mode)...")
         print(f"Comparing access_token: Expected 'original_access', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "original_access"
-        
+        assert saved_data["access_token"] == "original_access"
+
         print(f"Comparing refresh_token: Expected 'original_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "original_refresh"
-    
+        assert saved_data["refresh_token"] == "original_refresh"
+
     def test_save_fallback_when_primary_key_deleted(self, tmp_path):
         """
         What it does: Verifies fallback mechanism when primary key is deleted.
         Purpose: Ensure tokens are saved to alternative key if primary is missing.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with kirocli:social:token...")
         db_file = tmp_path / "data_fallback.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Create initial token in social key
         token_data = {
             "access_token": "social_access",
             "refresh_token": "social_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Loading credentials from kirocli:social:token...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Primary key tracked...")
         assert manager._sqlite_token_key == "kirocli:social:token"
-        
+
         print("Action: Deleting primary key and creating alternative key...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         # Delete social token
         cursor.execute("DELETE FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        
+
         # Create alternative key (kirocli:odic:token)
         odic_data = {
             "access_token": "odic_access",
             "refresh_token": "odic_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:token", json.dumps(odic_data))
-        )
+        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(odic_data)))
         conn.commit()
         conn.close()
-        
+
         print("Action: Updating tokens and saving...")
         manager._access_token = "fallback_access"
         manager._refresh_token = "fallback_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Tokens saved to fallback key (kirocli:odic:token)...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print(f"Comparing access_token: Expected 'fallback_access', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "fallback_access"
-        
+        assert saved_data["access_token"] == "fallback_access"
+
         print(f"Comparing refresh_token: Expected 'fallback_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "fallback_refresh"
-    
+        assert saved_data["refresh_token"] == "fallback_refresh"
+
     def test_save_fallback_when_primary_key_is_none(self, tmp_path):
         """
         What it does: Verifies fallback when _sqlite_token_key is None.
         Purpose: Ensure robustness when source key is not tracked.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with kirocli:social:token...")
         db_file = tmp_path / "data_none_key.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         token_data = {
             "access_token": "existing_access",
             "refresh_token": "existing_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with direct credentials...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            sqlite_db=str(db_file)
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
+
         print("Action: Manually setting _sqlite_token_key to None...")
         manager._sqlite_token_key = None
-        
+
         print("Action: Updating tokens and saving...")
         manager._access_token = "none_key_access"
         manager._refresh_token = "none_key_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Fallback found and updated kirocli:social:token...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print(f"Comparing access_token: Expected 'none_key_access', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "none_key_access"
-        
+        assert saved_data["access_token"] == "none_key_access"
+
         print(f"Comparing refresh_token: Expected 'none_key_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data['refresh_token'] == "none_key_refresh"
-    
+        assert saved_data["refresh_token"] == "none_key_refresh"
+
     def test_save_handles_corrupted_json_gracefully(self, tmp_path):
         """
         What it does: Verifies graceful handling of corrupted JSON during save.
         Purpose: Ensure _try_save_to_key skips corrupted key and fallback is used.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with valid key...")
         db_file = tmp_path / "data_corrupted.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Valid JSON in social key (will be loaded)
         social_data = {
             "access_token": "social_access",
             "refresh_token": "social_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(social_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(social_data))
         )
-        
+
         # Valid JSON in odic key (fallback)
         odic_data = {
             "access_token": "odic_access",
             "refresh_token": "odic_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:token", json.dumps(odic_data))
-        )
+        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(odic_data)))
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager (loads from social)...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Verification: Loaded from social key...")
         assert manager._access_token == "social_access"
         assert manager._sqlite_token_key == "kirocli:social:token"
-        
+
         print("Action: Corrupting primary key in database...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        cursor.execute(
-            "UPDATE auth_kv SET value = ? WHERE key = ?",
-            ("not a valid json {{{", "kirocli:social:token")
-        )
+        cursor.execute("UPDATE auth_kv SET value = ? WHERE key = ?", ("not a valid json {{{", "kirocli:social:token"))
         conn.commit()
         conn.close()
-        
+
         print("Action: Updating tokens and saving (primary key now corrupted)...")
         manager._access_token = "corrupted_test_access"
         manager._refresh_token = "corrupted_test_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Tokens saved to fallback key (skipped corrupted primary)...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         assert row is not None
         saved_data = json.loads(row[0])
-        
+
         print(f"Comparing access_token: Expected 'corrupted_test_access', Got '{saved_data['access_token']}'")
-        assert saved_data['access_token'] == "corrupted_test_access"
-    
+        assert saved_data["access_token"] == "corrupted_test_access"
+
     def test_save_preserves_scopes_when_present(self, tmp_path):
         """
         What it does: Verifies scopes field is updated when present.
         Purpose: Ensure scopes are saved correctly for AWS SSO OIDC.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with scopes...")
         db_file = tmp_path / "data_scopes.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         token_data = {
             "access_token": "old_access",
             "refresh_token": "old_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
             "region": "us-east-1",
-            "scopes": ["old_scope_1", "old_scope_2"]
+            "scopes": ["old_scope_1", "old_scope_2"],
         }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:token", json.dumps(token_data))
-        )
-        
+        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(token_data)))
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:device-registration", json.dumps(registration_data))
+            ("kirocli:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating scopes and saving...")
         manager._access_token = "new_access"
         manager._refresh_token = "new_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._scopes = ["new_scope_1", "new_scope_2", "new_scope_3"]
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         saved_data = json.loads(row[0])
-        
+
         print("Verification: Scopes updated...")
-        print(f"Comparing scopes: Expected ['new_scope_1', 'new_scope_2', 'new_scope_3'], Got {saved_data.get('scopes')}")
-        assert saved_data.get('scopes') == ["new_scope_1", "new_scope_2", "new_scope_3"]
-    
+        print(
+            f"Comparing scopes: Expected ['new_scope_1', 'new_scope_2', 'new_scope_3'], Got {saved_data.get('scopes')}"
+        )
+        assert saved_data.get("scopes") == ["new_scope_1", "new_scope_2", "new_scope_3"]
+
     def test_save_updates_region_always(self, tmp_path):
         """
         What it does: Verifies region field is always updated.
         Purpose: Ensure region reflects current SSO region.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with old region...")
         db_file = tmp_path / "data_region.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         token_data = {
             "access_token": "access",
             "refresh_token": "refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Action: Updating region and saving...")
         manager._access_token = "new_access"
         manager._refresh_token = "new_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         manager._sso_region = "eu-west-1"
         manager._save_credentials_to_sqlite()
-        
+
         print("Verification: Reading SQLite...")
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
         cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
         row = cursor.fetchone()
         conn.close()
-        
+
         saved_data = json.loads(row[0])
-        
+
         print("Verification: Region updated...")
         print(f"Comparing region: Expected 'eu-west-1', Got '{saved_data['region']}'")
-        assert saved_data['region'] == "eu-west-1"
-    
+        assert saved_data["region"] == "eu-west-1"
+
     def test_try_save_to_key_returns_false_when_key_not_found(self, tmp_path):
         """
         What it does: Verifies _try_save_to_key returns False when key doesn't exist.
         Purpose: Ensure helper method correctly reports failure.
         """
         import sqlite3
-        
+
         print("Setup: Creating empty SQLite database...")
         db_file = tmp_path / "data_empty.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
@@ -3635,97 +3505,90 @@ class TestKiroAuthManagerSqliteWriteBackPreservation:
             )
         """)
         conn.commit()
-        
+
         print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            sqlite_db=str(db_file)
-        )
+        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
         manager._access_token = "test_access"
         manager._refresh_token = "test_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _try_save_to_key with nonexistent key...")
         result = manager._try_save_to_key(cursor, "nonexistent_key")
-        
+
         conn.close()
-        
+
         print("Verification: Returns False...")
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
-    
+
     def test_try_save_to_key_returns_true_on_success(self, tmp_path):
         """
         What it does: Verifies _try_save_to_key returns True on successful save.
         Purpose: Ensure helper method correctly reports success.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with valid key...")
         db_file = tmp_path / "data_valid.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         token_data = {
             "access_token": "old_access",
             "refresh_token": "old_refresh",
             "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1"
+            "region": "us-east-1",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
-        
+
         print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            sqlite_db=str(db_file)
-        )
+        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
         manager._access_token = "new_access"
         manager._refresh_token = "new_refresh"
         manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        
+
         print("Action: Calling _try_save_to_key with valid key...")
         result = manager._try_save_to_key(cursor, "kirocli:social:token")
-        
+
         conn.commit()
         conn.close()
-        
+
         print("Verification: Returns True...")
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_save_after_token_refresh_kiro_desktop(self, tmp_path, mock_kiro_token_response):
         """
         What it does: Verifies tokens are saved after Kiro Desktop refresh with extra fields preserved.
         Purpose: Integration test for Issue #131 fix with Kiro Desktop auth.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with social login + extra fields...")
         db_file = tmp_path / "data_refresh_desktop.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # Social login with extra fields
         token_data = {
             "access_token": "old_desktop_access",
@@ -3734,79 +3597,80 @@ class TestKiroAuthManagerSqliteWriteBackPreservation:
             "region": "us-east-1",
             "startUrl": "https://example.awsapps.com/start",
             "provider": "github",
-            "customField": "must_be_preserved"
+            "customField": "must_be_preserved",
         }
         cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:social:token", json.dumps(token_data))
+            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Setup: Mocking successful Kiro Desktop refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_kiro_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _refresh_token_kiro_desktop()...")
             await manager._refresh_token_kiro_desktop()
-            
+
             print("Verification: Reading SQLite to check persistence...")
             conn = sqlite3.connect(str(db_file))
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
             row = cursor.fetchone()
             conn.close()
-            
+
             assert row is not None
             saved_data = json.loads(row[0])
-            
+
             print("Verification: New tokens saved...")
             print(f"Comparing refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'")
-            assert saved_data['refresh_token'] == "new_refresh_token_xyz"
-            
+            assert saved_data["refresh_token"] == "new_refresh_token_xyz"
+
             print("Verification: Extra fields preserved...")
-            print(f"Comparing startUrl: Expected 'https://example.awsapps.com/start', Got '{saved_data.get('startUrl')}'")
-            assert saved_data.get('startUrl') == "https://example.awsapps.com/start"
-            
+            print(
+                f"Comparing startUrl: Expected 'https://example.awsapps.com/start', Got '{saved_data.get('startUrl')}'"
+            )
+            assert saved_data.get("startUrl") == "https://example.awsapps.com/start"
+
             print(f"Comparing provider: Expected 'github', Got '{saved_data.get('provider')}'")
-            assert saved_data.get('provider') == "github"
-            
+            assert saved_data.get("provider") == "github"
+
             print(f"Comparing customField: Expected 'must_be_preserved', Got '{saved_data.get('customField')}'")
-            assert saved_data.get('customField') == "must_be_preserved"
-    
+            assert saved_data.get("customField") == "must_be_preserved"
+
     @pytest.mark.asyncio
     async def test_save_after_token_refresh_aws_sso_oidc(self, tmp_path, mock_aws_sso_oidc_token_response):
         """
         What it does: Verifies tokens are saved after AWS SSO OIDC refresh with extra fields preserved.
         Purpose: Integration test for Issue #131 fix with AWS SSO OIDC auth.
         """
-        import sqlite3
         import json
-        
+        import sqlite3
+
         print("Setup: Creating SQLite with OIDC + extra fields...")
         db_file = tmp_path / "data_refresh_oidc.sqlite3"
         conn = sqlite3.connect(str(db_file))
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE auth_kv (
                 key TEXT PRIMARY KEY,
                 value TEXT
             )
         """)
-        
+
         # OIDC with extra fields
         token_data = {
             "access_token": "old_oidc_access",
@@ -3815,110 +3679,108 @@ class TestKiroAuthManagerSqliteWriteBackPreservation:
             "region": "eu-west-1",
             "unknownField1": "value1",
             "unknownField2": "value2",
-            "futureField": "future_value"
+            "futureField": "future_value",
         }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:token", json.dumps(token_data))
-        )
-        
+        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(token_data)))
+
         registration_data = {
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "region": "eu-west-1"
+            "region": "eu-west-1",
         }
         cursor.execute(
             "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:device-registration", json.dumps(registration_data))
+            ("kirocli:odic:device-registration", json.dumps(registration_data)),
         )
         conn.commit()
         conn.close()
-        
+
         print("Setup: Creating KiroAuthManager with SQLite...")
         manager = KiroAuthManager(sqlite_db=str(db_file))
-        
+
         print("Setup: Mocking successful AWS SSO OIDC refresh...")
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
         mock_response.raise_for_status = Mock()
-        
-        with patch('kiro.auth.httpx.AsyncClient') as mock_client_class:
+
+        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
-            
+
             print("Action: Calling _do_aws_sso_oidc_refresh()...")
             await manager._do_aws_sso_oidc_refresh()
-            
+
             print("Verification: Reading SQLite to check persistence...")
             conn = sqlite3.connect(str(db_file))
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
             row = cursor.fetchone()
             conn.close()
-            
+
             assert row is not None
             saved_data = json.loads(row[0])
-            
+
             print("Verification: New tokens saved...")
             print(f"Comparing access_token: Expected 'new_aws_sso_access_token', Got '{saved_data['access_token']}'")
-            assert saved_data['access_token'] == "new_aws_sso_access_token"
-            
+            assert saved_data["access_token"] == "new_aws_sso_access_token"
+
             print(f"Comparing refresh_token: Expected 'new_aws_sso_refresh_token', Got '{saved_data['refresh_token']}'")
-            assert saved_data['refresh_token'] == "new_aws_sso_refresh_token"
-            
+            assert saved_data["refresh_token"] == "new_aws_sso_refresh_token"
+
             print("Verification: Extra fields preserved...")
             print(f"Comparing unknownField1: Expected 'value1', Got '{saved_data.get('unknownField1')}'")
-            assert saved_data.get('unknownField1') == "value1"
-            
+            assert saved_data.get("unknownField1") == "value1"
+
             print(f"Comparing unknownField2: Expected 'value2', Got '{saved_data.get('unknownField2')}'")
-            assert saved_data.get('unknownField2') == "value2"
-            
+            assert saved_data.get("unknownField2") == "value2"
+
             print(f"Comparing futureField: Expected 'future_value', Got '{saved_data.get('futureField')}'")
-            assert saved_data.get('futureField') == "future_value"
+            assert saved_data.get("futureField") == "future_value"
 
 
 # =============================================================================
 # Tests for API Region Auto-Detection from SQLite
 # =============================================================================
 
+
 class TestAPIRegionAutoDetectionSQLite:
     """Tests for automatic API region detection from SQLite profile ARN.
-    
+
     Background: AWS uses different regions for SSO (OIDC token refresh) and Q API.
     The gateway must auto-detect the correct API region from profile ARN in state table.
     """
-    
+
     def test_api_region_from_profile_arn_success(self, temp_sqlite_db_with_profile_arn):
         """
         What it does: Verifies successful extraction of API region from profile ARN.
         Purpose: Ensure API region is correctly parsed from ARN in state table.
         """
-        print(f"Setup: Creating KiroAuthManager with SQLite containing profile ARN...")
+        print("Setup: Creating KiroAuthManager with SQLite containing profile ARN...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_with_profile_arn)
-        
+
         print("Verification: SSO region loaded from token data...")
         print(f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print("Verification: API region auto-detected from profile ARN...")
         print(f"Comparing _detected_api_region: Expected 'eu-central-1', Got '{manager._detected_api_region}'")
         assert manager._detected_api_region == "eu-central-1"
-        
+
         print("Verification: API hosts use detected API region...")
         print(f"api_host: {manager._api_host}")
         assert "eu-central-1" in manager._api_host
-        
+
         print(f"q_host: {manager._q_host}")
         assert "eu-central-1" in manager._q_host
-        
+
         print("Verification: Refresh URL uses SSO region...")
         print(f"refresh_url: {manager._refresh_url}")
         assert "eu-west-1" in manager._refresh_url
-    
+
     def test_api_region_env_var_overrides_arn(self, temp_sqlite_db_with_profile_arn, monkeypatch):
         """
         What it does: Verifies KIRO_API_REGION env var has highest priority.
@@ -3926,22 +3788,22 @@ class TestAPIRegionAutoDetectionSQLite:
         """
         print("Setup: Setting KIRO_API_REGION env var...")
         monkeypatch.setenv("KIRO_API_REGION", "us-east-1")
-        
-        print(f"Setup: Creating KiroAuthManager with SQLite (ARN region=eu-central-1)...")
+
+        print("Setup: Creating KiroAuthManager with SQLite (ARN region=eu-central-1)...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_with_profile_arn)
-        
+
         print("Verification: API region detected from ARN...")
         print(f"Comparing _detected_api_region: Expected 'eu-central-1', Got '{manager._detected_api_region}'")
         assert manager._detected_api_region == "eu-central-1"
-        
+
         print("Verification: But API hosts use env var override...")
         print(f"api_host: {manager._api_host}")
         assert "us-east-1" in manager._api_host
         assert "eu-central-1" not in manager._api_host
-        
+
         print(f"q_host: {manager._q_host}")
         assert "us-east-1" in manager._q_host
-    
+
     def test_api_region_fallback_when_no_state_table(self, temp_sqlite_db):
         """
         What it does: Verifies graceful fallback when state table doesn't exist.
@@ -3949,18 +3811,18 @@ class TestAPIRegionAutoDetectionSQLite:
         """
         print("Setup: Creating KiroAuthManager with SQLite without state table...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db)
-        
+
         print("Verification: No API region detected...")
         print(f"Comparing _detected_api_region: Expected None, Got '{manager._detected_api_region}'")
         assert manager._detected_api_region is None
-        
+
         print("Verification: API hosts use SSO region as fallback...")
         print(f"Comparing _sso_region: Expected 'eu-west-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "eu-west-1"
-        
+
         print(f"api_host: {manager._api_host}")
         assert "eu-west-1" in manager._api_host
-    
+
     def test_api_region_fallback_when_no_profile_key(self, temp_sqlite_db_with_empty_state_table):
         """
         What it does: Verifies graceful fallback when profile key is missing from state table.
@@ -3968,37 +3830,37 @@ class TestAPIRegionAutoDetectionSQLite:
         """
         print("Setup: Creating KiroAuthManager with empty state table...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_with_empty_state_table)
-        
+
         print("Verification: No API region detected...")
         print(f"Comparing _detected_api_region: Expected None, Got '{manager._detected_api_region}'")
         assert manager._detected_api_region is None
-        
+
         print("Verification: API hosts use SSO region as fallback...")
         print(f"Comparing _sso_region: Expected 'us-west-2', Got '{manager._sso_region}'")
         assert manager._sso_region == "us-west-2"
-        
+
         print(f"api_host: {manager._api_host}")
         assert "us-west-2" in manager._api_host
-    
+
     def test_api_region_invalid_arn_format(self, temp_sqlite_db_with_invalid_arn):
         """
         What it does: Verifies handling of invalid ARN formats.
         Purpose: Ensure invalid ARNs are ignored and fallback is used.
         """
-        print(f"Setup: Creating KiroAuthManager with invalid ARN...")
+        print("Setup: Creating KiroAuthManager with invalid ARN...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_with_invalid_arn)
-        
+
         print("Verification: Invalid ARN ignored, no API region detected...")
         print(f"Comparing _detected_api_region: Expected None, Got '{manager._detected_api_region}'")
         assert manager._detected_api_region is None
-        
+
         print("Verification: API hosts use SSO region as fallback...")
         print(f"Comparing _sso_region: Expected 'ap-southeast-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "ap-southeast-1"
-        
+
         print(f"api_host: {manager._api_host}")
         assert "ap-southeast-1" in manager._api_host
-    
+
     def test_api_region_malformed_json_in_state_table(self, temp_sqlite_db_with_malformed_state_json):
         """
         What it does: Verifies handling of malformed JSON in state table.
@@ -4006,15 +3868,15 @@ class TestAPIRegionAutoDetectionSQLite:
         """
         print("Setup: Creating KiroAuthManager with malformed state JSON...")
         manager = KiroAuthManager(sqlite_db=temp_sqlite_db_with_malformed_state_json)
-        
+
         print("Verification: Malformed JSON ignored, no API region detected...")
         print(f"Comparing _detected_api_region: Expected None, Got '{manager._detected_api_region}'")
         assert manager._detected_api_region is None
-        
+
         print("Verification: API hosts use SSO region as fallback...")
         print(f"Comparing _sso_region: Expected 'ap-south-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "ap-south-1"
-        
+
         print(f"api_host: {manager._api_host}")
         assert "ap-south-1" in manager._api_host
 
@@ -4023,31 +3885,32 @@ class TestAPIRegionAutoDetectionSQLite:
 # Tests for API Region Auto-Detection from JSON
 # =============================================================================
 
+
 class TestAPIRegionAutoDetectionJSON:
     """Tests for automatic API region detection from JSON credentials file.
-    
+
     Background: JSON credentials contain region field that should be used as API region.
     """
-    
+
     def test_api_region_from_json_region_field(self, temp_creds_file):
         """
         What it does: Verifies region field from JSON is used as API region.
         Purpose: Ensure JSON region is detected and used for API calls.
         """
-        print(f"Setup: Creating KiroAuthManager with JSON credentials...")
+        print("Setup: Creating KiroAuthManager with JSON credentials...")
         manager = KiroAuthManager(creds_file=temp_creds_file)
-        
+
         print("Verification: Region detected from JSON...")
         print(f"Comparing _detected_api_region: Expected 'us-east-1', Got '{manager._detected_api_region}'")
         assert manager._detected_api_region == "us-east-1"
-        
+
         print(f"Comparing _sso_region: Expected 'us-east-1', Got '{manager._sso_region}'")
         assert manager._sso_region == "us-east-1"
-        
+
         print("Verification: API hosts use detected region...")
         print(f"api_host: {manager._api_host}")
         assert "us-east-1" in manager._api_host
-    
+
     def test_api_region_json_env_var_override(self, temp_creds_file, monkeypatch):
         """
         What it does: Verifies KIRO_API_REGION env var overrides JSON region.
@@ -4055,14 +3918,14 @@ class TestAPIRegionAutoDetectionJSON:
         """
         print("Setup: Setting KIRO_API_REGION env var...")
         monkeypatch.setenv("KIRO_API_REGION", "eu-central-1")
-        
-        print(f"Setup: Creating KiroAuthManager with JSON (region=us-east-1)...")
+
+        print("Setup: Creating KiroAuthManager with JSON (region=us-east-1)...")
         manager = KiroAuthManager(creds_file=temp_creds_file)
-        
+
         print("Verification: Region detected from JSON...")
         print(f"Comparing _detected_api_region: Expected 'us-east-1', Got '{manager._detected_api_region}'")
         assert manager._detected_api_region == "us-east-1"
-        
+
         print("Verification: But API hosts use env var override...")
         print(f"api_host: {manager._api_host}")
         assert "eu-central-1" in manager._api_host
@@ -4073,16 +3936,17 @@ class TestAPIRegionAutoDetectionJSON:
 # Tests for API Region Priority Hierarchy
 # =============================================================================
 
+
 class TestAPIRegionPriorityHierarchy:
     """Tests for complete priority hierarchy of API region determination.
-    
+
     Priority order:
     1. KIRO_API_REGION env var (highest)
     2. Auto-detected from credentials
     3. SSO region (fallback)
     4. Default region parameter (lowest)
     """
-    
+
     def test_priority_env_var_highest(self, monkeypatch):
         """
         What it does: Verifies KIRO_API_REGION has highest priority.
@@ -4090,52 +3954,43 @@ class TestAPIRegionPriorityHierarchy:
         """
         print("Setup: Setting KIRO_API_REGION env var...")
         monkeypatch.setenv("KIRO_API_REGION", "us-west-1")
-        
+
         print("Setup: Creating KiroAuthManager with default region...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", region="us-east-1")
+
         print("Verification: API hosts use env var, not default...")
         print(f"api_host: {manager._api_host}")
         assert "us-west-1" in manager._api_host
         assert "us-east-1" not in manager._api_host
-    
+
     def test_priority_fallback_to_default(self):
         """
         What it does: Verifies fallback to default region when nothing else available.
         Purpose: Ensure default region is used as last resort.
         """
         print("Setup: Creating KiroAuthManager with only refresh_token...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            region="us-east-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", region="us-east-1")
+
         print("Verification: No auto-detection (no file, no SQLite)...")
         assert manager._detected_api_region is None
         assert manager._sso_region is None
-        
+
         print("Verification: API hosts use default region...")
         print(f"api_host: {manager._api_host}")
         assert "us-east-1" in manager._api_host
-    
+
     def test_priority_custom_default_region(self):
         """
         What it does: Verifies custom default region parameter is used.
         Purpose: Ensure region parameter works when no auto-detection.
         """
         print("Setup: Creating KiroAuthManager with custom region...")
-        manager = KiroAuthManager(
-            refresh_token="test_refresh",
-            region="ap-south-1"
-        )
-        
+        manager = KiroAuthManager(refresh_token="test_refresh", region="ap-south-1")
+
         print("Verification: API hosts use custom default region...")
         print(f"api_host: {manager._api_host}")
         assert "ap-south-1" in manager._api_host
-    
+
     def test_auth_manager_api_region_parameter(self, temp_creds_file, monkeypatch):
         """
         What it does: Verifies api_region parameter has highest priority.
@@ -4143,34 +3998,31 @@ class TestAPIRegionPriorityHierarchy:
         """
         print("Setup: Setting KIRO_API_REGION env var to us-west-1...")
         monkeypatch.setenv("KIRO_API_REGION", "us-west-1")
-        
+
         print("Setup: Creating KiroAuthManager with api_region=eu-central-1...")
         print("  - JSON file has region=us-east-1 (detected)")
         print("  - KIRO_API_REGION env var=us-west-1")
         print("  - api_region parameter=eu-central-1 (should win)")
-        manager = KiroAuthManager(
-            creds_file=temp_creds_file,
-            api_region="eu-central-1"
-        )
-        
+        manager = KiroAuthManager(creds_file=temp_creds_file, api_region="eu-central-1")
+
         print("Verification: Region detected from JSON...")
         print(f"Comparing _detected_api_region: Expected 'us-east-1', Got '{manager._detected_api_region}'")
         assert manager._detected_api_region == "us-east-1"
-        
+
         print("Verification: But API hosts use api_region parameter (highest priority)...")
         print(f"api_host: {manager._api_host}")
         assert "eu-central-1" in manager._api_host
         assert "us-west-1" not in manager._api_host
         assert "us-east-1" not in manager._api_host
-        
+
         print(f"q_host: {manager._q_host}")
         assert "eu-central-1" in manager._q_host
-    
+
     def test_auth_manager_api_region_priority_hierarchy(self, temp_sqlite_db_with_profile_arn, monkeypatch):
         """
         What it does: Verifies complete priority hierarchy for API region.
         Purpose: Ensure all 5 levels of priority work correctly.
-        
+
         Priority hierarchy (highest to lowest):
         1. api_region parameter (per-account override)
         2. KIRO_API_REGION env var (global override)
@@ -4181,73 +4033,58 @@ class TestAPIRegionPriorityHierarchy:
         print("=== Test 1: api_region parameter (highest priority) ===")
         monkeypatch.setenv("KIRO_API_REGION", "us-west-1")
         manager1 = KiroAuthManager(
-            sqlite_db=temp_sqlite_db_with_profile_arn,
-            region="ap-south-1",
-            api_region="ap-northeast-1"
+            sqlite_db=temp_sqlite_db_with_profile_arn, region="ap-south-1", api_region="ap-northeast-1"
         )
-        print(f"  - api_region=ap-northeast-1 (parameter)")
-        print(f"  - KIRO_API_REGION=us-west-1 (env)")
-        print(f"  - detected=eu-central-1 (from ARN)")
-        print(f"  - sso=eu-west-1 (from token)")
-        print(f"  - default=ap-south-1 (parameter)")
+        print("  - api_region=ap-northeast-1 (parameter)")
+        print("  - KIRO_API_REGION=us-west-1 (env)")
+        print("  - detected=eu-central-1 (from ARN)")
+        print("  - sso=eu-west-1 (from token)")
+        print("  - default=ap-south-1 (parameter)")
         print(f"Result: api_host={manager1._api_host}")
         assert "ap-northeast-1" in manager1._api_host
-        
+
         print("\n=== Test 2: KIRO_API_REGION env var (2nd priority) ===")
-        manager2 = KiroAuthManager(
-            sqlite_db=temp_sqlite_db_with_profile_arn,
-            region="ap-south-1"
-        )
-        print(f"  - api_region=None")
-        print(f"  - KIRO_API_REGION=us-west-1 (env)")
-        print(f"  - detected=eu-central-1 (from ARN)")
-        print(f"  - sso=eu-west-1 (from token)")
-        print(f"  - default=ap-south-1 (parameter)")
+        manager2 = KiroAuthManager(sqlite_db=temp_sqlite_db_with_profile_arn, region="ap-south-1")
+        print("  - api_region=None")
+        print("  - KIRO_API_REGION=us-west-1 (env)")
+        print("  - detected=eu-central-1 (from ARN)")
+        print("  - sso=eu-west-1 (from token)")
+        print("  - default=ap-south-1 (parameter)")
         print(f"Result: api_host={manager2._api_host}")
         assert "us-west-1" in manager2._api_host
-        
+
         print("\n=== Test 3: Auto-detected from ARN (3rd priority) ===")
         monkeypatch.delenv("KIRO_API_REGION", raising=False)
-        manager3 = KiroAuthManager(
-            sqlite_db=temp_sqlite_db_with_profile_arn,
-            region="ap-south-1"
-        )
-        print(f"  - api_region=None")
-        print(f"  - KIRO_API_REGION=None")
-        print(f"  - detected=eu-central-1 (from ARN)")
-        print(f"  - sso=eu-west-1 (from token)")
-        print(f"  - default=ap-south-1 (parameter)")
+        manager3 = KiroAuthManager(sqlite_db=temp_sqlite_db_with_profile_arn, region="ap-south-1")
+        print("  - api_region=None")
+        print("  - KIRO_API_REGION=None")
+        print("  - detected=eu-central-1 (from ARN)")
+        print("  - sso=eu-west-1 (from token)")
+        print("  - default=ap-south-1 (parameter)")
         print(f"Result: api_host={manager3._api_host}")
         assert "eu-central-1" in manager3._api_host
-        
+
         print("\n=== Test 4: SSO region fallback (4th priority) ===")
-        manager4 = KiroAuthManager(
-            sqlite_db=temp_sqlite_db_with_profile_arn,
-            region="ap-south-1"
-        )
+        manager4 = KiroAuthManager(sqlite_db=temp_sqlite_db_with_profile_arn, region="ap-south-1")
         # Force no detection by clearing detected region
         manager4._detected_api_region = None
         # Rebuild URLs to apply the change
         manager4._api_host = f"https://codewhisperer.{manager4._sso_region}.api.aws"
         manager4._q_host = f"https://q.{manager4._sso_region}.api.aws"
-        print(f"  - api_region=None")
-        print(f"  - KIRO_API_REGION=None")
-        print(f"  - detected=None (forced)")
-        print(f"  - sso=eu-west-1 (from token)")
-        print(f"  - default=ap-south-1 (parameter)")
+        print("  - api_region=None")
+        print("  - KIRO_API_REGION=None")
+        print("  - detected=None (forced)")
+        print("  - sso=eu-west-1 (from token)")
+        print("  - default=ap-south-1 (parameter)")
         print(f"Result: api_host={manager4._api_host}")
         assert "eu-west-1" in manager4._api_host
-        
+
         print("\n=== Test 5: Default region (lowest priority) ===")
-        manager5 = KiroAuthManager(
-            refresh_token="test_refresh",
-            region="ap-south-1"
-        )
-        print(f"  - api_region=None")
-        print(f"  - KIRO_API_REGION=None")
-        print(f"  - detected=None (no file)")
-        print(f"  - sso=None (no file)")
-        print(f"  - default=ap-south-1 (parameter)")
+        manager5 = KiroAuthManager(refresh_token="test_refresh", region="ap-south-1")
+        print("  - api_region=None")
+        print("  - KIRO_API_REGION=None")
+        print("  - detected=None (no file)")
+        print("  - sso=None (no file)")
+        print("  - default=ap-south-1 (parameter)")
         print(f"Result: api_host={manager5._api_host}")
         assert "ap-south-1" in manager5._api_host
-

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -7,6 +7,7 @@ Unit-тесты для ModelInfoCache.
 
 import asyncio
 import time
+
 import pytest
 
 from kiro.cache import ModelInfoCache
@@ -15,7 +16,7 @@ from kiro.config import DEFAULT_MAX_INPUT_TOKENS
 
 class TestModelInfoCacheInitialization:
     """Тесты инициализации ModelInfoCache."""
-    
+
     def test_initialization_creates_empty_cache(self):
         """
         Что он делает: Проверяет, что кэш создаётся пустым.
@@ -23,14 +24,14 @@ class TestModelInfoCacheInitialization:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: Кэш пуст при создании...")
         print(f"Сравниваем is_empty(): Ожидалось True, Получено {cache.is_empty()}")
         assert cache.is_empty() is True
-        
+
         print(f"Сравниваем size: Ожидалось 0, Получено {cache.size}")
         assert cache.size == 0
-    
+
     def test_initialization_with_custom_ttl(self):
         """
         Что он делает: Проверяет создание кэша с кастомным TTL.
@@ -38,11 +39,11 @@ class TestModelInfoCacheInitialization:
         """
         print("Настройка: Создание ModelInfoCache с TTL=7200...")
         cache = ModelInfoCache(cache_ttl=7200)
-        
+
         print("Проверка: TTL установлен корректно...")
         print(f"Сравниваем _cache_ttl: Ожидалось 7200, Получено {cache._cache_ttl}")
         assert cache._cache_ttl == 7200
-    
+
     def test_initialization_last_update_is_none(self):
         """
         Что он делает: Проверяет, что last_update_time изначально None.
@@ -50,7 +51,7 @@ class TestModelInfoCacheInitialization:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: last_update_time изначально None...")
         print(f"Сравниваем last_update_time: Ожидалось None, Получено {cache.last_update_time}")
         assert cache.last_update_time is None
@@ -58,7 +59,7 @@ class TestModelInfoCacheInitialization:
 
 class TestModelInfoCacheUpdate:
     """Тесты обновления кэша."""
-    
+
     @pytest.mark.asyncio
     async def test_update_populates_cache(self, sample_models_data):
         """
@@ -67,17 +68,17 @@ class TestModelInfoCacheUpdate:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         print(f"Действие: Обновление кэша с {len(sample_models_data)} моделями...")
         await cache.update(sample_models_data)
-        
+
         print("Проверка: Кэш заполнен...")
         print(f"Сравниваем is_empty(): Ожидалось False, Получено {cache.is_empty()}")
         assert cache.is_empty() is False
-        
+
         print(f"Сравниваем size: Ожидалось {len(sample_models_data)}, Получено {cache.size}")
         assert cache.size == len(sample_models_data)
-    
+
     @pytest.mark.asyncio
     async def test_update_sets_last_update_time(self, sample_models_data):
         """
@@ -86,17 +87,17 @@ class TestModelInfoCacheUpdate:
         """
         print("Настройка: Создание ModelInfoCache...")
         cache = ModelInfoCache()
-        
+
         before_update = time.time()
         print(f"Действие: Обновление кэша (время до: {before_update})...")
         await cache.update(sample_models_data)
         after_update = time.time()
-        
+
         print("Проверка: last_update_time установлен в разумных пределах...")
         print(f"last_update_time: {cache.last_update_time}")
         assert cache.last_update_time is not None
         assert before_update <= cache.last_update_time <= after_update
-    
+
     @pytest.mark.asyncio
     async def test_update_replaces_existing_data(self, sample_models_data):
         """
@@ -106,21 +107,21 @@ class TestModelInfoCacheUpdate:
         print("Настройка: Создание ModelInfoCache и первое обновление...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Обновление с новыми данными...")
         new_data = [{"modelId": "new-model", "tokenLimits": {"maxInputTokens": 50000}}]
         await cache.update(new_data)
-        
+
         print("Проверка: Старые данные заменены...")
         print(f"Сравниваем size: Ожидалось 1, Получено {cache.size}")
         assert cache.size == 1
-        
+
         print("Проверка: Старая модель недоступна...")
         assert cache.get("claude-sonnet-4") is None
-        
+
         print("Проверка: Новая модель доступна...")
         assert cache.get("new-model") is not None
-    
+
     @pytest.mark.asyncio
     async def test_update_with_empty_list(self):
         """
@@ -130,10 +131,10 @@ class TestModelInfoCacheUpdate:
         print("Настройка: Создание ModelInfoCache с данными...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "test-model"}])
-        
+
         print("Действие: Обновление пустым списком...")
         await cache.update([])
-        
+
         print("Проверка: Кэш пуст...")
         print(f"Сравниваем is_empty(): Ожидалось True, Получено {cache.is_empty()}")
         assert cache.is_empty() is True
@@ -141,7 +142,7 @@ class TestModelInfoCacheUpdate:
 
 class TestModelInfoCacheGet:
     """Тесты получения данных из кэша."""
-    
+
     @pytest.mark.asyncio
     async def test_get_returns_model_info(self, sample_models_data):
         """
@@ -151,15 +152,15 @@ class TestModelInfoCacheGet:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение информации о claude-sonnet-4...")
         model_info = cache.get("claude-sonnet-4")
-        
+
         print("Проверка: Информация получена...")
         print(f"model_info: {model_info}")
         assert model_info is not None
         assert model_info["modelId"] == "claude-sonnet-4"
-    
+
     @pytest.mark.asyncio
     async def test_get_returns_none_for_unknown_model(self, sample_models_data):
         """
@@ -169,14 +170,14 @@ class TestModelInfoCacheGet:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение информации о несуществующей модели...")
         model_info = cache.get("non-existent-model")
-        
+
         print("Проверка: Возвращён None...")
         print(f"Сравниваем model_info: Ожидалось None, Получено {model_info}")
         assert model_info is None
-    
+
     def test_get_from_empty_cache(self):
         """
         Что он делает: Проверяет get() из пустого кэша.
@@ -184,10 +185,10 @@ class TestModelInfoCacheGet:
         """
         print("Настройка: Создание пустого кэша...")
         cache = ModelInfoCache()
-        
+
         print("Действие: Получение из пустого кэша...")
         model_info = cache.get("any-model")
-        
+
         print("Проверка: Возвращён None...")
         print(f"Сравниваем model_info: Ожидалось None, Получено {model_info}")
         assert model_info is None
@@ -195,7 +196,7 @@ class TestModelInfoCacheGet:
 
 class TestModelInfoCacheGetMaxInputTokens:
     """Тесты получения maxInputTokens."""
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_value(self, sample_models_data):
         """
@@ -205,14 +206,14 @@ class TestModelInfoCacheGetMaxInputTokens:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение maxInputTokens для claude-sonnet-4...")
         max_tokens = cache.get_max_input_tokens("claude-sonnet-4")
-        
+
         print("Проверка: Значение корректно...")
         print(f"Сравниваем max_tokens: Ожидалось 200000, Получено {max_tokens}")
         assert max_tokens == 200000
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_default_for_unknown(self, sample_models_data):
         """
@@ -222,14 +223,14 @@ class TestModelInfoCacheGetMaxInputTokens:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение maxInputTokens для неизвестной модели...")
         max_tokens = cache.get_max_input_tokens("unknown-model")
-        
+
         print("Проверка: Возвращён дефолт...")
         print(f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}")
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_default_when_no_token_limits(self):
         """
@@ -239,14 +240,14 @@ class TestModelInfoCacheGetMaxInputTokens:
         print("Настройка: Создание кэша с моделью без tokenLimits...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "model-without-limits"}])
-        
+
         print("Действие: Получение maxInputTokens...")
         max_tokens = cache.get_max_input_tokens("model-without-limits")
-        
+
         print("Проверка: Возвращён дефолт...")
         print(f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}")
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
-    
+
     @pytest.mark.asyncio
     async def test_get_max_input_tokens_returns_default_when_max_input_is_none(self):
         """
@@ -255,14 +256,11 @@ class TestModelInfoCacheGetMaxInputTokens:
         """
         print("Настройка: Создание кэша с моделью с maxInputTokens=None...")
         cache = ModelInfoCache()
-        await cache.update([{
-            "modelId": "model-with-null",
-            "tokenLimits": {"maxInputTokens": None}
-        }])
-        
+        await cache.update([{"modelId": "model-with-null", "tokenLimits": {"maxInputTokens": None}}])
+
         print("Действие: Получение maxInputTokens...")
         max_tokens = cache.get_max_input_tokens("model-with-null")
-        
+
         print("Проверка: Возвращён дефолт...")
         print(f"Сравниваем max_tokens: Ожидалось {DEFAULT_MAX_INPUT_TOKENS}, Получено {max_tokens}")
         assert max_tokens == DEFAULT_MAX_INPUT_TOKENS
@@ -270,7 +268,7 @@ class TestModelInfoCacheGetMaxInputTokens:
 
 class TestModelInfoCacheIsEmpty:
     """Тесты проверки пустоты кэша."""
-    
+
     def test_is_empty_returns_true_for_new_cache(self):
         """
         Что он делает: Проверяет is_empty() для нового кэша.
@@ -278,11 +276,11 @@ class TestModelInfoCacheIsEmpty:
         """
         print("Настройка: Создание нового кэша...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: is_empty() возвращает True...")
         print(f"Сравниваем is_empty(): Ожидалось True, Получено {cache.is_empty()}")
         assert cache.is_empty() is True
-    
+
     @pytest.mark.asyncio
     async def test_is_empty_returns_false_after_update(self, sample_models_data):
         """
@@ -292,7 +290,7 @@ class TestModelInfoCacheIsEmpty:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Проверка: is_empty() возвращает False...")
         print(f"Сравниваем is_empty(): Ожидалось False, Получено {cache.is_empty()}")
         assert cache.is_empty() is False
@@ -300,7 +298,7 @@ class TestModelInfoCacheIsEmpty:
 
 class TestModelInfoCacheIsStale:
     """Тесты проверки устаревания кэша."""
-    
+
     def test_is_stale_returns_true_for_new_cache(self):
         """
         Что он делает: Проверяет is_stale() для нового кэша.
@@ -308,11 +306,11 @@ class TestModelInfoCacheIsStale:
         """
         print("Настройка: Создание нового кэша...")
         cache = ModelInfoCache()
-        
+
         print("Проверка: is_stale() возвращает True...")
         print(f"Сравниваем is_stale(): Ожидалось True, Получено {cache.is_stale()}")
         assert cache.is_stale() is True
-    
+
     @pytest.mark.asyncio
     async def test_is_stale_returns_false_after_recent_update(self, sample_models_data):
         """
@@ -322,11 +320,11 @@ class TestModelInfoCacheIsStale:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Проверка: is_stale() возвращает False...")
         print(f"Сравниваем is_stale(): Ожидалось False, Получено {cache.is_stale()}")
         assert cache.is_stale() is False
-    
+
     @pytest.mark.asyncio
     async def test_is_stale_returns_true_after_ttl_expires(self, sample_models_data):
         """
@@ -336,10 +334,10 @@ class TestModelInfoCacheIsStale:
         print("Настройка: Создание кэша с TTL=0.1 секунды...")
         cache = ModelInfoCache(cache_ttl=0.1)
         await cache.update(sample_models_data)
-        
+
         print("Действие: Ожидание истечения TTL...")
         await asyncio.sleep(0.2)
-        
+
         print("Проверка: is_stale() возвращает True...")
         print(f"Сравниваем is_stale(): Ожидалось True, Получено {cache.is_stale()}")
         assert cache.is_stale() is True
@@ -347,7 +345,7 @@ class TestModelInfoCacheIsStale:
 
 class TestModelInfoCacheGetAllModelIds:
     """Тесты получения списка ID моделей."""
-    
+
     def test_get_all_model_ids_returns_empty_for_new_cache(self):
         """
         Что он делает: Проверяет get_all_model_ids() для пустого кэша.
@@ -355,14 +353,14 @@ class TestModelInfoCacheGetAllModelIds:
         """
         print("Настройка: Создание пустого кэша...")
         cache = ModelInfoCache()
-        
+
         print("Действие: Получение списка ID моделей...")
         model_ids = cache.get_all_model_ids()
-        
+
         print("Проверка: Список пуст...")
         print(f"Сравниваем model_ids: Ожидалось [], Получено {model_ids}")
         assert model_ids == []
-    
+
     @pytest.mark.asyncio
     async def test_get_all_model_ids_returns_all_ids(self, sample_models_data):
         """
@@ -372,10 +370,10 @@ class TestModelInfoCacheGetAllModelIds:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: Получение списка ID моделей...")
         model_ids = cache.get_all_model_ids()
-        
+
         print("Проверка: Все ID присутствуют...")
         expected_ids = [m["modelId"] for m in sample_models_data]
         print(f"Сравниваем model_ids: Ожидалось {expected_ids}, Получено {model_ids}")
@@ -384,7 +382,7 @@ class TestModelInfoCacheGetAllModelIds:
 
 class TestModelInfoCacheThreadSafety:
     """Тесты потокобезопасности кэша."""
-    
+
     @pytest.mark.asyncio
     async def test_concurrent_updates_dont_corrupt_cache(self, sample_models_data):
         """
@@ -393,29 +391,29 @@ class TestModelInfoCacheThreadSafety:
         """
         print("Настройка: Создание кэша...")
         cache = ModelInfoCache()
-        
+
         async def update_with_data(data):
             await cache.update(data)
-        
+
         print("Действие: 10 параллельных обновлений...")
         tasks = []
         for i in range(10):
             data = [{"modelId": f"model-{i}", "tokenLimits": {"maxInputTokens": 100000 + i}}]
             tasks.append(update_with_data(data))
-        
+
         await asyncio.gather(*tasks)
-        
+
         print("Проверка: Кэш содержит данные последнего обновления...")
         # Из-за race condition, мы не знаем какое обновление было последним,
         # но кэш должен содержать ровно одну модель
         print(f"Сравниваем size: Ожидалось 1, Получено {cache.size}")
         assert cache.size == 1
-        
+
         print("Проверка: Кэш не повреждён...")
         model_ids = cache.get_all_model_ids()
         assert len(model_ids) == 1
         assert model_ids[0].startswith("model-")
-    
+
     @pytest.mark.asyncio
     async def test_concurrent_reads_are_safe(self, sample_models_data):
         """
@@ -425,13 +423,14 @@ class TestModelInfoCacheThreadSafety:
         print("Настройка: Создание и заполнение кэша...")
         cache = ModelInfoCache()
         await cache.update(sample_models_data)
-        
+
         print("Действие: 100 параллельных чтений...")
+
         async def read_model():
             return cache.get("claude-sonnet-4")
-        
+
         results = await asyncio.gather(*[read_model() for _ in range(100)])
-        
+
         print("Проверка: Все чтения вернули одинаковый результат...")
         assert all(r is not None for r in results)
         assert all(r["modelId"] == "claude-sonnet-4" for r in results)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,175 +5,196 @@ Unit tests for the configuration module.
 Verifies loading settings from environment variables.
 """
 
-import pytest
 import os
 from unittest.mock import patch
+
+import pytest
 
 
 class TestLogLevelConfig:
     """Tests for LOG_LEVEL configuration."""
-    
+
     def test_default_log_level_is_info(self):
         """
         What it does: Verifies that LOG_LEVEL defaults to INFO.
         Purpose: Ensure that INFO is used when no environment variable is set.
-        
+
         Note: This test verifies the config.py code logic, not the actual
         value from the .env file. We mock os.getenv to simulate
         the absence of the environment variable.
         """
         print("Setup: Mocking os.getenv for LOG_LEVEL...")
-        
+
         # Create a mock that returns None for LOG_LEVEL (simulating missing variable)
         original_getenv = os.getenv
-        
+
         def mock_getenv(key, default=None):
             if key == "LOG_LEVEL":
                 print(f"os.getenv('{key}') -> None (mocked)")
                 return default  # Return default, simulating missing variable
             return original_getenv(key, default)
-        
-        with patch.object(os, 'getenv', side_effect=mock_getenv):
+
+        with patch.object(os, "getenv", side_effect=mock_getenv):
             # Reload config module with mocked getenv
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'INFO', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "INFO"
-        
+
         # Restore module with real values
         import importlib
+
         import kiro.config as config_module
+
         importlib.reload(config_module)
-    
+
     def test_log_level_from_environment(self):
         """
         What it does: Verifies loading LOG_LEVEL from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting LOG_LEVEL=DEBUG...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'DEBUG', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "DEBUG"
-    
+
     def test_log_level_uppercase_conversion(self):
         """
         What it does: Verifies LOG_LEVEL conversion to uppercase.
         Purpose: Ensure that lowercase value is converted to uppercase.
         """
         print("Setup: Setting LOG_LEVEL=warning (lowercase)...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "warning"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             print(f"Comparing: Expected 'WARNING', Got '{config_module.LOG_LEVEL}'")
             assert config_module.LOG_LEVEL == "WARNING"
-    
+
     def test_log_level_trace(self):
         """
         What it does: Verifies setting LOG_LEVEL=TRACE.
         Purpose: Ensure that TRACE level is supported.
         """
         print("Setup: Setting LOG_LEVEL=TRACE...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "TRACE"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "TRACE"
-    
+
     def test_log_level_error(self):
         """
         What it does: Verifies setting LOG_LEVEL=ERROR.
         Purpose: Ensure that ERROR level is supported.
         """
         print("Setup: Setting LOG_LEVEL=ERROR...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "ERROR"
-    
+
     def test_log_level_critical(self):
         """
         What it does: Verifies setting LOG_LEVEL=CRITICAL.
         Purpose: Ensure that CRITICAL level is supported.
         """
         print("Setup: Setting LOG_LEVEL=CRITICAL...")
-        
+
         with patch.dict(os.environ, {"LOG_LEVEL": "CRITICAL"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"LOG_LEVEL: {config_module.LOG_LEVEL}")
             assert config_module.LOG_LEVEL == "CRITICAL"
 
 
 class TestToolDescriptionMaxLengthConfig:
     """Tests for TOOL_DESCRIPTION_MAX_LENGTH configuration."""
-    
+
     def test_default_tool_description_max_length(self):
         """
         What it does: Verifies the default value for TOOL_DESCRIPTION_MAX_LENGTH.
         Purpose: Ensure that 10000 is used by default.
         """
         print("Setup: Removing TOOL_DESCRIPTION_MAX_LENGTH from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "TOOL_DESCRIPTION_MAX_LENGTH" in os.environ:
                 del os.environ["TOOL_DESCRIPTION_MAX_LENGTH"]
-            
+
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 10000
-    
+
     def test_tool_description_max_length_from_environment(self):
         """
         What it does: Verifies loading TOOL_DESCRIPTION_MAX_LENGTH from environment.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting TOOL_DESCRIPTION_MAX_LENGTH=5000...")
-        
+
         with patch.dict(os.environ, {"TOOL_DESCRIPTION_MAX_LENGTH": "5000"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 5000
-    
+
     def test_tool_description_max_length_zero_disables(self):
         """
         What it does: Verifies that 0 disables the feature.
         Purpose: Ensure that TOOL_DESCRIPTION_MAX_LENGTH=0 works.
         """
         print("Setup: Setting TOOL_DESCRIPTION_MAX_LENGTH=0...")
-        
+
         with patch.dict(os.environ, {"TOOL_DESCRIPTION_MAX_LENGTH": "0"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"TOOL_DESCRIPTION_MAX_LENGTH: {config_module.TOOL_DESCRIPTION_MAX_LENGTH}")
             assert config_module.TOOL_DESCRIPTION_MAX_LENGTH == 0
 
@@ -195,111 +216,107 @@ class TestDebugCaptureConfig:
 
 class TestTimeoutConfigurationWarning:
     """Tests for _warn_timeout_configuration() function."""
-    
+
     def test_no_warning_when_first_token_less_than_streaming(self, capsys):
         """
         What it does: Verifies that warning is NOT shown with correct configuration.
         Purpose: Ensure that no warning when FIRST_TOKEN_TIMEOUT < STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=15, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "15",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(os.environ, {"FIRST_TOKEN_TIMEOUT": "15", "STREAMING_READ_TIMEOUT": "300"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning should NOT be shown
             assert "WARNING" not in captured.err
             assert "Suboptimal timeout configuration" not in captured.err
-    
+
     def test_warning_when_first_token_equals_streaming(self, capsys):
         """
         What it does: Verifies that warning is shown when timeouts are equal.
         Purpose: Ensure that warning when FIRST_TOKEN_TIMEOUT == STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=300, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "300",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(os.environ, {"FIRST_TOKEN_TIMEOUT": "300", "STREAMING_READ_TIMEOUT": "300"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning SHOULD be shown
             assert "WARNING" in captured.err or "Suboptimal timeout configuration" in captured.err
-    
+
     def test_warning_when_first_token_greater_than_streaming(self, capsys):
         """
         What it does: Verifies that warning is shown when FIRST_TOKEN > STREAMING.
         Purpose: Ensure that warning when FIRST_TOKEN_TIMEOUT > STREAMING_READ_TIMEOUT.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=500, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "500",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(os.environ, {"FIRST_TOKEN_TIMEOUT": "500", "STREAMING_READ_TIMEOUT": "300"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning SHOULD be shown
             assert "WARNING" in captured.err or "Suboptimal timeout configuration" in captured.err
             # Verify that timeout values are mentioned in warning
             assert "500" in captured.err
             assert "300" in captured.err
-    
+
     def test_warning_contains_recommendation(self, capsys):
         """
         What it does: Verifies that warning contains a recommendation.
         Purpose: Ensure that user receives useful information.
         """
         print("Setup: FIRST_TOKEN_TIMEOUT=400, STREAMING_READ_TIMEOUT=300...")
-        
-        with patch.dict(os.environ, {
-            "FIRST_TOKEN_TIMEOUT": "400",
-            "STREAMING_READ_TIMEOUT": "300"
-        }):
+
+        with patch.dict(os.environ, {"FIRST_TOKEN_TIMEOUT": "400", "STREAMING_READ_TIMEOUT": "300"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             # Call the warning function
             config_module._warn_timeout_configuration()
-            
+
             captured = capsys.readouterr()
             print(f"Captured stderr: {captured.err}")
-            
+
             # Warning should contain recommendation
             assert "Recommendation" in captured.err or "LESS than" in captured.err
 
 
 class TestAwsSsoOidcUrlConfig:
     """Tests for AWS SSO OIDC URL configuration."""
-    
+
     def test_aws_sso_oidc_url_template_exists(self):
         """
         What it does: Verifies that AWS_SSO_OIDC_URL_TEMPLATE constant exists.
@@ -307,17 +324,19 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing config module...")
         import importlib
+
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: AWS_SSO_OIDC_URL_TEMPLATE exists...")
-        assert hasattr(config_module, 'AWS_SSO_OIDC_URL_TEMPLATE')
-        
+        assert hasattr(config_module, "AWS_SSO_OIDC_URL_TEMPLATE")
+
         print(f"AWS_SSO_OIDC_URL_TEMPLATE: {config_module.AWS_SSO_OIDC_URL_TEMPLATE}")
         assert "oidc" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
         assert "amazonaws.com" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
         assert "{region}" in config_module.AWS_SSO_OIDC_URL_TEMPLATE
-    
+
     def test_get_aws_sso_oidc_url_returns_correct_url(self):
         """
         What it does: Verifies that get_aws_sso_oidc_url returns correct URL.
@@ -325,15 +344,15 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing get_aws_sso_oidc_url...")
         from kiro.config import get_aws_sso_oidc_url
-        
+
         print("Action: Calling get_aws_sso_oidc_url('us-east-1')...")
         url = get_aws_sso_oidc_url("us-east-1")
-        
-        print(f"Verification: URL is correct...")
+
+        print("Verification: URL is correct...")
         expected = "https://oidc.us-east-1.amazonaws.com/token"
         print(f"Comparing: Expected '{expected}', Got '{url}'")
         assert url == expected
-    
+
     def test_get_aws_sso_oidc_url_with_different_regions(self):
         """
         What it does: Verifies URL generation for different regions.
@@ -341,14 +360,14 @@ class TestAwsSsoOidcUrlConfig:
         """
         print("Setup: Importing get_aws_sso_oidc_url...")
         from kiro.config import get_aws_sso_oidc_url
-        
+
         test_cases = [
             ("us-east-1", "https://oidc.us-east-1.amazonaws.com/token"),
             ("eu-west-1", "https://oidc.eu-west-1.amazonaws.com/token"),
             ("ap-southeast-1", "https://oidc.ap-southeast-1.amazonaws.com/token"),
             ("us-west-2", "https://oidc.us-west-2.amazonaws.com/token"),
         ]
-        
+
         for region, expected in test_cases:
             print(f"Action: Calling get_aws_sso_oidc_url('{region}')...")
             url = get_aws_sso_oidc_url(region)
@@ -358,127 +377,141 @@ class TestAwsSsoOidcUrlConfig:
 
 class TestServerHostConfig:
     """Tests for SERVER_HOST configuration."""
-    
+
     def test_default_server_host_is_0_0_0_0(self):
         """
         What it does: Verifies that SERVER_HOST defaults to 0.0.0.0.
         Purpose: Ensure that 0.0.0.0 (all interfaces) is used when no environment variable is set.
         """
         print("Setup: Removing SERVER_HOST from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "SERVER_HOST" in os.environ:
                 del os.environ["SERVER_HOST"]
-            
+
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             print(f"DEFAULT_SERVER_HOST: {config_module.DEFAULT_SERVER_HOST}")
             print(f"Comparing: Expected '0.0.0.0', Got '{config_module.SERVER_HOST}'")
             assert config_module.SERVER_HOST == "0.0.0.0"
             assert config_module.DEFAULT_SERVER_HOST == "0.0.0.0"
-    
+
     def test_server_host_from_environment(self):
         """
         What it does: Verifies loading SERVER_HOST from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting SERVER_HOST=127.0.0.1...")
-        
+
         with patch.dict(os.environ, {"SERVER_HOST": "127.0.0.1"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             print(f"Comparing: Expected '127.0.0.1', Got '{config_module.SERVER_HOST}'")
             assert config_module.SERVER_HOST == "127.0.0.1"
-    
+
     def test_server_host_custom_value(self):
         """
         What it does: Verifies setting SERVER_HOST to a custom IP address.
         Purpose: Ensure that any valid IP address can be used.
         """
         print("Setup: Setting SERVER_HOST=192.168.1.100...")
-        
+
         with patch.dict(os.environ, {"SERVER_HOST": "192.168.1.100"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_HOST: {config_module.SERVER_HOST}")
             assert config_module.SERVER_HOST == "192.168.1.100"
 
 
 class TestServerPortConfig:
     """Tests for SERVER_PORT configuration."""
-    
+
     def test_default_server_port_is_8000(self):
         """
         What it does: Verifies that SERVER_PORT defaults to 8000.
         Purpose: Ensure that 8000 is used when no environment variable is set.
         """
         print("Setup: Removing SERVER_PORT from environment...")
-        
+
         with patch.dict(os.environ, {}, clear=False):
             if "SERVER_PORT" in os.environ:
                 del os.environ["SERVER_PORT"]
-            
+
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"DEFAULT_SERVER_PORT: {config_module.DEFAULT_SERVER_PORT}")
             print(f"Comparing: Expected 8000, Got {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 8000
             assert config_module.DEFAULT_SERVER_PORT == 8000
-    
+
     def test_server_port_from_environment(self):
         """
         What it does: Verifies loading SERVER_PORT from environment variable.
         Purpose: Ensure that the value from environment is used.
         """
         print("Setup: Setting SERVER_PORT=9000...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "9000"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"Comparing: Expected 9000, Got {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 9000
-    
+
     def test_server_port_custom_value(self):
         """
         What it does: Verifies setting SERVER_PORT to a custom port number.
         Purpose: Ensure that any valid port number can be used.
         """
         print("Setup: Setting SERVER_PORT=3000...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "3000"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             assert config_module.SERVER_PORT == 3000
-    
+
     def test_server_port_is_integer(self):
         """
         What it does: Verifies that SERVER_PORT is converted to integer.
         Purpose: Ensure that string from environment is converted to int.
         """
         print("Setup: Setting SERVER_PORT=8080 (as string)...")
-        
+
         with patch.dict(os.environ, {"SERVER_PORT": "8080"}):
             import importlib
+
             import kiro.config as config_module
+
             importlib.reload(config_module)
-            
+
             print(f"SERVER_PORT: {config_module.SERVER_PORT}")
             print(f"Type: {type(config_module.SERVER_PORT)}")
             assert isinstance(config_module.SERVER_PORT, int)
@@ -487,7 +520,7 @@ class TestServerPortConfig:
 
 class TestKiroCliDbFileConfig:
     """Tests for KIRO_CLI_DB_FILE configuration."""
-    
+
     def test_kiro_cli_db_file_config_exists(self):
         """
         What it does: Verifies that KIRO_CLI_DB_FILE constant exists.
@@ -495,35 +528,37 @@ class TestKiroCliDbFileConfig:
         """
         print("Setup: Importing config module...")
         import importlib
+
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: KIRO_CLI_DB_FILE exists...")
-        assert hasattr(config_module, 'KIRO_CLI_DB_FILE')
-        
+        assert hasattr(config_module, "KIRO_CLI_DB_FILE")
+
         print(f"KIRO_CLI_DB_FILE: '{config_module.KIRO_CLI_DB_FILE}'")
         # Default should be empty string
         assert isinstance(config_module.KIRO_CLI_DB_FILE, str)
-    
+
     def test_kiro_cli_db_file_from_environment(self):
         """
         What it does: Verifies loading KIRO_CLI_DB_FILE from environment variable.
         Purpose: Ensure the value from environment is used and normalized.
         """
         print("Setup: Importing config module...")
-        import importlib
         import kiro.config as config_module
-        
+
         # Test that KIRO_CLI_DB_FILE is loaded and is a string
         print(f"KIRO_CLI_DB_FILE: {config_module.KIRO_CLI_DB_FILE}")
         assert isinstance(config_module.KIRO_CLI_DB_FILE, str)
-        
+
         # If value is set (not empty), verify it's a normalized path
         if config_module.KIRO_CLI_DB_FILE:
             # Path should be normalized (no raw ~ or forward slashes on Windows)
             assert not config_module.KIRO_CLI_DB_FILE.startswith("~")
             # Should be a valid path string (contains path separators or is absolute)
             from pathlib import Path
+
             path = Path(config_module.KIRO_CLI_DB_FILE)
             # Path should be constructable (doesn't raise exception)
             assert str(path) == config_module.KIRO_CLI_DB_FILE
@@ -531,7 +566,7 @@ class TestKiroCliDbFileConfig:
 
 class TestFallbackModelsConfig:
     """Tests for FALLBACK_MODELS configuration."""
-    
+
     def test_fallback_models_exists(self):
         """
         What it does: Verifies that FALLBACK_MODELS constant exists.
@@ -539,15 +574,17 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing config module...")
         import importlib
+
         import kiro.config as config_module
+
         importlib.reload(config_module)
-        
+
         print("Verification: FALLBACK_MODELS exists...")
-        assert hasattr(config_module, 'FALLBACK_MODELS')
-        
+        assert hasattr(config_module, "FALLBACK_MODELS")
+
         print(f"FALLBACK_MODELS type: {type(config_module.FALLBACK_MODELS)}")
         assert isinstance(config_module.FALLBACK_MODELS, list)
-    
+
     def test_fallback_models_not_empty(self):
         """
         What it does: Verifies that FALLBACK_MODELS contains at least one model.
@@ -555,11 +592,11 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         print(f"FALLBACK_MODELS length: {len(FALLBACK_MODELS)}")
         print(f"Comparing: Expected > 0, Got {len(FALLBACK_MODELS)}")
         assert len(FALLBACK_MODELS) > 0
-    
+
     def test_fallback_models_structure(self):
         """
         What it does: Verifies that each fallback model has required modelId field.
@@ -567,23 +604,23 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         print(f"Action: Checking structure of {len(FALLBACK_MODELS)} models...")
         for i, model in enumerate(FALLBACK_MODELS):
             print(f"Checking model {i}: {model}")
-            
-            print(f"  Verification: model is dict...")
+
+            print("  Verification: model is dict...")
             assert isinstance(model, dict), f"Model {i} is not a dict"
-            
-            print(f"  Verification: model has 'modelId'...")
+
+            print("  Verification: model has 'modelId'...")
             assert "modelId" in model, f"Model {i} missing 'modelId'"
-            
-            print(f"  Verification: modelId is string...")
+
+            print("  Verification: modelId is string...")
             assert isinstance(model["modelId"], str), f"Model {i} modelId is not string"
-            
-            print(f"  Verification: modelId is not empty...")
+
+            print("  Verification: modelId is not empty...")
             assert len(model["modelId"]) > 0, f"Model {i} modelId is empty"
-    
+
     def test_fallback_models_contain_claude_models(self):
         """
         What it does: Verifies that fallback models include Claude models.
@@ -591,14 +628,14 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         model_ids = [m["modelId"] for m in FALLBACK_MODELS]
         print(f"Model IDs in fallback list: {model_ids}")
-        
+
         print("Verification: Contains at least one Claude model...")
         has_claude = any("claude" in mid.lower() for mid in model_ids)
         assert has_claude, "No Claude models in fallback list"
-    
+
     def test_fallback_models_use_dot_format(self):
         """
         What it does: Verifies that model IDs use dot format (e.g., claude-4.5).
@@ -606,12 +643,12 @@ class TestFallbackModelsConfig:
         """
         print("Setup: Importing FALLBACK_MODELS...")
         from kiro.config import FALLBACK_MODELS
-        
+
         print("Action: Checking model ID format...")
         for model in FALLBACK_MODELS:
             model_id = model["modelId"]
             print(f"Checking: {model_id}")
-            
+
             # If model has version number, it should use dot format
             if any(char.isdigit() for char in model_id):
                 # Check for patterns like "4.5" or "4-5"
@@ -623,7 +660,7 @@ class TestFallbackModelsConfig:
 
 class TestFallbackModelsIntegration:
     """Integration tests for FALLBACK_MODELS with ModelResolver."""
-    
+
     @pytest.mark.asyncio
     async def test_fallback_models_work_with_model_resolver(self):
         """
@@ -632,20 +669,20 @@ class TestFallbackModelsIntegration:
                  works correctly with fallback models, just like with API models.
         """
         print("Setup: Importing FALLBACK_MODELS and creating cache...")
-        from kiro.config import FALLBACK_MODELS
         from kiro.cache import ModelInfoCache
+        from kiro.config import FALLBACK_MODELS
         from kiro.model_resolver import ModelResolver
-        
+
         # Simulate DNS failure scenario - populate cache with fallback models
         cache = ModelInfoCache()
         await cache.update(FALLBACK_MODELS)
-        
+
         print(f"Cache populated with {cache.size} fallback models")
         print(f"Model IDs in cache: {cache.get_all_model_ids()}")
-        
+
         # Create resolver
         resolver = ModelResolver(cache=cache, hidden_models={})
-        
+
         print("\nAction: Testing normalization with dash format...")
         # Test that dash format (claude-opus-4-5) is normalized and found
         test_cases = [
@@ -653,27 +690,27 @@ class TestFallbackModelsIntegration:
             ("claude-sonnet-4-5", "claude-sonnet-4.5"),  # Dash → Dot
             ("claude-haiku-4-5", "claude-haiku-4.5"),  # Dash → Dot
         ]
-        
+
         for input_name, expected_normalized in test_cases:
             print(f"\n  Testing: {input_name} → {expected_normalized}")
             resolution = resolver.resolve(input_name)
-            
+
             print(f"    Resolution source: {resolution.source}")
             print(f"    Normalized: {resolution.normalized}")
             print(f"    Internal ID: {resolution.internal_id}")
             print(f"    Is verified: {resolution.is_verified}")
-            
+
             # Verify normalization happened
             print(f"    Comparing normalized: Expected '{expected_normalized}', Got '{resolution.normalized}'")
             assert resolution.normalized == expected_normalized
-            
+
             # Verify model was found in cache (not passthrough)
             print(f"    Comparing source: Expected 'cache', Got '{resolution.source}'")
             assert resolution.source == "cache", f"Model {input_name} should be found in fallback cache"
-            
+
             print(f"    Comparing is_verified: Expected True, Got {resolution.is_verified}")
             assert resolution.is_verified is True
-    
+
     @pytest.mark.asyncio
     async def test_fallback_models_appear_in_available_models(self):
         """
@@ -681,26 +718,26 @@ class TestFallbackModelsIntegration:
         Purpose: Ensure that /v1/models endpoint will show fallback models.
         """
         print("Setup: Importing FALLBACK_MODELS and creating cache...")
-        from kiro.config import FALLBACK_MODELS
         from kiro.cache import ModelInfoCache
+        from kiro.config import FALLBACK_MODELS
         from kiro.model_resolver import ModelResolver
-        
+
         cache = ModelInfoCache()
         await cache.update(FALLBACK_MODELS)
-        
+
         resolver = ModelResolver(cache=cache, hidden_models={})
-        
+
         print("Action: Getting available models...")
         available = resolver.get_available_models()
-        
+
         print(f"Available models: {available}")
         print(f"Comparing length: Expected {len(FALLBACK_MODELS)}, Got {len(available)}")
         assert len(available) == len(FALLBACK_MODELS)
-        
+
         # Verify all fallback models are present
         fallback_ids = {m["modelId"] for m in FALLBACK_MODELS}
         available_set = set(available)
-        
+
         print(f"Comparing sets: Expected {fallback_ids}, Got {available_set}")
         assert fallback_ids == available_set
 
@@ -709,9 +746,10 @@ class TestFallbackModelsIntegration:
 # Tests for WebSearch Configuration
 # ==================================================================================================
 
+
 class TestWebSearchConfig:
     """Tests for WebSearch configuration (WEB_SEARCH_ENABLED)."""
-    
+
     def test_web_search_enabled_default_true(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED defaults to true.
@@ -719,15 +757,17 @@ class TestWebSearchConfig:
         """
         print("Setup: Removing WEB_SEARCH_ENABLED from environment...")
         monkeypatch.delenv("WEB_SEARCH_ENABLED", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is True
-    
+
     def test_web_search_enabled_false(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED=false disables auto-injection.
@@ -735,15 +775,17 @@ class TestWebSearchConfig:
         """
         print("Setup: Setting WEB_SEARCH_ENABLED=false...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "false")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is False
-    
+
     def test_web_search_enabled_true(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED=true enables auto-injection.
@@ -751,15 +793,17 @@ class TestWebSearchConfig:
         """
         print("Setup: Setting WEB_SEARCH_ENABLED=true...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "true")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is True
-    
+
     def test_web_search_enabled_numeric_values(self, monkeypatch):
         """
         What it does: Verifies numeric values (1/0) work for WEB_SEARCH_ENABLED.
@@ -767,21 +811,23 @@ class TestWebSearchConfig:
         """
         print("Setup: Testing WEB_SEARCH_ENABLED=1...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "1")
-        
+
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is True
-        
+
         print("Setup: Testing WEB_SEARCH_ENABLED=0...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "0")
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is False
-    
+
     def test_web_search_enabled_yes_value(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED=yes enables auto-injection.
@@ -789,15 +835,17 @@ class TestWebSearchConfig:
         """
         print("Setup: Setting WEB_SEARCH_ENABLED=yes...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "yes")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is True
-    
+
     def test_web_search_enabled_case_insensitive(self, monkeypatch):
         """
         What it does: Verifies WEB_SEARCH_ENABLED is case-insensitive.
@@ -805,18 +853,20 @@ class TestWebSearchConfig:
         """
         print("Setup: Testing WEB_SEARCH_ENABLED=TRUE...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "TRUE")
-        
+
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is True
-        
+
         print("Setup: Testing WEB_SEARCH_ENABLED=FALSE...")
         monkeypatch.setenv("WEB_SEARCH_ENABLED", "FALSE")
         reload(config_module)
-        
+
         print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
         assert config_module.WEB_SEARCH_ENABLED is False
 
@@ -825,38 +875,43 @@ class TestWebSearchConfig:
 # Tests for Account System Configuration
 # ==================================================================================================
 
+
 class TestAccountSystemConfig:
     """Tests for Account System configuration constants."""
-    
+
     def test_account_system_default_false(self):
         """
         What it does: Verifies ACCOUNT_SYSTEM defaults to false.
         Purpose: Ensure legacy mode is default (backward compatibility).
         """
         print("Setup: Mocking os.getenv for ACCOUNT_SYSTEM...")
-        
+
         original_getenv = os.getenv
-        
+
         def mock_getenv(key, default=None):
             if key == "ACCOUNT_SYSTEM":
                 print(f"os.getenv('{key}') -> None (mocked)")
                 return default  # Return default, simulating missing variable
             return original_getenv(key, default)
-        
-        with patch.object(os, 'getenv', side_effect=mock_getenv):
+
+        with patch.object(os, "getenv", side_effect=mock_getenv):
             print("Action: Reloading config module...")
             from importlib import reload
+
             import kiro.config as config_module
+
             reload(config_module)
-            
+
             print(f"Comparing ACCOUNT_SYSTEM: Expected False, Got {config_module.ACCOUNT_SYSTEM}")
             assert config_module.ACCOUNT_SYSTEM is False
-        
+
         # Restore module with real values
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-    
+
     def test_account_system_enabled(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_SYSTEM=true enables account system.
@@ -864,15 +919,17 @@ class TestAccountSystemConfig:
         """
         print("Setup: Setting ACCOUNT_SYSTEM=true...")
         monkeypatch.setenv("ACCOUNT_SYSTEM", "true")
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing ACCOUNT_SYSTEM: Expected True, Got {config_module.ACCOUNT_SYSTEM}")
         assert config_module.ACCOUNT_SYSTEM is True
-    
+
     def test_accounts_config_file_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNTS_CONFIG_FILE defaults to credentials.json.
@@ -880,15 +937,19 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNTS_CONFIG_FILE from environment...")
         monkeypatch.delenv("ACCOUNTS_CONFIG_FILE", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNTS_CONFIG_FILE: Expected 'credentials.json', Got '{config_module.ACCOUNTS_CONFIG_FILE}'")
+
+        print(
+            f"Comparing ACCOUNTS_CONFIG_FILE: Expected 'credentials.json', Got '{config_module.ACCOUNTS_CONFIG_FILE}'"
+        )
         assert config_module.ACCOUNTS_CONFIG_FILE == "credentials.json"
-    
+
     def test_accounts_state_file_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNTS_STATE_FILE defaults to state.json.
@@ -896,15 +957,17 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNTS_STATE_FILE from environment...")
         monkeypatch.delenv("ACCOUNTS_STATE_FILE", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing ACCOUNTS_STATE_FILE: Expected 'state.json', Got '{config_module.ACCOUNTS_STATE_FILE}'")
         assert config_module.ACCOUNTS_STATE_FILE == "state.json"
-    
+
     def test_account_recovery_timeout_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_RECOVERY_TIMEOUT defaults to 60 seconds.
@@ -912,15 +975,17 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_RECOVERY_TIMEOUT from environment...")
         monkeypatch.delenv("ACCOUNT_RECOVERY_TIMEOUT", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing ACCOUNT_RECOVERY_TIMEOUT: Expected 60, Got {config_module.ACCOUNT_RECOVERY_TIMEOUT}")
         assert config_module.ACCOUNT_RECOVERY_TIMEOUT == 60
-    
+
     def test_account_max_backoff_multiplier_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_MAX_BACKOFF_MULTIPLIER defaults to 1440.0.
@@ -928,15 +993,19 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_MAX_BACKOFF_MULTIPLIER from environment...")
         monkeypatch.delenv("ACCOUNT_MAX_BACKOFF_MULTIPLIER", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_MAX_BACKOFF_MULTIPLIER: Expected 1440.0, Got {config_module.ACCOUNT_MAX_BACKOFF_MULTIPLIER}")
+
+        print(
+            f"Comparing ACCOUNT_MAX_BACKOFF_MULTIPLIER: Expected 1440.0, Got {config_module.ACCOUNT_MAX_BACKOFF_MULTIPLIER}"
+        )
         assert config_module.ACCOUNT_MAX_BACKOFF_MULTIPLIER == 1440.0
-    
+
     def test_account_probabilistic_retry_chance_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_PROBABILISTIC_RETRY_CHANCE defaults to 0.1.
@@ -944,15 +1013,19 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_PROBABILISTIC_RETRY_CHANCE from environment...")
         monkeypatch.delenv("ACCOUNT_PROBABILISTIC_RETRY_CHANCE", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
-        print(f"Comparing ACCOUNT_PROBABILISTIC_RETRY_CHANCE: Expected 0.1, Got {config_module.ACCOUNT_PROBABILISTIC_RETRY_CHANCE}")
+
+        print(
+            f"Comparing ACCOUNT_PROBABILISTIC_RETRY_CHANCE: Expected 0.1, Got {config_module.ACCOUNT_PROBABILISTIC_RETRY_CHANCE}"
+        )
         assert config_module.ACCOUNT_PROBABILISTIC_RETRY_CHANCE == 0.1
-    
+
     def test_account_cache_ttl_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_CACHE_TTL defaults to 43200 seconds (12 hours).
@@ -960,15 +1033,17 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing ACCOUNT_CACHE_TTL from environment...")
         monkeypatch.delenv("ACCOUNT_CACHE_TTL", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing ACCOUNT_CACHE_TTL: Expected 43200, Got {config_module.ACCOUNT_CACHE_TTL}")
         assert config_module.ACCOUNT_CACHE_TTL == 43200
-    
+
     def test_state_save_interval_seconds_default(self, monkeypatch):
         """
         What it does: Verifies STATE_SAVE_INTERVAL_SECONDS defaults to 10 seconds.
@@ -976,11 +1051,13 @@ class TestAccountSystemConfig:
         """
         print("Setup: Removing STATE_SAVE_INTERVAL_SECONDS from environment...")
         monkeypatch.delenv("STATE_SAVE_INTERVAL_SECONDS", raising=False)
-        
+
         print("Action: Reloading config module...")
         from importlib import reload
+
         import kiro.config as config_module
+
         reload(config_module)
-        
+
         print(f"Comparing STATE_SAVE_INTERVAL_SECONDS: Expected 10, Got {config_module.STATE_SAVE_INTERVAL_SECONDS}")
         assert config_module.STATE_SAVE_INTERVAL_SECONDS == 10

--- a/tests/unit/test_converters_anthropic.py
+++ b/tests/unit/test_converters_anthropic.py
@@ -12,34 +12,27 @@ Tests for Anthropic Messages API to Kiro format conversion:
 - Full Anthropic → Kiro payload conversion
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
-
 from kiro.converters_anthropic import (
     convert_anthropic_content_to_text,
-    extract_system_prompt,
-    extract_tool_results_from_anthropic_content,
-    extract_images_from_tool_results,
-    extract_tool_uses_from_anthropic_content,
     convert_anthropic_messages,
     convert_anthropic_tools,
-    anthropic_to_kiro,
+    extract_images_from_tool_results,
+    extract_system_prompt,
+    extract_tool_results_from_anthropic_content,
+    extract_tool_uses_from_anthropic_content,
 )
 from kiro.converters_core import (
-    UnifiedMessage,
     UnifiedTool,
     convert_tool_results_to_kiro_format,
 )
 from kiro.models_anthropic import (
-    AnthropicMessagesRequest,
     AnthropicMessage,
     AnthropicTool,
-    TextContentBlock,
-    ToolUseContentBlock,
-    ToolResultContentBlock,
     SystemContentBlock,
+    TextContentBlock,
+    ToolResultContentBlock,
+    ToolUseContentBlock,
 )
-
 
 # ==================================================================================================
 # Tests for convert_anthropic_content_to_text
@@ -176,9 +169,7 @@ class TestExtractSystemPrompt:
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
 
-        print(
-            f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'"
-        )
+        print(f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'")
         assert result == "You are a helpful assistant."
 
     def test_extracts_from_list_with_text_blocks(self):
@@ -195,9 +186,7 @@ class TestExtractSystemPrompt:
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
 
-        print(
-            f"Comparing result: Expected 'You are helpful.\\nBe concise.', Got '{result}'"
-        )
+        print(f"Comparing result: Expected 'You are helpful.\\nBe concise.', Got '{result}'")
         assert result == "You are helpful.\nBe concise."
 
     def test_extracts_from_list_with_cache_control(self):
@@ -217,9 +206,7 @@ class TestExtractSystemPrompt:
         print("Action: Extracting system prompt...")
         result = extract_system_prompt(system)
 
-        print(
-            f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'"
-        )
+        print(f"Comparing result: Expected 'You are a helpful assistant.', Got '{result}'")
         assert result == "You are a helpful assistant."
 
     def test_extracts_from_pydantic_system_content_blocks(self):
@@ -355,9 +342,7 @@ class TestExtractToolResultsFromAnthropicContent:
         Purpose: Ensure tool_result blocks are extracted correctly.
         """
         print("Setup: Content with tool_result block...")
-        content = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
-        ]
+        content = [{"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}]
 
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
@@ -374,11 +359,7 @@ class TestExtractToolResultsFromAnthropicContent:
         Purpose: Ensure Pydantic models are handled correctly.
         """
         print("Setup: Content with Pydantic ToolResultContentBlock...")
-        content = [
-            ToolResultContentBlock(
-                type="tool_result", tool_use_id="call_456", content="Pydantic result"
-            )
-        ]
+        content = [ToolResultContentBlock(type="tool_result", tool_use_id="call_456", content="Pydantic result")]
 
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_anthropic_content(content)
@@ -850,11 +831,7 @@ class TestExtractToolUsesFromAnthropicContent:
         Purpose: Ensure Pydantic models are handled correctly.
         """
         print("Setup: Content with Pydantic ToolUseContentBlock...")
-        content = [
-            ToolUseContentBlock(
-                type="tool_use", id="call_456", name="search", input={"query": "test"}
-            )
-        ]
+        content = [ToolUseContentBlock(type="tool_use", id="call_456", name="search", input={"query": "test"})]
 
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_anthropic_content(content)
@@ -1146,19 +1123,13 @@ class TestConvertAnthropicMessages:
 
         print("Checking images field...")
         assert result[0].images is not None, "images field should not be None"
-        assert len(result[0].images) == 1, (
-            f"Expected 1 image, got {len(result[0].images)}"
-        )
+        assert len(result[0].images) == 1, f"Expected 1 image, got {len(result[0].images)}"
 
         image = result[0].images[0]
-        print(
-            f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'"
-        )
+        print(f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'")
         assert image["media_type"] == "image/jpeg"
 
-        print(
-            f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}..."
-        )
+        print(f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}...")
         assert image["data"] == test_image_base64
 
     def test_images_only_extracted_from_user_role(self):
@@ -1197,9 +1168,7 @@ class TestConvertAnthropicMessages:
         assert len(result[0].images) == 1
 
         print("Checking assistant message has no images...")
-        assert result[1].images is None, (
-            "Assistant messages should not have images extracted"
-        )
+        assert result[1].images is None, "Assistant messages should not have images extracted"
 
     def test_extracts_multiple_images_from_user_message(self):
         """
@@ -1245,14 +1214,10 @@ class TestConvertAnthropicMessages:
         print("Action: Converting messages...")
         result = convert_anthropic_messages(messages)
 
-        print(
-            f"Result images count: {len(result[0].images) if result[0].images else 0}"
-        )
+        print(f"Result images count: {len(result[0].images) if result[0].images else 0}")
 
         assert result[0].images is not None
-        assert len(result[0].images) == 3, (
-            f"Expected 3 images, got {len(result[0].images)}"
-        )
+        assert len(result[0].images) == 3, f"Expected 3 images, got {len(result[0].images)}"
 
         print("Checking image media types...")
         media_types = [img["media_type"] for img in result[0].images]
@@ -1446,14 +1411,16 @@ class TestConvertAnthropicTools:
 
 class TestAnthropicToolResultStatus:
     def test_preserves_is_error_in_kiro_status(self):
-        extracted = extract_tool_results_from_anthropic_content([
-            {
-                "type": "tool_result",
-                "tool_use_id": "toolu_A",
-                "is_error": True,
-                "content": "database unavailable",
-            }
-        ])
+        extracted = extract_tool_results_from_anthropic_content(
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_A",
+                    "is_error": True,
+                    "content": "database unavailable",
+                }
+            ]
+        )
 
         converted = convert_tool_results_to_kiro_format(extracted)
 

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -11,32 +11,28 @@ Tests for shared conversion logic used by both OpenAI and Anthropic adapters:
 - Thinking tag injection
 """
 
-import os
-import pytest
 from unittest.mock import patch
 
 from kiro.converters_core import (
-    extract_text_content,
-    extract_images_from_content,
-    convert_images_to_kiro_format,
-    merge_adjacent_messages,
-    ensure_first_message_is_user,
-    normalize_message_roles,
-    ensure_alternating_roles,
-    ensure_assistant_before_tool_results,
-    strip_all_tool_content,
-    build_kiro_history,
-    build_kiro_payload,
-    process_tools_with_long_descriptions,
-    extract_tool_results_from_content,
-    extract_tool_uses_from_message,
-    sanitize_json_schema,
-    convert_tools_to_kiro_format,
-    convert_tool_results_to_kiro_format,
-    tool_calls_to_text,
-    tool_results_to_text,
     UnifiedMessage,
     UnifiedTool,
+    build_kiro_history,
+    convert_images_to_kiro_format,
+    convert_tool_results_to_kiro_format,
+    ensure_alternating_roles,
+    ensure_assistant_before_tool_results,
+    ensure_first_message_is_user,
+    extract_images_from_content,
+    extract_text_content,
+    extract_tool_results_from_content,
+    extract_tool_uses_from_message,
+    merge_adjacent_messages,
+    normalize_message_roles,
+    process_tools_with_long_descriptions,
+    sanitize_json_schema,
+    strip_all_tool_content,
+    tool_calls_to_text,
+    tool_results_to_text,
 )
 
 # Test data for images - 1x1 pixel JPEG
@@ -47,9 +43,10 @@ TEST_IMAGE_BASE64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAs
 # Tests for extract_text_content
 # ==================================================================================================
 
+
 class TestExtractTextContent:
     """Tests for extract_text_content function."""
-    
+
     def test_extracts_from_string(self):
         """
         What it does: Verifies text extraction from a string.
@@ -57,43 +54,40 @@ class TestExtractTextContent:
         """
         print("Setup: Simple string...")
         content = "Hello, World!"
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello, World!', Got '{result}'")
         assert result == "Hello, World!"
-    
+
     def test_extracts_from_none(self):
         """
         What it does: Verifies None handling.
         Purpose: Ensure None returns empty string.
         """
         print("Setup: None...")
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(None)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_extracts_from_list_with_text_type(self):
         """
         What it does: Verifies extraction from list with type=text.
         Purpose: Ensure multimodal format is handled.
         """
         print("Setup: List with type=text...")
-        content = [
-            {"type": "text", "text": "Hello"},
-            {"type": "text", "text": " World"}
-        ]
-        
+        content = [{"type": "text", "text": "Hello"}, {"type": "text", "text": " World"}]
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_list_with_text_key(self):
         """
         What it does: Verifies extraction from list with text key.
@@ -101,13 +95,13 @@ class TestExtractTextContent:
         """
         print("Setup: List with text key...")
         content = [{"text": "Hello"}, {"text": " World"}]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_list_with_strings(self):
         """
         What it does: Verifies extraction from list of strings.
@@ -115,31 +109,27 @@ class TestExtractTextContent:
         """
         print("Setup: List of strings...")
         content = ["Hello", " ", "World"]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Hello World', Got '{result}'")
         assert result == "Hello World"
-    
+
     def test_extracts_from_mixed_list(self):
         """
         What it does: Verifies extraction from mixed list.
         Purpose: Ensure different formats in one list are handled.
         """
         print("Setup: Mixed list...")
-        content = [
-            {"type": "text", "text": "Part1"},
-            "Part2",
-            {"text": "Part3"}
-        ]
-        
+        content = [{"type": "text", "text": "Part1"}, "Part2", {"text": "Part3"}]
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected 'Part1Part2Part3', Got '{result}'")
         assert result == "Part1Part2Part3"
-    
+
     def test_converts_other_types_to_string(self):
         """
         What it does: Verifies conversion of other types to string.
@@ -147,13 +137,13 @@ class TestExtractTextContent:
         """
         print("Setup: Number...")
         content = 42
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected '42', Got '{result}'")
         assert result == "42"
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
@@ -161,119 +151,115 @@ class TestExtractTextContent:
         """
         print("Setup: Empty list...")
         content = []
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_extracts_from_pydantic_text_content_block(self):
         """
         What it does: Verifies extraction from Pydantic TextContentBlock objects.
         Purpose: Ensure Pydantic models are handled correctly (Issue #46/#50 fix).
-        
+
         This is the critical test for Issue #46/#50 - the original bug was that
         Pydantic TextContentBlock objects weren't being handled, causing MCP tool
         results to return "(empty result)" instead of actual data.
         """
         from kiro.models_anthropic import TextContentBlock
-        
+
         print("Setup: Pydantic TextContentBlock...")
-        content = [
-            TextContentBlock(type="text", text="Hello from MCP")
-        ]
-        
+        content = [TextContentBlock(type="text", text="Hello from MCP")]
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Result: '{result}'")
         print(f"Comparing result: Expected 'Hello from MCP', Got '{result}'")
         assert result == "Hello from MCP"
-    
+
     def test_extracts_from_multiple_pydantic_text_blocks(self):
         """
         What it does: Verifies extraction from multiple Pydantic TextContentBlock objects.
         Purpose: Ensure multiple Pydantic models are concatenated correctly.
         """
         from kiro.models_anthropic import TextContentBlock
-        
+
         print("Setup: Multiple Pydantic TextContentBlocks...")
         content = [
             TextContentBlock(type="text", text="Part 1"),
             TextContentBlock(type="text", text=" Part 2"),
-            TextContentBlock(type="text", text=" Part 3")
+            TextContentBlock(type="text", text=" Part 3"),
         ]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Result: '{result}'")
         print(f"Comparing result: Expected 'Part 1 Part 2 Part 3', Got '{result}'")
         assert result == "Part 1 Part 2 Part 3"
-    
+
     def test_extracts_from_mixed_dict_and_pydantic(self):
         """
         What it does: Verifies extraction from mixed dict and Pydantic content.
         Purpose: Ensure dict and Pydantic models can coexist in the same list.
-        
+
         This simulates real-world scenarios where some content is parsed as dict
         and some as Pydantic models.
         """
         from kiro.models_anthropic import TextContentBlock
-        
+
         print("Setup: Mixed dict and Pydantic content...")
         content = [
             {"type": "text", "text": "Dict text"},
             TextContentBlock(type="text", text=" Pydantic text"),
-            " String text"
+            " String text",
         ]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Result: '{result}'")
         print(f"Comparing result: Expected 'Dict text Pydantic text String text', Got '{result}'")
         assert result == "Dict text Pydantic text String text"
-    
+
     def test_handles_pydantic_with_empty_text(self):
         """
         What it does: Verifies handling of Pydantic TextContentBlock with empty text.
         Purpose: Ensure empty text in Pydantic models doesn't cause errors.
         """
         from kiro.models_anthropic import TextContentBlock
-        
+
         print("Setup: Pydantic TextContentBlock with empty text...")
-        content = [
-            TextContentBlock(type="text", text="")
-        ]
-        
+        content = [TextContentBlock(type="text", text="")]
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Result: '{result}'")
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_extracts_text_ignoring_other_pydantic_types(self):
         """
         What it does: Verifies that only text-containing Pydantic models are extracted.
         Purpose: Ensure non-text Pydantic models (like ToolUseContentBlock) are ignored.
-        
+
         This simulates MCP tool results that contain both text and tool_use blocks.
         """
         from kiro.models_anthropic import TextContentBlock, ToolUseContentBlock
-        
+
         print("Setup: Mixed Pydantic content with text and tool_use...")
         content = [
             TextContentBlock(type="text", text="Before tool"),
             ToolUseContentBlock(type="tool_use", id="call_123", name="test_tool", input={}),
-            TextContentBlock(type="text", text="After tool")
+            TextContentBlock(type="text", text="After tool"),
         ]
-        
+
         print("Action: Extracting text...")
         result = extract_text_content(content)
-        
+
         print(f"Result: '{result}'")
         print(f"Comparing result: Expected 'Before toolAfter tool', Got '{result}'")
         assert result == "Before toolAfter tool"
@@ -288,7 +274,7 @@ class TestExtractTextContent:
             {"type": "text", "text": "Loaded tools:"},
             {"type": "tool_reference", "tool_name": "mcp__slack__read_channel"},
             {"type": "tool_reference", "tool_name": "Read"},
-            {"type": "text", "text": " done"}
+            {"type": "text", "text": " done"},
         ]
 
         print("Action: Extracting text...")
@@ -302,78 +288,69 @@ class TestExtractTextContent:
 # Tests for extract_images_from_content (Issue #30 fix)
 # ==================================================================================================
 
+
 class TestExtractImagesFromContent:
     """
     Tests for extract_images_from_content function.
-    
+
     This function extracts images from message content in unified format.
     Supports both OpenAI (image_url with data URL) and Anthropic (image with source) formats.
-    
+
     This is a critical function for Issue #30 fix - 422 Validation Error for image content blocks.
     """
-    
+
     def test_extracts_from_openai_format_data_url(self):
         """
         What it does: Verifies extraction from OpenAI image_url format with data URL.
         Purpose: Ensure OpenAI Vision API format is handled correctly.
-        
+
         OpenAI format: {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
         """
         print("Setup: OpenAI format image content...")
         content = [
             {"type": "text", "text": "What's in this image?"},
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_BASE64}"}
-            }
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{TEST_IMAGE_BASE64}"}},
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking media_type...")
         assert result[0]["media_type"] == "image/jpeg"
-        
+
         print("Checking data...")
         assert result[0]["data"] == TEST_IMAGE_BASE64
-    
+
     def test_extracts_from_anthropic_format_base64(self):
         """
         What it does: Verifies extraction from Anthropic image format with base64 source.
         Purpose: Ensure Anthropic Messages API format is handled correctly.
-        
+
         Anthropic format: {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "..."}}
         """
         print("Setup: Anthropic format image content...")
         content = [
             {"type": "text", "text": "Describe this image"},
-            {
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "media_type": "image/png",
-                    "data": TEST_IMAGE_BASE64
-                }
-            }
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": TEST_IMAGE_BASE64}},
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking media_type...")
         assert result[0]["media_type"] == "image/png"
-        
+
         print("Checking data...")
         assert result[0]["data"] == TEST_IMAGE_BASE64
-    
+
     def test_extracts_from_mixed_content(self):
         """
         What it does: Verifies extraction from mixed content (text + multiple images).
@@ -382,32 +359,26 @@ class TestExtractImagesFromContent:
         print("Setup: Mixed content with multiple images...")
         content = [
             {"type": "text", "text": "Compare these images:"},
-            {
-                "type": "image",
-                "source": {"type": "base64", "media_type": "image/jpeg", "data": "image1_data"}
-            },
+            {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "image1_data"}},
             {"type": "text", "text": "and"},
-            {
-                "type": "image",
-                "source": {"type": "base64", "media_type": "image/png", "data": "image2_data"}
-            }
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "image2_data"}},
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking first image...")
         assert result[0]["media_type"] == "image/jpeg"
         assert result[0]["data"] == "image1_data"
-        
+
         print("Checking second image...")
         assert result[1]["media_type"] == "image/png"
         assert result[1]["data"] == "image2_data"
-    
+
     def test_returns_empty_for_string_content(self):
         """
         What it does: Verifies empty list return for string content.
@@ -415,13 +386,13 @@ class TestExtractImagesFromContent:
         """
         print("Setup: String content...")
         content = "Just a text message"
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_empty_content(self):
         """
         What it does: Verifies empty list return for empty content.
@@ -429,13 +400,13 @@ class TestExtractImagesFromContent:
         """
         print("Setup: Empty list...")
         content = []
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_none_content(self):
         """
         What it does: Verifies empty list return for None content.
@@ -443,170 +414,133 @@ class TestExtractImagesFromContent:
         """
         print("Setup: None content...")
         content = None
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_text_only_content(self):
         """
         What it does: Verifies empty list return for text-only content.
         Purpose: Ensure text blocks don't produce images.
         """
         print("Setup: Text-only content...")
-        content = [
-            {"type": "text", "text": "Hello"},
-            {"type": "text", "text": "World"}
-        ]
-        
+        content = [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_url_images_with_warning(self):
         """
         What it does: Verifies URL-based images are skipped with warning.
         Purpose: Ensure URL images don't crash but are logged as unsupported.
-        
+
         URL-based images require fetching and are not supported by Kiro API directly.
         """
         print("Setup: URL-based image content...")
-        content = [
-            {
-                "type": "image_url",
-                "image_url": {"url": "https://example.com/image.jpg"}
-            }
-        ]
-        
+        content = [{"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}]
+
         print("Action: Extracting images (should skip URL images)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # URL images are skipped
-    
+
     def test_handles_anthropic_url_source_with_warning(self):
         """
         What it does: Verifies Anthropic URL source images are skipped with warning.
         Purpose: Ensure Anthropic URL format doesn't crash but is logged as unsupported.
         """
         print("Setup: Anthropic URL source image...")
-        content = [
-            {
-                "type": "image",
-                "source": {
-                    "type": "url",
-                    "url": "https://example.com/image.png"
-                }
-            }
-        ]
-        
+        content = [{"type": "image", "source": {"type": "url", "url": "https://example.com/image.png"}}]
+
         print("Action: Extracting images (should skip URL images)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # URL images are skipped
-    
+
     def test_handles_invalid_data_url(self):
         """
         What it does: Verifies handling of invalid data URL format.
         Purpose: Ensure malformed data URLs don't crash the function.
         """
         print("Setup: Invalid data URL...")
-        content = [
-            {
-                "type": "image_url",
-                "image_url": {"url": "data:invalid_format_without_comma"}
-            }
-        ]
-        
+        content = [{"type": "image_url", "image_url": {"url": "data:invalid_format_without_comma"}}]
+
         print("Action: Extracting images (should handle gracefully)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # Invalid data URL is skipped
-    
+
     def test_handles_empty_data_in_image(self):
         """
         What it does: Verifies handling of image with empty data.
         Purpose: Ensure images with empty data are skipped.
         """
         print("Setup: Image with empty data...")
-        content = [
-            {
-                "type": "image",
-                "source": {"type": "base64", "media_type": "image/jpeg", "data": ""}
-            }
-        ]
-        
+        content = [{"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": ""}}]
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # Empty data is skipped
-    
+
     def test_extracts_from_pydantic_image_content_block(self):
         """
         What it does: Verifies extraction from Pydantic ImageContentBlock objects.
         Purpose: Ensure Pydantic models are handled correctly (Issue #30 fix).
-        
+
         This is the critical test for Issue #30 - the original bug was that
         Pydantic ImageContentBlock objects weren't being handled.
         """
-        from kiro.models_anthropic import ImageContentBlock, Base64ImageSource
-        
+        from kiro.models_anthropic import Base64ImageSource, ImageContentBlock
+
         print("Setup: Pydantic ImageContentBlock...")
         content = [
             ImageContentBlock(
-                type="image",
-                source=Base64ImageSource(
-                    type="base64",
-                    media_type="image/webp",
-                    data=TEST_IMAGE_BASE64
-                )
+                type="image", source=Base64ImageSource(type="base64", media_type="image/webp", data=TEST_IMAGE_BASE64)
             )
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking media_type...")
         assert result[0]["media_type"] == "image/webp"
-        
+
         print("Checking data...")
         assert result[0]["data"] == TEST_IMAGE_BASE64
-    
+
     def test_extracts_from_pydantic_url_image_source(self):
         """
         What it does: Verifies handling of Pydantic URLImageSource objects.
         Purpose: Ensure Pydantic URL sources are skipped with warning.
         """
         from kiro.models_anthropic import ImageContentBlock, URLImageSource
-        
+
         print("Setup: Pydantic ImageContentBlock with URL source...")
         content = [
-            ImageContentBlock(
-                type="image",
-                source=URLImageSource(
-                    type="url",
-                    url="https://example.com/image.gif"
-                )
-            )
+            ImageContentBlock(type="image", source=URLImageSource(type="url", url="https://example.com/image.gif"))
         ]
-        
+
         print("Action: Extracting images (should skip URL images)...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []  # URL images are skipped
-    
+
     def test_extracts_multiple_formats_mixed(self):
         """
         What it does: Verifies extraction from mixed OpenAI and Anthropic formats.
@@ -615,32 +549,26 @@ class TestExtractImagesFromContent:
         print("Setup: Mixed OpenAI and Anthropic formats...")
         content = [
             # OpenAI format
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/jpeg;base64,openai_image_data"}
-            },
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,openai_image_data"}},
             # Anthropic format
-            {
-                "type": "image",
-                "source": {"type": "base64", "media_type": "image/png", "data": "anthropic_image_data"}
-            }
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "anthropic_image_data"}},
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking OpenAI image...")
         assert result[0]["media_type"] == "image/jpeg"
         assert result[0]["data"] == "openai_image_data"
-        
+
         print("Checking Anthropic image...")
         assert result[1]["media_type"] == "image/png"
         assert result[1]["data"] == "anthropic_image_data"
-    
+
     def test_handles_missing_source_in_anthropic_format(self):
         """
         What it does: Verifies handling of Anthropic image without source.
@@ -650,13 +578,13 @@ class TestExtractImagesFromContent:
         content = [
             {"type": "image"}  # Missing source
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_missing_image_url_in_openai_format(self):
         """
         What it does: Verifies handling of OpenAI image_url without image_url field.
@@ -666,53 +594,43 @@ class TestExtractImagesFromContent:
         content = [
             {"type": "image_url"}  # Missing image_url
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_extracts_gif_format(self):
         """
         What it does: Verifies extraction of GIF images.
         Purpose: Ensure GIF format is supported.
         """
         print("Setup: GIF image...")
-        content = [
-            {
-                "type": "image",
-                "source": {"type": "base64", "media_type": "image/gif", "data": "gif_data"}
-            }
-        ]
-        
+        content = [{"type": "image", "source": {"type": "base64", "media_type": "image/gif", "data": "gif_data"}}]
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["media_type"] == "image/gif"
-    
+
     def test_extracts_webp_format(self):
         """
         What it does: Verifies extraction of WebP images.
         Purpose: Ensure WebP format is supported.
         """
         print("Setup: WebP image...")
-        content = [
-            {
-                "type": "image",
-                "source": {"type": "base64", "media_type": "image/webp", "data": "webp_data"}
-            }
-        ]
-        
+        content = [{"type": "image", "source": {"type": "base64", "media_type": "image/webp", "data": "webp_data"}}]
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["media_type"] == "image/webp"
-    
+
     def test_uses_default_media_type_when_missing(self):
         """
         What it does: Verifies default media_type is used when not specified.
@@ -722,13 +640,13 @@ class TestExtractImagesFromContent:
         content = [
             {
                 "type": "image",
-                "source": {"type": "base64", "data": "some_data"}  # No media_type
+                "source": {"type": "base64", "data": "some_data"},  # No media_type
             }
         ]
-        
+
         print("Action: Extracting images...")
         result = extract_images_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["media_type"] == "image/jpeg"  # Default
@@ -738,16 +656,17 @@ class TestExtractImagesFromContent:
 # Tests for convert_images_to_kiro_format
 # ==================================================================================================
 
+
 class TestConvertImagesToKiroFormat:
     """
     Tests for convert_images_to_kiro_format function.
-    
+
     This function converts unified images to Kiro API format.
-    
+
     Unified format: [{"media_type": "image/jpeg", "data": "base64..."}]
     Kiro format: [{"format": "jpeg", "source": {"bytes": "base64..."}}]
     """
-    
+
     def test_converts_single_image(self):
         """
         What it does: Verifies conversion of a single image.
@@ -755,20 +674,20 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Single image in unified format...")
         images = [{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Checking format...")
         assert result[0]["format"] == "jpeg"
-        
+
         print("Checking source.bytes...")
         assert result[0]["source"]["bytes"] == TEST_IMAGE_BASE64
-    
+
     def test_converts_multiple_images(self):
         """
         What it does: Verifies conversion of multiple images.
@@ -778,66 +697,63 @@ class TestConvertImagesToKiroFormat:
         images = [
             {"media_type": "image/jpeg", "data": "jpeg_data"},
             {"media_type": "image/png", "data": "png_data"},
-            {"media_type": "image/gif", "data": "gif_data"}
+            {"media_type": "image/gif", "data": "gif_data"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 3, Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking formats...")
         assert result[0]["format"] == "jpeg"
         assert result[1]["format"] == "png"
         assert result[2]["format"] == "gif"
-    
+
     def test_returns_empty_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns empty list.
         """
         print("Setup: None images...")
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(None)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_empty_list(self):
         """
         What it does: Verifies handling of empty list.
         Purpose: Ensure empty list returns empty list.
         """
         print("Setup: Empty images list...")
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_skips_images_with_empty_data(self):
         """
         What it does: Verifies skipping of images with empty data.
         Purpose: Ensure images without data are not included.
         """
         print("Setup: Image with empty data...")
-        images = [
-            {"media_type": "image/jpeg", "data": ""},
-            {"media_type": "image/png", "data": "valid_data"}
-        ]
-        
+        images = [{"media_type": "image/jpeg", "data": ""}, {"media_type": "image/png", "data": "valid_data"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert result[0]["format"] == "png"
-    
+
     def test_extracts_format_from_media_type(self):
         """
         What it does: Verifies extraction of format from media_type.
@@ -848,18 +764,18 @@ class TestConvertImagesToKiroFormat:
             {"media_type": "image/jpeg", "data": "data1"},
             {"media_type": "image/png", "data": "data2"},
             {"media_type": "image/gif", "data": "data3"},
-            {"media_type": "image/webp", "data": "data4"}
+            {"media_type": "image/webp", "data": "data4"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result formats: {[r['format'] for r in result]}")
         assert result[0]["format"] == "jpeg"
         assert result[1]["format"] == "png"
         assert result[2]["format"] == "gif"
         assert result[3]["format"] == "webp"
-    
+
     def test_handles_media_type_without_slash(self):
         """
         What it does: Verifies handling of media_type without slash.
@@ -867,14 +783,14 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Media type without slash...")
         images = [{"media_type": "jpeg", "data": "data"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["format"] == "jpeg"
-    
+
     def test_uses_default_media_type_when_missing(self):
         """
         What it does: Verifies default media_type is used when not specified.
@@ -882,14 +798,14 @@ class TestConvertImagesToKiroFormat:
         """
         print("Setup: Image without media_type...")
         images = [{"data": "some_data"}]  # No media_type
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["format"] == "jpeg"  # Default from "image/jpeg"
-    
+
     def test_preserves_large_image_data(self):
         """
         What it does: Verifies large image data is preserved.
@@ -898,37 +814,37 @@ class TestConvertImagesToKiroFormat:
         print("Setup: Large image data...")
         large_data = "A" * 100000  # 100KB of data
         images = [{"media_type": "image/png", "data": large_data}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result data length: {len(result[0]['source']['bytes'])}")
         assert len(result[0]["source"]["bytes"]) == 100000
-    
+
     # ==================================================================================
     # Data URL Prefix Stripping Tests (Issue #32 fix)
     # ==================================================================================
-    
+
     def test_strips_data_url_prefix_jpeg(self):
         """
         What it does: Verifies that data URL prefix is stripped from JPEG image data.
         Purpose: Ensure Kiro API receives pure base64 without the data URL prefix (Issue #32 fix).
-        
+
         Some clients send the full data URL in the data field instead of pure base64.
         Kiro API expects pure base64 without the "data:image/jpeg;base64," prefix.
         """
         print("Setup: Image with data URL prefix (JPEG)...")
         pure_base64 = "/9j/4AAQSkZJRg=="  # Sample JPEG base64
         images = [{"media_type": "image/jpeg", "data": f"data:image/jpeg;base64,{pure_base64}"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing bytes: Expected '{pure_base64}', Got '{result[0]['source']['bytes']}'")
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "jpeg"
-    
+
     def test_strips_data_url_prefix_png(self):
         """
         What it does: Verifies that data URL prefix is stripped from PNG image data.
@@ -937,20 +853,20 @@ class TestConvertImagesToKiroFormat:
         print("Setup: Image with data URL prefix (PNG)...")
         pure_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
         images = [{"media_type": "image/png", "data": f"data:image/png;base64,{pure_base64}"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print(f"Comparing bytes: Expected pure base64, Got '{result[0]['source']['bytes'][:50]}...'")
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "png"
-    
+
     def test_extracts_media_type_from_data_url(self):
         """
         What it does: Verifies that media_type is extracted from data URL header.
         Purpose: Ensure media_type from data URL overrides the original media_type (Issue #32 fix).
-        
+
         When data URL contains media type info, it should be used instead of the
         original media_type field (which might be incorrect or generic).
         """
@@ -958,57 +874,57 @@ class TestConvertImagesToKiroFormat:
         pure_base64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"  # GIF
         # Original media_type says jpeg, but data URL says gif
         images = [{"media_type": "image/jpeg", "data": f"data:image/gif;base64,{pure_base64}"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print("Checking that media_type from data URL is used...")
         assert result[0]["format"] == "gif"  # Should use gif from data URL, not jpeg
         assert result[0]["source"]["bytes"] == pure_base64
-    
+
     def test_handles_malformed_data_url_no_comma(self):
         """
         What it does: Verifies graceful handling of malformed data URL without comma.
         Purpose: Ensure function doesn't crash on malformed data URLs (Issue #32 fix).
-        
+
         If data URL is malformed (no comma separator), the function should
         log a warning and use the original data as-is.
         """
         print("Setup: Malformed data URL without comma...")
         malformed_data = "data:image/jpeg;base64_without_comma"
         images = [{"media_type": "image/jpeg", "data": malformed_data}]
-        
+
         print("Action: Converting to Kiro format (should handle gracefully)...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         # The function should still produce output, using the malformed data as-is
         # (since split(",", 1) will fail and the except block will catch it)
         assert len(result) == 1
         # After the fix, malformed data URL should be preserved as-is
         assert result[0]["source"]["bytes"] == malformed_data
-    
+
     def test_preserves_pure_base64_data(self):
         """
         What it does: Verifies that pure base64 data (without prefix) is preserved.
         Purpose: Ensure normal base64 data is not modified (Issue #32 fix).
-        
+
         When data is already pure base64 (doesn't start with "data:"),
         it should be passed through unchanged.
         """
         print("Setup: Pure base64 data without prefix...")
         pure_base64 = TEST_IMAGE_BASE64
         images = [{"media_type": "image/jpeg", "data": pure_base64}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print("Checking that pure base64 is preserved unchanged...")
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "jpeg"
-    
+
     def test_strips_data_url_prefix_webp(self):
         """
         What it does: Verifies that data URL prefix is stripped from WebP image data.
@@ -1017,29 +933,29 @@ class TestConvertImagesToKiroFormat:
         print("Setup: Image with data URL prefix (WebP)...")
         pure_base64 = "UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA="
         images = [{"media_type": "image/webp", "data": f"data:image/webp;base64,{pure_base64}"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         assert result[0]["source"]["bytes"] == pure_base64
         assert result[0]["format"] == "webp"
-    
+
     def test_handles_data_url_with_empty_base64(self):
         """
         What it does: Verifies handling of data URL with empty base64 part.
         Purpose: Ensure empty data after prefix is handled correctly (Issue #32 fix).
-        
+
         Note: The function strips the prefix but doesn't re-check for empty data after stripping.
         This means an image with "data:image/jpeg;base64," will result in empty bytes.
         This is acceptable behavior as Kiro API will handle the validation.
         """
         print("Setup: Data URL with empty base64 part...")
         images = [{"media_type": "image/jpeg", "data": "data:image/jpeg;base64,"}]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_images_to_kiro_format(images)
-        
+
         print(f"Result: {result}")
         print("Checking that image is converted (with empty bytes)...")
         # The function strips the prefix but doesn't re-check for empty data
@@ -1053,28 +969,26 @@ class TestConvertImagesToKiroFormat:
 # Tests for merge_adjacent_messages
 # ==================================================================================================
 
+
 class TestMergeAdjacentMessages:
     """Tests for merge_adjacent_messages function using UnifiedMessage."""
-    
+
     def test_merges_adjacent_user_messages(self):
         """
         What it does: Verifies merging of adjacent user messages.
         Purpose: Ensure messages with the same role are merged.
         """
         print("Setup: Two consecutive user messages...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello"),
-            UnifiedMessage(role="user", content="World")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello"), UnifiedMessage(role="user", content="World")]
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert "Hello" in result[0].content
         assert "World" in result[0].content
-    
+
     def test_preserves_alternating_messages(self):
         """
         What it does: Verifies preservation of alternating messages.
@@ -1084,28 +998,28 @@ class TestMergeAdjacentMessages:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty list doesn't cause errors.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_single_message(self):
         """
         What it does: Verifies single message handling.
@@ -1113,14 +1027,14 @@ class TestMergeAdjacentMessages:
         """
         print("Setup: Single message...")
         messages = [UnifiedMessage(role="user", content="Hello")]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert result[0].content == "Hello"
-    
+
     def test_merges_multiple_adjacent_groups(self):
         """
         What it does: Verifies merging of multiple groups.
@@ -1132,18 +1046,18 @@ class TestMergeAdjacentMessages:
             UnifiedMessage(role="user", content="B"),
             UnifiedMessage(role="assistant", content="C"),
             UnifiedMessage(role="assistant", content="D"),
-            UnifiedMessage(role="user", content="E")
+            UnifiedMessage(role="user", content="E"),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         assert result[0].role == "user"
         assert result[1].role == "assistant"
         assert result[2].role == "user"
-    
+
     def test_merges_list_contents_correctly(self):
         """
         What it does: Verifies merging of list contents.
@@ -1152,22 +1066,22 @@ class TestMergeAdjacentMessages:
         print("Setup: Two user messages with list content...")
         messages = [
             UnifiedMessage(role="user", content=[{"type": "text", "text": "Part 1"}]),
-            UnifiedMessage(role="user", content=[{"type": "text", "text": "Part 2"}])
+            UnifiedMessage(role="user", content=[{"type": "text", "text": "Part 2"}]),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert isinstance(result[0].content, list)
         assert len(result[0].content) == 2
-    
+
     def test_merges_adjacent_assistant_tool_calls(self):
         """
         What it does: Verifies merging of tool_calls when merging adjacent assistant messages.
         Purpose: Ensure tool_calls from all assistant messages are preserved when merging.
-        
+
         This is a critical test for a bug where multiple assistant messages with tool_calls
         were sent in a row, and the second tool_call was lost.
         """
@@ -1176,41 +1090,45 @@ class TestMergeAdjacentMessages:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "tooluse_first",
-                    "type": "function",
-                    "function": {"name": "shell", "arguments": '{"command": ["ls"]}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "tooluse_first",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": '{"command": ["ls"]}'},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "tooluse_second",
-                    "type": "function",
-                    "function": {"name": "shell", "arguments": '{"command": ["pwd"]}'}
-                }]
-            )
+                tool_calls=[
+                    {
+                        "id": "tooluse_second",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": '{"command": ["pwd"]}'},
+                    }
+                ],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         assert result[0].role == "assistant"
-        
+
         print("Checking that both tool_calls are preserved...")
         assert result[0].tool_calls is not None
         print(f"Comparing tool_calls count: Expected 2, Got {len(result[0].tool_calls)}")
         assert len(result[0].tool_calls) == 2
-        
+
         tool_ids = [tc["id"] for tc in result[0].tool_calls]
         print(f"Tool IDs: {tool_ids}")
         assert "tooluse_first" in tool_ids
         assert "tooluse_second" in tool_ids
-    
+
     def test_merges_three_adjacent_assistant_tool_calls(self):
         """
         What it does: Verifies merging of tool_calls from three assistant messages.
@@ -1218,28 +1136,34 @@ class TestMergeAdjacentMessages:
         """
         print("Setup: Three assistant messages with tool_calls...")
         messages = [
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}
-            ]),
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_2", "type": "function", "function": {"name": "tool2", "arguments": "{}"}}
-            ]),
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_3", "type": "function", "function": {"name": "tool3", "arguments": "{}"}}
-            ])
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}],
+            ),
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "call_2", "type": "function", "function": {"name": "tool2", "arguments": "{}"}}],
+            ),
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "call_3", "type": "function", "function": {"name": "tool3", "arguments": "{}"}}],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert len(result[0].tool_calls) == 3
-        
+
         tool_ids = [tc["id"] for tc in result[0].tool_calls]
         print(f"Comparing tool IDs: Expected ['call_1', 'call_2', 'call_3'], Got {tool_ids}")
         assert tool_ids == ["call_1", "call_2", "call_3"]
-    
+
     def test_merges_assistant_with_and_without_tool_calls(self):
         """
         What it does: Verifies merging of assistant with and without tool_calls.
@@ -1248,21 +1172,23 @@ class TestMergeAdjacentMessages:
         print("Setup: Assistant without tool_calls + assistant with tool_calls...")
         messages = [
             UnifiedMessage(role="assistant", content="Thinking...", tool_calls=None),
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}
-            ])
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].tool_calls is not None
         print(f"Comparing tool_calls count: Expected 1, Got {len(result[0].tool_calls)}")
         assert len(result[0].tool_calls) == 1
         assert result[0].tool_calls[0]["id"] == "call_1"
-    
+
     def test_merges_user_messages_with_tool_results(self):
         """
         What it does: Verifies merging of user messages with tool_results.
@@ -1270,17 +1196,21 @@ class TestMergeAdjacentMessages:
         """
         print("Setup: Two user messages with tool_results...")
         messages = [
-            UnifiedMessage(role="user", content="", tool_results=[
-                {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"}
-            ]),
-            UnifiedMessage(role="user", content="", tool_results=[
-                {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
-            ])
+            UnifiedMessage(
+                role="user",
+                content="",
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"}],
+            ),
+            UnifiedMessage(
+                role="user",
+                content="",
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}],
+            ),
         ]
-        
+
         print("Action: Merging messages...")
         result = merge_adjacent_messages(messages)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0].tool_results is not None
@@ -1291,36 +1221,34 @@ class TestMergeAdjacentMessages:
 # Tests for ensure_first_message_is_user
 # ==================================================================================================
 
+
 class TestEnsureFirstMessageIsUser:
     """
     Tests for ensure_first_message_is_user function.
-    
+
     This function ensures that conversations start with a user message, as required by Kiro API.
     If the first message is from assistant (or any non-user role), a minimal synthetic user
     message is prepended. This fixes issue #60 where conversations starting with assistant
     messages cause "Improperly formed request" errors.
     """
-    
+
     def test_preserves_messages_starting_with_user(self):
         """
         What it does: Verifies that messages starting with user are unchanged.
         Purpose: Ensure correct conversations pass through unmodified.
         """
         print("Setup: Messages starting with user...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello"),
-            UnifiedMessage(role="assistant", content="Hi there")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello"), UnifiedMessage(role="assistant", content="Hi there")]
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print(f"Comparing length: Expected 2, Got {len(result)}")
         assert len(result) == 2
         assert result[0].role == "user"
         assert result[0].content == "Hello"
         assert result[1].role == "assistant"
-    
+
     def test_prepends_synthetic_user_when_first_is_assistant(self):
         """
         What it does: Verifies synthetic user message is prepended when first message is assistant.
@@ -1329,57 +1257,55 @@ class TestEnsureFirstMessageIsUser:
         print("Setup: Messages starting with assistant...")
         messages = [
             UnifiedMessage(role="assistant", content="Hello! I'm here to help."),
-            UnifiedMessage(role="user", content="Hi, can you help me?")
+            UnifiedMessage(role="user", content="Hi, can you help me?"),
         ]
-        
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print(f"Comparing length: Expected 3 (synthetic + 2 original), Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking first message is synthetic user...")
         assert result[0].role == "user"
         assert result[0].content == ""
-        
+
         print("Checking original messages are preserved...")
         assert result[1].role == "assistant"
         assert result[1].content == "Hello! I'm here to help."
         assert result[2].role == "user"
         assert result[2].content == "Hi, can you help me?"
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output without errors.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_single_assistant_message(self):
         """
         What it does: Verifies single assistant message gets synthetic user prepended.
         Purpose: Handle edge case of conversation with only assistant message.
         """
         print("Setup: Single assistant message...")
-        messages = [
-            UnifiedMessage(role="assistant", content="Previous response to continue...")
-        ]
-        
+        messages = [UnifiedMessage(role="assistant", content="Previous response to continue...")]
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print(f"Comparing length: Expected 2 (synthetic + original), Got {len(result)}")
         assert len(result) == 2
         assert result[0].role == "user"
         assert result[0].content == ""
         assert result[1].role == "assistant"
-    
+
     def test_handles_assistant_user_assistant_sequence(self):
         """
         What it does: Verifies synthetic user is prepended for assistant-first sequences.
@@ -1389,12 +1315,12 @@ class TestEnsureFirstMessageIsUser:
         messages = [
             UnifiedMessage(role="assistant", content="First response"),
             UnifiedMessage(role="user", content="Question"),
-            UnifiedMessage(role="assistant", content="Second response")
+            UnifiedMessage(role="assistant", content="Second response"),
         ]
-        
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print(f"Comparing length: Expected 4 (synthetic + 3 original), Got {len(result)}")
         assert len(result) == 4
         assert result[0].role == "user"
@@ -1402,7 +1328,7 @@ class TestEnsureFirstMessageIsUser:
         assert result[1].role == "assistant"
         assert result[2].role == "user"
         assert result[3].role == "assistant"
-    
+
     def test_preserves_tool_calls_in_assistant_message(self):
         """
         What it does: Verifies tool_calls are preserved when prepending synthetic user.
@@ -1413,28 +1339,30 @@ class TestEnsureFirstMessageIsUser:
             UnifiedMessage(
                 role="assistant",
                 content="Let me check that for you.",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print("Checking synthetic user was prepended...")
         assert len(result) == 2
         assert result[0].role == "user"
         assert result[0].content == ""
-        
+
         print("Checking tool_calls are preserved...")
         assert result[1].role == "assistant"
         assert result[1].tool_calls is not None
         assert len(result[1].tool_calls) == 1
         assert result[1].tool_calls[0]["id"] == "call_123"
-    
+
     def test_preserves_images_in_messages(self):
         """
         What it does: Verifies images are preserved when prepending synthetic user.
@@ -1444,34 +1372,30 @@ class TestEnsureFirstMessageIsUser:
         messages = [
             UnifiedMessage(role="assistant", content="What's in this image?"),
             UnifiedMessage(
-                role="user",
-                content="Here it is",
-                images=[{"media_type": "image/jpeg", "data": "base64data"}]
-            )
+                role="user", content="Here it is", images=[{"media_type": "image/jpeg", "data": "base64data"}]
+            ),
         ]
-        
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print("Checking images are preserved...")
         assert len(result) == 3
         assert result[0].role == "user"  # Synthetic
         assert result[2].images is not None
         assert len(result[2].images) == 1
-    
+
     def test_uses_minimal_content_for_synthetic_message(self):
         """
         What it does: Verifies synthetic message uses minimal content ("").
         Purpose: Ensure minimal token usage and avoid disrupting conversation context.
         """
         print("Setup: Assistant-first conversation...")
-        messages = [
-            UnifiedMessage(role="assistant", content="Hello")
-        ]
-        
+        messages = [UnifiedMessage(role="assistant", content="Hello")]
+
         print("Action: Ensuring first message is user...")
         result = ensure_first_message_is_user(messages)
-        
+
         print("Checking synthetic message content...")
         assert result[0].content == ""
         print("✓ Synthetic message uses minimal content (matches LiteLLM behavior)")
@@ -1481,15 +1405,16 @@ class TestEnsureFirstMessageIsUser:
 # Tests for normalize_message_roles
 # ==================================================================================================
 
+
 class TestNormalizeMessageRoles:
     """
     Tests for normalize_message_roles function.
-    
+
     This function converts all unknown roles (developer, system, moderator, etc.)
     to 'user' role to maintain Kiro API compatibility. This is part of the fix
     for Issue #64 where Codex App sends 'developer' role messages.
     """
-    
+
     def test_converts_developer_role_to_user(self):
         """
         What it does: Verifies conversion of 'developer' role to 'user'.
@@ -1499,12 +1424,12 @@ class TestNormalizeMessageRoles:
         print("Setup: Message with 'developer' role (Codex App)...")
         messages = [
             UnifiedMessage(role="developer", content="<permissions>sandbox enabled</permissions>"),
-            UnifiedMessage(role="user", content="test")
+            UnifiedMessage(role="user", content="test"),
         ]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 2, Got {len(result)}")
         assert len(result) == 2
         print("Checking that developer was converted to user...")
@@ -1512,7 +1437,7 @@ class TestNormalizeMessageRoles:
         assert result[0].content == "<permissions>sandbox enabled</permissions>"
         print("Checking that original user role is preserved...")
         assert result[1].role == "user"
-    
+
     def test_converts_multiple_unknown_roles_to_user(self):
         """
         What it does: Verifies conversion of multiple different unknown roles.
@@ -1523,12 +1448,12 @@ class TestNormalizeMessageRoles:
             UnifiedMessage(role="developer", content="Dev context"),
             UnifiedMessage(role="system", content="System context"),
             UnifiedMessage(role="moderator", content="Moderation note"),
-            UnifiedMessage(role="user", content="Question")
+            UnifiedMessage(role="user", content="Question"),
         ]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 4, Got {len(result)}")
         assert len(result) == 4
         print("Checking that all roles are now 'user'...")
@@ -1538,7 +1463,7 @@ class TestNormalizeMessageRoles:
         assert result[1].content == "System context"
         assert result[2].content == "Moderation note"
         assert result[3].content == "Question"
-    
+
     def test_preserves_user_and_assistant_roles(self):
         """
         What it does: Verifies that user and assistant roles are not modified.
@@ -1548,12 +1473,12 @@ class TestNormalizeMessageRoles:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         print("Checking that roles are unchanged...")
@@ -1564,7 +1489,7 @@ class TestNormalizeMessageRoles:
         assert result[0].content == "Hello"
         assert result[1].content == "Hi"
         assert result[2].content == "How are you?"
-    
+
     def test_preserves_tool_calls_when_normalizing(self):
         """
         What it does: Verifies tool_calls are preserved when converting role.
@@ -1575,13 +1500,13 @@ class TestNormalizeMessageRoles:
             UnifiedMessage(
                 role="developer",
                 content="Context",
-                tool_calls=[{"id": "call_123", "function": {"name": "bash", "arguments": "{}"}}]
+                tool_calls=[{"id": "call_123", "function": {"name": "bash", "arguments": "{}"}}],
             )
         ]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         print("Checking that role was converted...")
@@ -1590,7 +1515,7 @@ class TestNormalizeMessageRoles:
         assert result[0].tool_calls is not None
         assert len(result[0].tool_calls) == 1
         assert result[0].tool_calls[0]["id"] == "call_123"
-    
+
     def test_preserves_tool_results_when_normalizing(self):
         """
         What it does: Verifies tool_results are preserved when converting role.
@@ -1601,13 +1526,13 @@ class TestNormalizeMessageRoles:
             UnifiedMessage(
                 role="developer",
                 content="Result",
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Output"}]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Output"}],
             )
         ]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         print("Checking that role was converted...")
@@ -1616,7 +1541,7 @@ class TestNormalizeMessageRoles:
         assert result[0].tool_results is not None
         assert len(result[0].tool_results) == 1
         assert result[0].tool_results[0]["tool_use_id"] == "call_123"
-    
+
     def test_preserves_images_when_normalizing(self):
         """
         What it does: Verifies images are preserved when converting role.
@@ -1625,15 +1550,13 @@ class TestNormalizeMessageRoles:
         print("Setup: Developer message with images...")
         messages = [
             UnifiedMessage(
-                role="developer",
-                content="Screenshot",
-                images=[{"media_type": "image/png", "data": "base64data"}]
+                role="developer", content="Screenshot", images=[{"media_type": "image/png", "data": "base64data"}]
             )
         ]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         print("Checking that role was converted...")
@@ -1642,20 +1565,20 @@ class TestNormalizeMessageRoles:
         assert result[0].images is not None
         assert len(result[0].images) == 1
         assert result[0].images[0]["media_type"] == "image/png"
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_single_message(self):
         """
         What it does: Verifies single message handling.
@@ -1663,10 +1586,10 @@ class TestNormalizeMessageRoles:
         """
         print("Setup: Single developer message...")
         messages = [UnifiedMessage(role="developer", content="Solo")]
-        
+
         print("Action: Normalizing roles...")
         result = normalize_message_roles(messages)
-        
+
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
         print("Checking that role was converted...")
@@ -1678,30 +1601,28 @@ class TestNormalizeMessageRoles:
 # Tests for ensure_alternating_roles
 # ==================================================================================================
 
+
 class TestEnsureAlternatingRoles:
     """
     Tests for ensure_alternating_roles function.
-    
+
     This function ensures alternating user/assistant roles by inserting synthetic
     assistant messages with "" content between consecutive user messages.
     This is part of the fix for Issue #64 where multiple 'developer' roles
     (converted to 'user') create consecutive userInputMessage entries.
     """
-    
+
     def test_inserts_synthetic_assistant_between_two_consecutive_users(self):
         """
         What it does: Verifies insertion of synthetic assistant between two user messages.
         Purpose: Ensure Kiro API requirement of alternating roles is maintained.
         """
         print("Setup: Two consecutive user messages...")
-        messages = [
-            UnifiedMessage(role="user", content="First"),
-            UnifiedMessage(role="user", content="Second")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="First"), UnifiedMessage(role="user", content="Second")]
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 3 (2 user + 1 synthetic), Got {len(result)}")
         assert len(result) == 3
         print("Checking alternation pattern...")
@@ -1711,7 +1632,7 @@ class TestEnsureAlternatingRoles:
         assert result[1].content == ""
         assert result[2].role == "user"
         assert result[2].content == "Second"
-    
+
     def test_inserts_multiple_synthetic_assistants_for_four_consecutive_users(self):
         """
         What it does: Verifies insertion of multiple synthetic assistants.
@@ -1722,12 +1643,12 @@ class TestEnsureAlternatingRoles:
             UnifiedMessage(role="user", content="First"),
             UnifiedMessage(role="user", content="Second"),
             UnifiedMessage(role="user", content="Third"),
-            UnifiedMessage(role="user", content="Fourth")
+            UnifiedMessage(role="user", content="Fourth"),
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 7 (4 user + 3 synthetic), Got {len(result)}")
         assert len(result) == 7
         print("Checking alternation pattern...")
@@ -1738,7 +1659,7 @@ class TestEnsureAlternatingRoles:
         assert result[4].role == "user" and result[4].content == "Third"
         assert result[5].role == "assistant" and result[5].content == ""
         assert result[6].role == "user" and result[6].content == "Fourth"
-    
+
     def test_preserves_already_alternating_messages(self):
         """
         What it does: Verifies already alternating messages are not modified.
@@ -1749,12 +1670,12 @@ class TestEnsureAlternatingRoles:
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
             UnifiedMessage(role="user", content="How are you?"),
-            UnifiedMessage(role="assistant", content="Fine")
+            UnifiedMessage(role="assistant", content="Fine"),
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 4 (no changes), Got {len(result)}")
         assert len(result) == 4
         print("Checking that messages are unchanged...")
@@ -1762,7 +1683,7 @@ class TestEnsureAlternatingRoles:
         assert result[1].role == "assistant" and result[1].content == "Hi"
         assert result[2].role == "user" and result[2].content == "How are you?"
         assert result[3].role == "assistant" and result[3].content == "Fine"
-    
+
     def test_handles_multiple_groups_of_consecutive_users(self):
         """
         What it does: Verifies handling of multiple groups of consecutive users.
@@ -1775,12 +1696,12 @@ class TestEnsureAlternatingRoles:
             UnifiedMessage(role="assistant", content="C"),
             UnifiedMessage(role="user", content="D"),
             UnifiedMessage(role="user", content="E"),
-            UnifiedMessage(role="user", content="F")
+            UnifiedMessage(role="user", content="F"),
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 9 (6 original + 3 synthetic), Got {len(result)}")
         assert len(result) == 9
         print("Checking first group (A, synthetic, B)...")
@@ -1795,20 +1716,20 @@ class TestEnsureAlternatingRoles:
         assert result[6].role == "user" and result[6].content == "E"
         assert result[7].role == "assistant" and result[7].content == ""
         assert result[8].role == "user" and result[8].content == "F"
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_single_message(self):
         """
         What it does: Verifies single message handling.
@@ -1816,15 +1737,15 @@ class TestEnsureAlternatingRoles:
         """
         print("Setup: Single user message...")
         messages = [UnifiedMessage(role="user", content="Solo")]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 1 (no changes), Got {len(result)}")
         assert len(result) == 1
         assert result[0].role == "user"
         assert result[0].content == "Solo"
-    
+
     def test_preserves_tool_results_in_original_messages(self):
         """
         What it does: Verifies tool_results are preserved in original messages.
@@ -1835,18 +1756,18 @@ class TestEnsureAlternatingRoles:
             UnifiedMessage(
                 role="user",
                 content="First",
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"}]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"}],
             ),
             UnifiedMessage(
                 role="user",
                 content="Second",
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}],
+            ),
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         print("Checking that synthetic assistant has no tool_results...")
@@ -1857,7 +1778,7 @@ class TestEnsureAlternatingRoles:
         assert len(result[0].tool_results) == 1
         assert result[2].tool_results is not None
         assert len(result[2].tool_results) == 1
-    
+
     def test_preserves_images_in_original_messages(self):
         """
         What it does: Verifies images are preserved in original messages.
@@ -1865,21 +1786,13 @@ class TestEnsureAlternatingRoles:
         """
         print("Setup: Two consecutive user messages with images...")
         messages = [
-            UnifiedMessage(
-                role="user",
-                content="First",
-                images=[{"media_type": "image/png", "data": "data1"}]
-            ),
-            UnifiedMessage(
-                role="user",
-                content="Second",
-                images=[{"media_type": "image/jpeg", "data": "data2"}]
-            )
+            UnifiedMessage(role="user", content="First", images=[{"media_type": "image/png", "data": "data1"}]),
+            UnifiedMessage(role="user", content="Second", images=[{"media_type": "image/jpeg", "data": "data2"}]),
         ]
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         print("Checking that synthetic assistant has no images...")
@@ -1896,15 +1809,16 @@ class TestEnsureAlternatingRoles:
 # Tests for normalize_message_roles + ensure_alternating_roles integration
 # ==================================================================================================
 
+
 class TestNormalizeAndAlternatingIntegration:
     """
     Integration tests for normalize_message_roles + ensure_alternating_roles.
-    
+
     These tests verify the complete pipeline for Issue #64 fix:
     1. Unknown roles (developer, system) are normalized to 'user'
     2. Consecutive user messages get synthetic assistant messages inserted
     """
-    
+
     def test_developer_messages_are_normalized_and_alternated(self):
         """
         What it does: Verifies complete pipeline for Issue #64.
@@ -1915,16 +1829,16 @@ class TestNormalizeAndAlternatingIntegration:
             UnifiedMessage(role="developer", content="Context 1"),
             UnifiedMessage(role="developer", content="Context 2"),
             UnifiedMessage(role="developer", content="Context 3"),
-            UnifiedMessage(role="user", content="Question")
+            UnifiedMessage(role="user", content="Question"),
         ]
-        
+
         print("Action: Normalizing roles...")
         normalized = normalize_message_roles(messages)
         print(f"After normalization: {[msg.role for msg in normalized]}")
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(normalized)
-        
+
         print(f"Comparing length: Expected 7 (4 user + 3 synthetic), Got {len(result)}")
         assert len(result) == 7
         print("Checking alternation pattern...")
@@ -1935,7 +1849,7 @@ class TestNormalizeAndAlternatingIntegration:
         assert result[4].role == "user" and result[4].content == "Context 3"
         assert result[5].role == "assistant" and result[5].content == ""
         assert result[6].role == "user" and result[6].content == "Question"
-    
+
     def test_mixed_roles_are_normalized_and_alternated(self):
         """
         What it does: Verifies pipeline with mixed roles (developer, system, user, assistant).
@@ -1948,19 +1862,19 @@ class TestNormalizeAndAlternatingIntegration:
             UnifiedMessage(role="user", content="User1"),
             UnifiedMessage(role="assistant", content="Assistant1"),
             UnifiedMessage(role="developer", content="Dev2"),
-            UnifiedMessage(role="user", content="User2")
+            UnifiedMessage(role="user", content="User2"),
         ]
-        
+
         print("Action: Normalizing roles...")
         normalized = normalize_message_roles(messages)
         print(f"After normalization: {[msg.role for msg in normalized]}")
-        
+
         print("Action: Ensuring alternating roles...")
         result = ensure_alternating_roles(normalized)
-        
+
         print(f"Result length: {len(result)}")
         print(f"Result roles: {[msg.role for msg in result]}")
-        
+
         # After normalization: all system/developer → user
         # [user, user, user, assistant, user, user]
         # After alternation: insert synthetic between consecutive users
@@ -1982,30 +1896,31 @@ class TestNormalizeAndAlternatingIntegration:
 # Tests for ensure_assistant_before_tool_results
 # ==================================================================================================
 
+
 class TestEnsureAssistantBeforeToolResults:
     """
     Tests for ensure_assistant_before_tool_results function.
-    
+
     This function handles the case when clients (like Cline/Roo/Cursor) send truncated
     conversations with tool_results but without the preceding assistant message
     that contains the tool_calls. Since we don't know the original tool name,
     we strip the orphaned tool_results to avoid Kiro API rejection.
     """
-    
+
     def test_returns_empty_list_for_empty_input(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
         assert stripped is False
-    
+
     def test_preserves_messages_without_tool_results(self):
         """
         What it does: Verifies messages without tool_results are unchanged.
@@ -2015,19 +1930,19 @@ class TestEnsureAssistantBeforeToolResults:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi there"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         assert result[0].content == "Hello"
         assert result[1].content == "Hi there"
         assert result[2].content == "How are you?"
         assert stripped is False
-    
+
     def test_preserves_tool_results_with_preceding_assistant(self):
         """
         What it does: Verifies tool_results are preserved when assistant with tool_calls precedes.
@@ -2039,41 +1954,39 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Weather is sunny"
-                }]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Weather is sunny"}],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking that tool_results are preserved...")
         assert result[2].tool_results is not None
         assert len(result[2].tool_results) == 1
         assert result[2].tool_results[0]["tool_use_id"] == "call_123"
         assert stripped is False
-    
+
     def test_strips_orphaned_tool_results_at_start(self):
         """
         What it does: Verifies orphaned tool_results at the start are converted to text.
         Purpose: Ensure tool_results without preceding assistant are converted to text representation.
-        
+
         This is the critical bug fix test - when a client sends a truncated
         conversation starting with tool_results, they should be converted to text.
         """
@@ -2082,33 +1995,29 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_orphan",
-                    "content": "Orphaned result"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_orphan", "content": "Orphaned result"}],
             ),
-            UnifiedMessage(role="user", content="Continue the conversation")
+            UnifiedMessage(role="user", content="Continue the conversation"),
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking that orphaned tool_results are converted to text...")
         assert result[0].tool_results is None
-        
+
         print("Checking that content now contains the tool result as text...")
         print(f"Content: '{result[0].content}'")
         assert "[Tool Result (call_orphan)]" in result[0].content
         assert "Orphaned result" in result[0].content
-        
+
         assert result[1].content == "Continue the conversation"
         assert converted is True
-    
+
     def test_converts_tool_results_after_assistant_without_tool_calls(self):
         """
         What it does: Verifies tool_results are converted when preceding assistant has no tool_calls.
@@ -2121,27 +2030,23 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result"}],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are converted to text...")
         assert result[2].tool_results is None
-        
+
         print(f"Content after conversion: '{result[2].content}'")
         assert "[Tool Result (call_123)]" in result[2].content
         assert "Result" in result[2].content
-        
+
         assert converted is True
-    
+
     def test_converts_tool_results_after_user_message(self):
         """
         What it does: Verifies tool_results are converted when preceded by user message.
@@ -2153,27 +2058,23 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result"}],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are converted to text...")
         assert result[1].tool_results is None
-        
+
         print(f"Content after conversion: '{result[1].content}'")
         assert "[Tool Result (call_123)]" in result[1].content
         assert "Result" in result[1].content
-        
+
         assert converted is True
-    
+
     def test_preserves_content_when_converting_tool_results(self):
         """
         What it does: Verifies message content is preserved and tool_results are appended as text.
@@ -2184,32 +2085,28 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="Here is some context",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result"}],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after conversion: '{result[0].content}'")
-        
+
         print("Checking that original content is preserved...")
         assert "Here is some context" in result[0].content
-        
+
         print("Checking that tool_results are converted to text and appended...")
         assert "[Tool Result (call_123)]" in result[0].content
         assert "Result" in result[0].content
-        
+
         print("Checking that tool_results field is removed...")
         assert result[0].tool_results is None
-        
+
         assert converted is True
-    
+
     def test_preserves_tool_calls_when_converting_tool_results(self):
         """
         What it does: Verifies tool_calls are preserved when tool_results are converted.
@@ -2220,34 +2117,34 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_new",
-                    "type": "function",
-                    "function": {"name": "new_tool", "arguments": "{}"}
-                }],
-                tool_results=[{  # This shouldn't happen but let's test it
-                    "type": "tool_result",
-                    "tool_use_id": "call_old",
-                    "content": "Old result"
-                }]
+                tool_calls=[
+                    {"id": "call_new", "type": "function", "function": {"name": "new_tool", "arguments": "{}"}}
+                ],
+                tool_results=[
+                    {  # This shouldn't happen but let's test it
+                        "type": "tool_result",
+                        "tool_use_id": "call_old",
+                        "content": "Old result",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_calls are preserved...")
         assert result[0].tool_calls is not None
         assert len(result[0].tool_calls) == 1
-        
+
         print("Checking that tool_results are converted to text...")
         assert result[0].tool_results is None
         assert "[Tool Result (call_old)]" in result[0].content
         assert "Old result" in result[0].content
-        
+
         assert converted is True
-    
+
     def test_handles_multiple_orphaned_tool_results(self):
         """
         What it does: Verifies multiple orphaned tool_results are all converted.
@@ -2261,17 +2158,17 @@ class TestEnsureAssistantBeforeToolResults:
                 tool_results=[
                     {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
                     {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
-                    {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"}
-                ]
+                    {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"},
+                ],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after conversion: '{result[0].content}'")
-        
+
         print("Checking that all tool_results are converted to text...")
         assert result[0].tool_results is None
         assert "[Tool Result (call_1)]" in result[0].content
@@ -2280,13 +2177,13 @@ class TestEnsureAssistantBeforeToolResults:
         assert "Result 2" in result[0].content
         assert "[Tool Result (call_3)]" in result[0].content
         assert "Result 3" in result[0].content
-        
+
         assert converted is True
-    
+
     # ==================================================================================
     # New tests for tool_results conversion (PR #49)
     # ==================================================================================
-    
+
     def test_conversion_preserves_images(self):
         """
         What it does: Verifies that images field is preserved when converting tool_results.
@@ -2298,29 +2195,25 @@ class TestEnsureAssistantBeforeToolResults:
                 role="user",
                 content="Here's an image and tool result",
                 images=[{"media_type": "image/jpeg", "data": "image_data"}],
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Tool output"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Tool output"}],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that images are preserved...")
         assert result[0].images is not None
         assert len(result[0].images) == 1
         assert result[0].images[0]["media_type"] == "image/jpeg"
-        
+
         print("Checking that tool_results are converted...")
         assert result[0].tool_results is None
         assert "[Tool Result" in result[0].content
-        
+
         assert converted is True
-    
+
     def test_conversion_appends_to_existing_content(self):
         """
         What it does: Verifies tool_results are appended with double newline.
@@ -2331,29 +2224,25 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="Original content here",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_abc",
-                    "content": "Tool data"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_abc", "content": "Tool data"}],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result content: '{result[0].content}'")
-        
+
         print("Checking formatting...")
         assert "Original content here" in result[0].content
         assert "[Tool Result (call_abc)]" in result[0].content
         assert "Tool data" in result[0].content
-        
+
         # Check double newline separator
         assert "\n\n" in result[0].content
-        
+
         assert converted is True
-    
+
     def test_conversion_handles_empty_original_content(self):
         """
         What it does: Verifies conversion works when original content is empty.
@@ -2364,76 +2253,72 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_xyz",
-                    "content": "Only tool result"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_xyz", "content": "Only tool result"}],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result content: '{result[0].content}'")
-        
+
         print("Checking that only tool result text is present...")
         assert "[Tool Result (call_xyz)]" in result[0].content
         assert "Only tool result" in result[0].content
-        
+
         # Should not have leading/trailing whitespace from empty original content
         assert result[0].content.strip() == result[0].content
-        
+
         assert converted is True
-    
+
     def test_conversion_returns_correct_flag(self):
         """
         What it does: Verifies that converted_any_tool_results flag is returned correctly.
         Purpose: Ensure return value accurately reflects whether conversion happened.
         """
         print("Setup: Two scenarios - with and without orphaned tool_results...")
-        
+
         # Scenario 1: With orphaned tool_results (should return True)
         messages_with_orphaned = [
             UnifiedMessage(
                 role="user",
                 content="Test",
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}],
             )
         ]
-        
+
         print("Action: Processing messages with orphaned tool_results...")
         result1, converted1 = ensure_assistant_before_tool_results(messages_with_orphaned)
-        
+
         print(f"Comparing converted flag: Expected True, Got {converted1}")
         assert converted1 is True
-        
+
         # Scenario 2: Without orphaned tool_results (should return False)
         messages_without_orphaned = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}]
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}],
+            ),
         ]
-        
+
         print("Action: Processing messages without orphaned tool_results...")
         result2, converted2 = ensure_assistant_before_tool_results(messages_without_orphaned)
-        
+
         print(f"Comparing converted flag: Expected False, Got {converted2}")
         assert converted2 is False
-    
+
     def test_normal_tool_results_unchanged(self):
         """
         What it does: Verifies that normal (non-orphaned) tool_results are NOT converted.
         Purpose: CRITICAL - ensure 99% of cases (normal tool use) have zero change.
-        
+
         This is the most important backward compatibility test. Normal tool_results
         (with preceding assistant message with tool_calls) should pass through unchanged.
         """
@@ -2443,40 +2328,36 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_valid",
-                    "type": "function",
-                    "function": {"name": "test_tool", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {"id": "call_valid", "type": "function", "function": {"name": "test_tool", "arguments": "{}"}}
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_valid",
-                    "content": "Tool executed successfully"
-                }]
-            )
+                tool_results=[
+                    {"type": "tool_result", "tool_use_id": "call_valid", "content": "Tool executed successfully"}
+                ],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, converted = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print(f"Comparing converted flag: Expected False, Got {converted}")
         assert converted is False  # No conversion happened
-        
+
         print("Checking that tool_results are preserved (NOT converted)...")
         assert result[2].tool_results is not None  # Still has tool_results
         assert len(result[2].tool_results) == 1
         assert result[2].tool_results[0]["tool_use_id"] == "call_valid"
         assert result[2].tool_results[0]["content"] == "Tool executed successfully"
-        
+
         print("Checking that content is NOT modified...")
         assert result[2].content == ""  # Original empty content preserved
         assert "[Tool Result" not in result[2].content  # NOT converted to text
-    
+
     def test_mixed_valid_and_orphaned_tool_results(self):
         """
         What it does: Verifies correct handling of mixed valid and orphaned tool_results.
@@ -2488,46 +2369,36 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_orphan",
-                    "content": "Orphaned"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_orphan", "content": "Orphaned"}],
             ),
             # Valid assistant with tool_calls
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_valid",
-                    "type": "function",
-                    "function": {"name": "valid_tool", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {"id": "call_valid", "type": "function", "function": {"name": "valid_tool", "arguments": "{}"}}
+                ],
             ),
             # Valid tool_results
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_valid",
-                    "content": "Valid result"
-                }]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_valid", "content": "Valid result"}],
+            ),
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking orphaned tool_results are stripped...")
         assert result[0].tool_results is None
-        
+
         print("Checking valid tool_results are preserved...")
         assert result[2].tool_results is not None
         assert result[2].tool_results[0]["tool_use_id"] == "call_valid"
         assert stripped is True  # Because orphaned ones were stripped
-    
+
     def test_single_message_with_tool_results(self):
         """
         What it does: Verifies handling of single message with tool_results.
@@ -2538,17 +2409,13 @@ class TestEnsureAssistantBeforeToolResults:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result"}],
             )
         ]
-        
+
         print("Action: Processing messages...")
         result, stripped = ensure_assistant_before_tool_results(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are stripped...")
         assert len(result) == 1
@@ -2560,129 +2427,113 @@ class TestEnsureAssistantBeforeToolResults:
 # Tests for sanitize_json_schema
 # ==================================================================================================
 
+
 class TestSanitizeJsonSchema:
     """
     Tests for sanitize_json_schema function.
-    
+
     This function cleans JSON Schema from fields that Kiro API doesn't accept:
     - Empty required arrays []
     - additionalProperties
     """
-    
+
     def test_returns_empty_dict_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns empty dict.
         """
         print("Setup: None schema...")
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(None)
-        
+
         print(f"Comparing result: Expected {{}}, Got {result}")
         assert result == {}
-    
+
     def test_returns_empty_dict_for_empty_dict(self):
         """
         What it does: Verifies handling of empty dict.
         Purpose: Ensure empty dict is returned as-is.
         """
         print("Setup: Empty dict...")
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema({})
-        
+
         print(f"Comparing result: Expected {{}}, Got {result}")
         assert result == {}
-    
+
     def test_removes_empty_required_array(self):
         """
         What it does: Verifies removal of empty required array.
         Purpose: Ensure required: [] is removed from schema.
-        
+
         This is a critical test for a bug where tools with required: []
         caused a 400 "Improperly formed request" error from Kiro API.
         """
         print("Setup: Schema with empty required...")
-        schema = {
-            "type": "object",
-            "properties": {},
-            "required": []
-        }
-        
+        schema = {"type": "object", "properties": {}, "required": []}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that required is removed...")
         assert "required" not in result
         assert result["type"] == "object"
         assert result["properties"] == {}
-    
+
     def test_preserves_non_empty_required_array(self):
         """
         What it does: Verifies preservation of non-empty required array.
         Purpose: Ensure required with elements is preserved.
         """
         print("Setup: Schema with non-empty required...")
-        schema = {
-            "type": "object",
-            "properties": {"location": {"type": "string"}},
-            "required": ["location"]
-        }
-        
+        schema = {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that required is preserved...")
         assert "required" in result
         assert result["required"] == ["location"]
-    
+
     def test_removes_additional_properties(self):
         """
         What it does: Verifies removal of additionalProperties.
         Purpose: Ensure additionalProperties is removed from schema.
-        
+
         Kiro API doesn't support additionalProperties in JSON Schema.
         """
         print("Setup: Schema with additionalProperties...")
-        schema = {
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False
-        }
-        
+        schema = {"type": "object", "properties": {}, "additionalProperties": False}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that additionalProperties is removed...")
         assert "additionalProperties" not in result
         assert result["type"] == "object"
-    
+
     def test_removes_both_empty_required_and_additional_properties(self):
         """
         What it does: Verifies removal of both problematic fields.
         Purpose: Ensure both fields are removed simultaneously.
         """
         print("Setup: Schema with both problematic fields...")
-        schema = {
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties": False
-        }
-        
+        schema = {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking that both fields are removed...")
         assert "required" not in result
         assert "additionalProperties" not in result
         assert result == {"type": "object", "properties": {}}
-    
+
     def test_recursively_sanitizes_nested_properties(self):
         """
         What it does: Verifies recursive sanitization of nested properties.
@@ -2692,63 +2543,50 @@ class TestSanitizeJsonSchema:
         schema = {
             "type": "object",
             "properties": {
-                "nested": {
-                    "type": "object",
-                    "properties": {},
-                    "required": [],
-                    "additionalProperties": False
-                }
-            }
+                "nested": {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
+            },
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking nested object...")
         nested = result["properties"]["nested"]
         assert "required" not in nested
         assert "additionalProperties" not in nested
-    
+
     def test_sanitizes_items_in_lists(self):
         """
         What it does: Verifies sanitization of items in lists (anyOf, oneOf).
         Purpose: Ensure list elements are also sanitized.
         """
         print("Setup: Schema with anyOf...")
-        schema = {
-            "anyOf": [
-                {"type": "string", "additionalProperties": False},
-                {"type": "number", "required": []}
-            ]
-        }
-        
+        schema = {"anyOf": [{"type": "string", "additionalProperties": False}, {"type": "number", "required": []}]}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking anyOf elements...")
         assert "additionalProperties" not in result["anyOf"][0]
         assert "required" not in result["anyOf"][1]
-    
+
     def test_preserves_non_dict_list_items(self):
         """
         What it does: Verifies preservation of non-dict list items.
         Purpose: Ensure strings and other types in lists are preserved.
         """
         print("Setup: Schema with enum...")
-        schema = {
-            "type": "string",
-            "enum": ["value1", "value2", "value3"]
-        }
-        
+        schema = {"type": "string", "enum": ["value1", "value2", "value3"]}
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking enum is preserved...")
         assert result["enum"] == ["value1", "value2", "value3"]
-    
+
     def test_complex_real_world_schema(self):
         """
         What it does: Verifies sanitization of real complex schema.
@@ -2759,15 +2597,15 @@ class TestSanitizeJsonSchema:
             "type": "object",
             "properties": {
                 "question": {"type": "string", "description": "The question to ask"},
-                "options": {"type": "string", "description": "Array of options"}
+                "options": {"type": "string", "description": "Array of options"},
             },
             "required": ["question", "options"],
-            "additionalProperties": False
+            "additionalProperties": False,
         }
-        
+
         print("Action: Sanitizing schema...")
         result = sanitize_json_schema(schema)
-        
+
         print(f"Result: {result}")
         print("Checking result...")
         assert "additionalProperties" not in result
@@ -2779,27 +2617,26 @@ class TestSanitizeJsonSchema:
 # Tests for extract_tool_results_from_content
 # ==================================================================================================
 
+
 class TestExtractToolResults:
     """Tests for extract_tool_results_from_content function."""
-    
+
     def test_extracts_tool_results_from_list(self):
         """
         What it does: Verifies extraction of tool results from list.
         Purpose: Ensure tool_result elements are extracted.
         """
         print("Setup: List with tool_result...")
-        content = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
-        ]
-        
+        content = [{"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}]
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["toolUseId"] == "call_123"
         assert result[0]["status"] == "success"
-    
+
     def test_returns_empty_for_string_content(self):
         """
         What it does: Verifies empty list return for string.
@@ -2807,13 +2644,13 @@ class TestExtractToolResults:
         """
         print("Setup: String...")
         content = "Just a string"
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_list_without_tool_results(self):
         """
         What it does: Verifies empty list return without tool_result.
@@ -2821,13 +2658,13 @@ class TestExtractToolResults:
         """
         print("Setup: List without tool_result...")
         content = [{"type": "text", "text": "Hello"}]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_extracts_multiple_tool_results(self):
         """
         What it does: Verifies extraction of multiple tool results.
@@ -2837,12 +2674,12 @@ class TestExtractToolResults:
         content = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
             {"type": "text", "text": "Some text"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Extracting tool results...")
         result = extract_tool_results_from_content(content)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
         assert result[0]["toolUseId"] == "call_1"
@@ -2853,48 +2690,47 @@ class TestExtractToolResults:
 # Tests for convert_tool_results_to_kiro_format
 # ==================================================================================================
 
+
 class TestConvertToolResultsToKiroFormat:
     """
     Tests for convert_tool_results_to_kiro_format function.
-    
+
     This function converts unified tool results format (snake_case) to Kiro API format (camelCase).
-    
+
     Unified format: {"type": "tool_result", "tool_use_id": "...", "content": "..."}
     Kiro format: {"content": [{"text": "..."}], "status": "success", "toolUseId": "..."}
-    
+
     This is a critical function for fixing the 400 "Improperly formed request" bug
     where tool_results were sent in unified format instead of Kiro format.
     """
-    
+
     def test_converts_single_tool_result(self):
         """
         What it does: Verifies conversion of a single tool result.
         Purpose: Ensure basic conversion from unified to Kiro format works.
         """
         print("Setup: Single tool result in unified format...")
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking structure...")
         assert len(result) == 1
-        
+
         print("Checking toolUseId (camelCase)...")
         assert result[0]["toolUseId"] == "call_123"
-        
+
         print("Checking status...")
         assert result[0]["status"] == "success"
-        
+
         print("Checking content structure...")
         assert "content" in result[0]
         assert isinstance(result[0]["content"], list)
         assert len(result[0]["content"]) == 1
         assert result[0]["content"][0]["text"] == "Result text"
-    
+
     def test_converts_multiple_tool_results(self):
         """
         What it does: Verifies conversion of multiple tool results.
@@ -2904,108 +2740,100 @@ class TestConvertToolResultsToKiroFormat:
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
             {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
-            {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"}
+            {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 3, Got {len(result)}")
         assert len(result) == 3
-        
+
         print("Checking all toolUseIds...")
         assert result[0]["toolUseId"] == "call_1"
         assert result[1]["toolUseId"] == "call_2"
         assert result[2]["toolUseId"] == "call_3"
-        
+
         print("Checking all contents...")
         assert result[0]["content"][0]["text"] == "Result 1"
         assert result[1]["content"][0]["text"] == "Result 2"
         assert result[2]["content"][0]["text"] == "Result 3"
-    
+
     def test_returns_empty_list_for_empty_input(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_replaces_empty_content_with_placeholder(self):
         """
         What it does: Verifies empty content is replaced with placeholder.
         Purpose: Ensure Kiro API receives non-empty content (required by API).
         """
         print("Setup: Tool result with empty content...")
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": ""}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": ""}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that empty content is replaced with placeholder...")
         assert result[0]["content"][0]["text"] == "(empty result)"
-    
+
     def test_replaces_none_content_with_placeholder(self):
         """
         What it does: Verifies None content is replaced with placeholder.
         Purpose: Ensure Kiro API receives non-empty content when content is None.
         """
         print("Setup: Tool result with None content...")
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": None}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": None}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that None content is replaced with placeholder...")
         assert result[0]["content"][0]["text"] == "(empty result)"
-    
+
     def test_handles_missing_content_key(self):
         """
         What it does: Verifies handling of missing content key.
         Purpose: Ensure function doesn't crash when content key is missing.
         """
         print("Setup: Tool result without content key...")
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123"}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that missing content is replaced with placeholder...")
         assert result[0]["content"][0]["text"] == "(empty result)"
-    
+
     def test_handles_missing_tool_use_id(self):
         """
         What it does: Verifies handling of missing tool_use_id.
         Purpose: Ensure function returns empty string for missing tool_use_id.
         """
         print("Setup: Tool result without tool_use_id...")
-        tool_results = [
-            {"type": "tool_result", "content": "Result text"}
-        ]
-        
+        tool_results = [{"type": "tool_result", "content": "Result text"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that missing tool_use_id becomes empty string...")
         assert result[0]["toolUseId"] == ""
         assert result[0]["content"][0]["text"] == "Result text"
-    
+
     def test_extracts_text_from_list_content(self):
         """
         What it does: Verifies extraction of text from list content.
@@ -3016,20 +2844,17 @@ class TestConvertToolResultsToKiroFormat:
             {
                 "type": "tool_result",
                 "tool_use_id": "call_123",
-                "content": [
-                    {"type": "text", "text": "Part 1"},
-                    {"type": "text", "text": " Part 2"}
-                ]
+                "content": [{"type": "text", "text": "Part 1"}, {"type": "text", "text": " Part 2"}],
             }
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that list content is extracted correctly...")
         assert result[0]["content"][0]["text"] == "Part 1 Part 2"
-    
+
     def test_preserves_long_content(self):
         """
         What it does: Verifies long content is preserved.
@@ -3037,18 +2862,16 @@ class TestConvertToolResultsToKiroFormat:
         """
         print("Setup: Tool result with long content...")
         long_content = "A" * 10000
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": long_content}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": long_content}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result content length: {len(result[0]['content'][0]['text'])}")
         print("Checking that long content is preserved...")
         assert result[0]["content"][0]["text"] == long_content
         assert len(result[0]["content"][0]["text"]) == 10000
-    
+
     def test_all_results_have_success_status(self):
         """
         What it does: Verifies all results have status="success".
@@ -3057,30 +2880,28 @@ class TestConvertToolResultsToKiroFormat:
         print("Setup: Multiple tool results...")
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print("Checking all statuses...")
         for i, r in enumerate(result):
             print(f"Result {i}: status = {r['status']}")
             assert r["status"] == "success"
-    
+
     def test_handles_unicode_content(self):
         """
         What it does: Verifies Unicode content is preserved.
         Purpose: Ensure non-ASCII characters are handled correctly.
         """
         print("Setup: Tool result with Unicode content...")
-        tool_results = [
-            {"type": "tool_result", "tool_use_id": "call_123", "content": "Привет мир! 你好世界! 🎉"}
-        ]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": "Привет мир! 你好世界! 🎉"}]
+
         print("Action: Converting to Kiro format...")
         result = convert_tool_results_to_kiro_format(tool_results)
-        
+
         print(f"Result: {result}")
         print("Checking that Unicode content is preserved...")
         assert result[0]["content"][0]["text"] == "Привет мир! 你好世界! 🎉"
@@ -3090,85 +2911,67 @@ class TestConvertToolResultsToKiroFormat:
 # Tests for extract_tool_uses_from_message
 # ==================================================================================================
 
+
 class TestExtractToolUses:
     """Tests for extract_tool_uses_from_message function."""
-    
+
     def test_extracts_from_tool_calls_field(self):
         """
         What it does: Verifies extraction from tool_calls field.
         Purpose: Ensure OpenAI tool_calls format is handled.
         """
         print("Setup: tool_calls list...")
-        tool_calls = [{
-            "id": "call_123",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"location": "Moscow"}'
-            }
-        }]
-        
+        tool_calls = [{"id": "call_123", "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}}]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content="", tool_calls=tool_calls)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["name"] == "get_weather"
         assert result[0]["toolUseId"] == "call_123"
-    
+
     def test_extracts_from_content_list(self):
         """
         What it does: Verifies extraction from content list.
         Purpose: Ensure tool_use in content is handled (Anthropic format).
         """
         print("Setup: Content with tool_use...")
-        content = [{
-            "type": "tool_use",
-            "id": "call_456",
-            "name": "search",
-            "input": {"query": "test"}
-        }]
-        
+        content = [{"type": "tool_use", "id": "call_456", "name": "search", "input": {"query": "test"}}]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content=content, tool_calls=None)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["name"] == "search"
         assert result[0]["toolUseId"] == "call_456"
-    
+
     def test_returns_empty_for_no_tool_uses(self):
         """
         What it does: Verifies empty list return without tool uses.
         Purpose: Ensure regular message doesn't contain tool uses.
         """
         print("Setup: Regular content...")
-        
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content="Hello", tool_calls=None)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_extracts_from_both_sources(self):
         """
         What it does: Verifies extraction from both tool_calls and content.
         Purpose: Ensure both sources are combined.
         """
         print("Setup: Both tool_calls and content with tool_use...")
-        tool_calls = [{
-            "id": "call_1",
-            "function": {"name": "tool1", "arguments": "{}"}
-        }]
-        content = [{
-            "type": "tool_use",
-            "id": "call_2",
-            "name": "tool2",
-            "input": {}
-        }]
-        
+        tool_calls = [{"id": "call_1", "function": {"name": "tool1", "arguments": "{}"}}]
+        content = [{"type": "tool_use", "id": "call_2", "name": "tool2", "input": {}}]
+
         print("Action: Extracting tool uses...")
         result = extract_tool_uses_from_message(content=content, tool_calls=tool_calls)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
 
@@ -3177,58 +2980,61 @@ class TestExtractToolUses:
 # Tests for process_tools_with_long_descriptions
 # ==================================================================================================
 
+
 class TestProcessToolsWithLongDescriptions:
     """Tests for process_tools_with_long_descriptions function using UnifiedTool."""
-    
+
     def test_returns_none_and_empty_string_for_none_tools(self):
         """
         What it does: Verifies handling of None instead of tools list.
         Purpose: Ensure None returns (None, "").
         """
         print("Setup: None instead of tools...")
-        
+
         print("Action: Processing tools...")
         processed, doc = process_tools_with_long_descriptions(None)
-        
+
         print(f"Comparing result: Expected (None, ''), Got ({processed}, '{doc}')")
         assert processed is None
         assert doc == ""
-    
+
     def test_returns_none_and_empty_string_for_empty_list(self):
         """
         What it does: Verifies handling of empty tools list.
         Purpose: Ensure empty list returns (None, "").
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Processing tools...")
         processed, doc = process_tools_with_long_descriptions([])
-        
+
         print(f"Comparing result: Expected (None, ''), Got ({processed}, '{doc}')")
         assert processed is None
         assert doc == ""
-    
+
     def test_short_description_unchanged(self):
         """
         What it does: Verifies short descriptions are unchanged.
         Purpose: Ensure tools with short descriptions remain as-is.
         """
         print("Setup: Tool with short description...")
-        tools = [UnifiedTool(
-            name="get_weather",
-            description="Get weather for a location",
-            input_schema={"type": "object", "properties": {}}
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="get_weather",
+                description="Get weather for a location",
+                input_schema={"type": "object", "properties": {}},
+            )
+        ]
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print(f"Comparing description: Expected 'Get weather for a location', Got '{processed[0].description}'")
         assert len(processed) == 1
         assert processed[0].description == "Get weather for a location"
         assert doc == ""
-    
+
     def test_long_description_moved_to_system_prompt(self):
         """
         What it does: Verifies moving long description to system prompt.
@@ -3236,25 +3042,27 @@ class TestProcessToolsWithLongDescriptions:
         """
         print("Setup: Tool with very long description...")
         long_description = "A" * 15000  # 15000 chars - exceeds limit
-        tools = [UnifiedTool(
-            name="bash",
-            description=long_description,
-            input_schema={"type": "object", "properties": {"command": {"type": "string"}}}
-        )]
-        
+        tools = [
+            UnifiedTool(
+                name="bash",
+                description=long_description,
+                input_schema={"type": "object", "properties": {"command": {"type": "string"}}},
+            )
+        ]
+
         print("Action: Processing tools with limit 10000...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking reference in description...")
         assert len(processed) == 1
         assert "[Full documentation in system prompt under '## Tool: bash']" in processed[0].description
-        
+
         print("Checking documentation in system prompt...")
         assert "## Tool: bash" in doc
         assert long_description in doc
         assert "# Tool Documentation" in doc
-    
+
     def test_mixed_short_and_long_descriptions(self):
         """
         What it does: Verifies handling of mixed tools list.
@@ -3265,24 +3073,24 @@ class TestProcessToolsWithLongDescriptions:
         long_desc = "B" * 15000
         tools = [
             UnifiedTool(name="short_tool", description=short_desc, input_schema={}),
-            UnifiedTool(name="long_tool", description=long_desc, input_schema={})
+            UnifiedTool(name="long_tool", description=long_desc, input_schema={}),
         ]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print(f"Checking tools count: Expected 2, Got {len(processed)}")
         assert len(processed) == 2
-        
+
         print("Checking short tool...")
         assert processed[0].description == short_desc
-        
+
         print("Checking long tool...")
         assert "[Full documentation in system prompt" in processed[1].description
         assert "## Tool: long_tool" in doc
         assert long_desc in doc
-    
+
     def test_disabled_when_limit_is_zero(self):
         """
         What it does: Verifies function is disabled when limit is 0.
@@ -3291,15 +3099,15 @@ class TestProcessToolsWithLongDescriptions:
         print("Setup: Tool with long description and limit 0...")
         long_desc = "D" * 15000
         tools = [UnifiedTool(name="test_tool", description=long_desc, input_schema={})]
-        
+
         print("Action: Processing tools with limit 0...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 0):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 0):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking that description is unchanged...")
         assert processed[0].description == long_desc
         assert doc == ""
-    
+
     def test_multiple_long_descriptions_all_moved(self):
         """
         What it does: Verifies moving of multiple long descriptions.
@@ -3309,23 +3117,23 @@ class TestProcessToolsWithLongDescriptions:
         tools = [
             UnifiedTool(name="tool1", description="F" * 15000, input_schema={}),
             UnifiedTool(name="tool2", description="G" * 15000, input_schema={}),
-            UnifiedTool(name="tool3", description="H" * 15000, input_schema={})
+            UnifiedTool(name="tool3", description="H" * 15000, input_schema={}),
         ]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking all three tools...")
         assert len(processed) == 3
         for tool in processed:
             assert "[Full documentation in system prompt" in tool.description
-        
+
         print("Checking documentation contains all three sections...")
         assert "## Tool: tool1" in doc
         assert "## Tool: tool2" in doc
         assert "## Tool: tool3" in doc
-    
+
     def test_empty_description_unchanged(self):
         """
         What it does: Verifies handling of empty description.
@@ -3333,15 +3141,15 @@ class TestProcessToolsWithLongDescriptions:
         """
         print("Setup: Tool with empty description...")
         tools = [UnifiedTool(name="empty_desc_tool", description="", input_schema={})]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking that empty description remains empty...")
         assert processed[0].description == ""
         assert doc == ""
-    
+
     def test_none_description_unchanged(self):
         """
         What it does: Verifies handling of None description.
@@ -3349,16 +3157,16 @@ class TestProcessToolsWithLongDescriptions:
         """
         print("Setup: Tool with None description...")
         tools = [UnifiedTool(name="none_desc_tool", description=None, input_schema={})]
-        
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking that None description is handled correctly...")
         # None should remain None or become empty string
         assert processed[0].description is None or processed[0].description == ""
         assert doc == ""
-    
+
     def test_preserves_tool_input_schema(self):
         """
         What it does: Verifies input_schema preservation when moving description.
@@ -3369,20 +3177,16 @@ class TestProcessToolsWithLongDescriptions:
             "type": "object",
             "properties": {
                 "location": {"type": "string", "description": "City name"},
-                "units": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                "units": {"type": "string", "enum": ["celsius", "fahrenheit"]},
             },
-            "required": ["location"]
+            "required": ["location"],
         }
-        tools = [UnifiedTool(
-            name="weather",
-            description="C" * 15000,
-            input_schema=input_schema
-        )]
-        
+        tools = [UnifiedTool(name="weather", description="C" * 15000, input_schema=input_schema)]
+
         print("Action: Processing tools...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             processed, doc = process_tools_with_long_descriptions(tools)
-        
+
         print("Checking input_schema preservation...")
         assert processed[0].input_schema == input_schema
 
@@ -3391,9 +3195,10 @@ class TestProcessToolsWithLongDescriptions:
 # Tests for convert_tools_to_kiro_format
 # ==================================================================================================
 
+
 class TestBuildKiroHistory:
     """Tests for build_kiro_history function using UnifiedMessage."""
-    
+
     def test_builds_user_message(self):
         """
         What it does: Verifies building of user message.
@@ -3401,16 +3206,16 @@ class TestBuildKiroHistory:
         """
         print("Setup: User message...")
         messages = [UnifiedMessage(role="user", content="Hello")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "userInputMessage" in result[0]
         assert result[0]["userInputMessage"]["content"] == "Hello"
         assert result[0]["userInputMessage"]["modelId"] == "claude-sonnet-4"
-    
+
     def test_builds_assistant_message(self):
         """
         What it does: Verifies building of assistant message.
@@ -3418,15 +3223,15 @@ class TestBuildKiroHistory:
         """
         print("Setup: Assistant message...")
         messages = [UnifiedMessage(role="assistant", content="Hi there")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "assistantResponseMessage" in result[0]
         assert result[0]["assistantResponseMessage"]["content"] == "Hi there"
-    
+
     def test_expects_normalized_roles_only(self):
         """
         What it does: Verifies build_kiro_history only handles user/assistant roles.
@@ -3436,12 +3241,12 @@ class TestBuildKiroHistory:
         print("Setup: Messages with normalized roles (user/assistant only)...")
         messages = [
             UnifiedMessage(role="user", content="Normalized user"),
-            UnifiedMessage(role="assistant", content="Assistant")
+            UnifiedMessage(role="assistant", content="Assistant"),
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Comparing length: Expected 2, Got {len(result)}")
         assert len(result) == 2
         print("Checking that user message is converted to userInputMessage...")
@@ -3450,7 +3255,7 @@ class TestBuildKiroHistory:
         print("Checking that assistant message is converted to assistantResponseMessage...")
         assert "assistantResponseMessage" in result[1]
         assert result[1]["assistantResponseMessage"]["content"] == "Assistant"
-    
+
     def test_builds_conversation_history(self):
         """
         What it does: Verifies building of full conversation history.
@@ -3460,31 +3265,31 @@ class TestBuildKiroHistory:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 3
         assert "userInputMessage" in result[0]
         assert "assistantResponseMessage" in result[1]
         assert "userInputMessage" in result[2]
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty list returns empty history.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Building history...")
         result = build_kiro_history([], "claude-sonnet-4")
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_builds_user_message_with_tool_results(self):
         """
         What it does: Verifies building of user message with tool_results.
@@ -3495,22 +3300,20 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="Here are the results",
-                tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}
-                ]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result text"}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "userInputMessage" in result[0]
         user_msg = result[0]["userInputMessage"]
         assert "userInputMessageContext" in user_msg
         assert "toolResults" in user_msg["userInputMessageContext"]
-    
+
     def test_builds_assistant_message_with_tool_calls(self):
         """
         What it does: Verifies building of assistant message with tool_calls.
@@ -3521,63 +3324,59 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="assistant",
                 content="I'll call a tool",
-                tool_calls=[{
-                    "id": "call_123",
-                    "function": {
-                        "name": "get_weather",
-                        "arguments": '{"location": "Moscow"}'
-                    }
-                }]
+                tool_calls=[
+                    {"id": "call_123", "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}}
+                ],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "assistantResponseMessage" in result[0]
         assistant_msg = result[0]["assistantResponseMessage"]
         assert "toolUses" in assistant_msg
-    
+
     def test_keeps_empty_content_for_empty_user_content(self):
         """
         What it does: Verifies that "" placeholder is added for user messages with empty content.
         Purpose: Ensure Kiro API receives non-empty content in history.
-        
+
         This is a fallback test for issue #20 - ensures any edge case with empty content
         is handled even if strip_all_tool_content didn't add a placeholder.
         """
         print("Setup: User message with empty content...")
         messages = [UnifiedMessage(role="user", content="")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['userInputMessage']['content']}'")
         print("Checking that 'empty content' placeholder is added...")
         assert result[0]["userInputMessage"]["content"] == ""
-    
+
     def test_keeps_empty_content_for_empty_assistant_content(self):
         """
         What it does: Verifies that "" placeholder is added for assistant messages with empty content.
         Purpose: Ensure Kiro API receives non-empty content in history.
-        
+
         This is a fallback test for issue #20 - ensures any edge case with empty content
         is handled even if strip_all_tool_content didn't add a placeholder.
         """
         print("Setup: Assistant message with empty content...")
         messages = [UnifiedMessage(role="assistant", content="")]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['assistantResponseMessage']['content']}'")
         print("Checking that 'empty content' placeholder is added...")
         assert result[0]["assistantResponseMessage"]["content"] == ""
-    
+
     def test_keeps_empty_content_for_none_user_content(self):
         """
         What it does: Verifies that "" placeholder is added for user messages with None content.
@@ -3585,15 +3384,15 @@ class TestBuildKiroHistory:
         """
         print("Setup: User message with None content...")
         messages = [UnifiedMessage(role="user", content=None)]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['userInputMessage']['content']}'")
         print("Checking that 'empty content' placeholder is added...")
         assert result[0]["userInputMessage"]["content"] == ""
-    
+
     def test_keeps_empty_content_for_none_assistant_content(self):
         """
         What it does: Verifies that "" placeholder is added for assistant messages with None content.
@@ -3601,39 +3400,36 @@ class TestBuildKiroHistory:
         """
         print("Setup: Assistant message with None content...")
         messages = [UnifiedMessage(role="assistant", content=None)]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print(f"Content: '{result[0]['assistantResponseMessage']['content']}'")
         print("Checking that 'empty content' placeholder is added...")
         assert result[0]["assistantResponseMessage"]["content"] == ""
-    
+
     def test_preserves_non_empty_content_in_history(self):
         """
         What it does: Verifies that non-empty content is preserved (not replaced with placeholder).
         Purpose: Ensure placeholder is only added when content is actually empty.
         """
         print("Setup: Messages with actual content...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello"),
-            UnifiedMessage(role="assistant", content="Hi there")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello"), UnifiedMessage(role="assistant", content="Hi there")]
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print("Checking that original content is preserved...")
         assert result[0]["userInputMessage"]["content"] == "Hello"
         assert result[1]["assistantResponseMessage"]["content"] == "Hi there"
-    
+
     def test_mixed_empty_and_non_empty_content_in_history(self):
         """
         What it does: Verifies correct handling of mixed empty and non-empty content.
         Purpose: Ensure only empty messages get placeholders.
-        
+
         This simulates a conversation where some messages have content and some don't.
         """
         print("Setup: Mixed conversation with empty and non-empty content...")
@@ -3641,32 +3437,32 @@ class TestBuildKiroHistory:
             UnifiedMessage(role="user", content="Start"),
             UnifiedMessage(role="assistant", content=""),  # Empty - should get placeholder
             UnifiedMessage(role="user", content=""),  # Empty - should get placeholder
-            UnifiedMessage(role="assistant", content="Response")
+            UnifiedMessage(role="assistant", content="Response"),
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         print("Checking each message...")
-        
+
         print(f"Message 0 content: '{result[0]['userInputMessage']['content']}'")
         assert result[0]["userInputMessage"]["content"] == "Start"
-        
+
         print(f"Message 1 content: '{result[1]['assistantResponseMessage']['content']}'")
         assert result[1]["assistantResponseMessage"]["content"] == ""
-        
+
         print(f"Message 2 content: '{result[2]['userInputMessage']['content']}'")
         assert result[2]["userInputMessage"]["content"] == ""
-        
+
         print(f"Message 3 content: '{result[3]['assistantResponseMessage']['content']}'")
         assert result[3]["assistantResponseMessage"]["content"] == "Response"
-    
+
     def test_builds_user_message_with_images(self):
         """
         What it does: Verifies building of user message with images.
         Purpose: Ensure images are included directly in userInputMessage.images (Issue #32 fix).
-        
+
         This is a critical test for Issue #30/#32 fix - images should be in Kiro format
         and placed directly in userInputMessage, NOT in userInputMessageContext.
         """
@@ -3675,29 +3471,29 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="What's in this image?",
-                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}]
+                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert "userInputMessage" in result[0]
-        
+
         user_msg = result[0]["userInputMessage"]
         print(f"User message: {user_msg}")
-        
+
         print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
         assert "images" in user_msg
-        
+
         print("Checking image format (Kiro format)...")
         images = user_msg["images"]
         assert len(images) == 1
         assert images[0]["format"] == "jpeg"
         assert images[0]["source"]["bytes"] == TEST_IMAGE_BASE64
-    
+
     def test_builds_user_message_with_multiple_images(self):
         """
         What it does: Verifies building of user message with multiple images.
@@ -3710,29 +3506,29 @@ class TestBuildKiroHistory:
                 content="Compare these images",
                 images=[
                     {"media_type": "image/jpeg", "data": "image1_data"},
-                    {"media_type": "image/png", "data": "image2_data"}
-                ]
+                    {"media_type": "image/png", "data": "image2_data"},
+                ],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         images = user_msg["images"]
-        
+
         print(f"Comparing image count: Expected 2, Got {len(images)}")
         assert len(images) == 2
-        
+
         print("Checking first image...")
         assert images[0]["format"] == "jpeg"
         assert images[0]["source"]["bytes"] == "image1_data"
-        
+
         print("Checking second image...")
         assert images[1]["format"] == "png"
         assert images[1]["source"]["bytes"] == "image2_data"
-    
+
     def test_builds_user_message_with_images_and_tool_results(self):
         """
         What it does: Verifies building of user message with both images and tool_results.
@@ -3744,51 +3540,45 @@ class TestBuildKiroHistory:
                 role="user",
                 content="Here's the image and tool result",
                 images=[{"media_type": "image/png", "data": "image_data"}],
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Tool output"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Tool output"}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         context = user_msg.get("userInputMessageContext", {})
-        
+
         print("Checking that images are directly in userInputMessage (Issue #32 fix)...")
         assert "images" in user_msg
-        
+
         print("Checking that toolResults are in userInputMessageContext...")
         assert "toolResults" in context
-        
+
         print("Checking images...")
         assert len(user_msg["images"]) == 1
         assert user_msg["images"][0]["format"] == "png"
-        
+
         print("Checking toolResults...")
         assert len(context["toolResults"]) == 1
         assert context["toolResults"][0]["toolUseId"] == "call_123"
-    
+
     def test_no_images_context_when_no_images(self):
         """
         What it does: Verifies that images key is not added when there are no images.
         Purpose: Ensure clean payload without empty images array.
         """
         print("Setup: User message without images...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello, no images here")
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello, no images here")]
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
-        
+
         print("Checking that images key is not present...")
         # Either no context at all, or context without images
         if "userInputMessageContext" in user_msg:
@@ -3796,7 +3586,7 @@ class TestBuildKiroHistory:
             assert "images" not in context or context.get("images") == []
         else:
             print("No userInputMessageContext - OK")
-    
+
     def test_builds_user_message_with_webp_image(self):
         """
         What it does: Verifies building of user message with WebP image.
@@ -3807,22 +3597,22 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="Analyze this WebP image",
-                images=[{"media_type": "image/webp", "data": "webp_image_data"}]
+                images=[{"media_type": "image/webp", "data": "webp_image_data"}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         images = user_msg["images"]
-        
+
         print("Checking WebP format...")
         assert len(images) == 1
         assert images[0]["format"] == "webp"
         assert images[0]["source"]["bytes"] == "webp_image_data"
-    
+
     def test_builds_user_message_with_gif_image(self):
         """
         What it does: Verifies building of user message with GIF image.
@@ -3833,52 +3623,54 @@ class TestBuildKiroHistory:
             UnifiedMessage(
                 role="user",
                 content="What's happening in this GIF?",
-                images=[{"media_type": "image/gif", "data": "gif_image_data"}]
+                images=[{"media_type": "image/gif", "data": "gif_image_data"}],
             )
         ]
-        
+
         print("Action: Building history...")
         result = build_kiro_history(messages, "claude-sonnet-4")
-        
+
         print(f"Result: {result}")
         user_msg = result[0]["userInputMessage"]
         images = user_msg["images"]
-        
+
         print("Checking GIF format...")
         assert len(images) == 1
         assert images[0]["format"] == "gif"
         assert images[0]["source"]["bytes"] == "gif_image_data"
-    
+
+
 # ==================================================================================================
 # Tests for strip_all_tool_content
 # ==================================================================================================
 
+
 class TestStripAllToolContent:
     """
     Tests for strip_all_tool_content function.
-    
+
     This function strips ALL tool-related content (tool_calls and tool_results)
     from messages. It is used when no tools are defined in the request, because
     Kiro API rejects requests that have toolResults but no tools defined.
-    
+
     This is a critical function for handling clients like Cline/Roo/Cursor that may
     send tool-related content even when tools are not available.
     """
-    
+
     def test_returns_empty_list_for_empty_input(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
         assert had_content is False
-    
+
     def test_preserves_messages_without_tool_content(self):
         """
         What it does: Verifies messages without tool content are unchanged.
@@ -3888,19 +3680,19 @@ class TestStripAllToolContent:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi there"),
-            UnifiedMessage(role="user", content="How are you?")
+            UnifiedMessage(role="user", content="How are you?"),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Comparing length: Expected 3, Got {len(result)}")
         assert len(result) == 3
         assert result[0].content == "Hello"
         assert result[1].content == "Hi there"
         assert result[2].content == "How are you?"
         assert had_content is False
-    
+
     def test_strips_tool_calls_from_assistant(self):
         """
         What it does: Verifies tool_calls are stripped and converted to text.
@@ -3911,17 +3703,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="I'll call a tool",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_calls are stripped and converted to text...")
         assert len(result) == 1
@@ -3930,7 +3724,7 @@ class TestStripAllToolContent:
         assert "I'll call a tool" in result[0].content
         assert "[Tool: get_weather" in result[0].content
         assert had_content is True
-    
+
     def test_strips_tool_results_from_user(self):
         """
         What it does: Verifies tool_results are stripped and converted to text.
@@ -3941,17 +3735,13 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="Here are the results",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Weather is sunny"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Weather is sunny"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that tool_results are stripped and converted to text...")
         assert len(result) == 1
@@ -3961,7 +3751,7 @@ class TestStripAllToolContent:
         assert "[Tool Result" in result[0].content
         assert "Weather is sunny" in result[0].content
         assert had_content is True
-    
+
     def test_strips_both_tool_calls_and_tool_results(self):
         """
         What it does: Verifies both tool_calls and tool_results are stripped.
@@ -3973,26 +3763,20 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {"id": "call_123", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result"
-                }]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result"}],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool content is stripped...")
         assert len(result) == 3
@@ -4003,7 +3787,7 @@ class TestStripAllToolContent:
         assert result[2].tool_calls is None
         assert result[2].tool_results is None
         assert had_content is True
-    
+
     def test_strips_multiple_tool_calls(self):
         """
         What it does: Verifies multiple tool_calls are all stripped.
@@ -4017,19 +3801,19 @@ class TestStripAllToolContent:
                 tool_calls=[
                     {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}},
                     {"id": "call_2", "type": "function", "function": {"name": "tool2", "arguments": "{}"}},
-                    {"id": "call_3", "type": "function", "function": {"name": "tool3", "arguments": "{}"}}
-                ]
+                    {"id": "call_3", "type": "function", "function": {"name": "tool3", "arguments": "{}"}},
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool_calls are stripped...")
         assert result[0].tool_calls is None
         assert had_content is True
-    
+
     def test_strips_multiple_tool_results(self):
         """
         What it does: Verifies multiple tool_results are all stripped.
@@ -4043,19 +3827,19 @@ class TestStripAllToolContent:
                 tool_results=[
                     {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
                     {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
-                    {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"}
-                ]
+                    {"type": "tool_result", "tool_use_id": "call_3", "content": "Result 3"},
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that all tool_results are stripped...")
         assert result[0].tool_results is None
         assert had_content is True
-    
+
     def test_preserves_message_content_when_stripping(self):
         """
         What it does: Verifies message content is preserved and tool content is appended as text.
@@ -4066,26 +3850,18 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="Let me help you with that",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "helper", "arguments": "{}"}
-                }]
+                tool_calls=[{"id": "call_123", "type": "function", "function": {"name": "helper", "arguments": "{}"}}],
             ),
             UnifiedMessage(
                 role="user",
                 content="Thanks for the result",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Done"
-                }]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Done"}],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that original content is preserved and tool text is appended...")
         assert "Let me help you with that" in result[0].content
@@ -4093,7 +3869,7 @@ class TestStripAllToolContent:
         assert "Thanks for the result" in result[1].content
         assert "[Tool Result" in result[1].content
         assert had_content is True
-    
+
     def test_preserves_message_role_when_stripping(self):
         """
         What it does: Verifies message role is preserved when tool content is stripped.
@@ -4101,23 +3877,27 @@ class TestStripAllToolContent:
         """
         print("Setup: Messages with tool content...")
         messages = [
-            UnifiedMessage(role="assistant", content="", tool_calls=[
-                {"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}
-            ]),
-            UnifiedMessage(role="user", content="", tool_results=[
-                {"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}
-            ])
+            UnifiedMessage(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}],
+            ),
+            UnifiedMessage(
+                role="user",
+                content="",
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking that roles are preserved...")
         assert result[0].role == "assistant"
         assert result[1].role == "user"
         assert had_content is True
-    
+
     def test_mixed_messages_with_and_without_tool_content(self):
         """
         What it does: Verifies correct handling of mixed messages.
@@ -4129,14 +3909,14 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}]
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}],
             ),  # Has tool content
             UnifiedMessage(role="user", content=""),  # No tool content
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking mixed handling...")
         assert result[0].content == "Hello"
@@ -4145,7 +3925,7 @@ class TestStripAllToolContent:
         assert result[2].content == ""
         assert result[2].tool_calls is None
         assert had_content is True
-    
+
     def test_returns_false_when_no_tool_content_stripped(self):
         """
         What it does: Verifies had_content flag is False when no tool content exists.
@@ -4155,15 +3935,15 @@ class TestStripAllToolContent:
         messages = [
             UnifiedMessage(role="user", content="Hello"),
             UnifiedMessage(role="assistant", content="Hi"),
-            UnifiedMessage(role="user", content="Bye")
+            UnifiedMessage(role="user", content="Bye"),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"had_content: {had_content}")
         assert had_content is False
-    
+
     def test_returns_true_when_tool_content_stripped(self):
         """
         What it does: Verifies had_content flag is True when tool content is stripped.
@@ -4174,57 +3954,53 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}]
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool", "arguments": "{}"}}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"had_content: {had_content}")
         assert had_content is True
-    
+
     def test_handles_empty_tool_calls_list(self):
         """
         What it does: Verifies handling of empty tool_calls list.
         Purpose: Ensure empty list is treated as no tool content.
         """
         print("Setup: Message with empty tool_calls list...")
-        messages = [
-            UnifiedMessage(role="assistant", content="Hello", tool_calls=[])
-        ]
-        
+        messages = [UnifiedMessage(role="assistant", content="Hello", tool_calls=[])]
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"had_content: {had_content}")
         # Empty list is falsy, so should not be considered as having tool content
         assert had_content is False
-    
+
     def test_handles_empty_tool_results_list(self):
         """
         What it does: Verifies handling of empty tool_results list.
         Purpose: Ensure empty list is treated as no tool content.
         """
         print("Setup: Message with empty tool_results list...")
-        messages = [
-            UnifiedMessage(role="user", content="Hello", tool_results=[])
-        ]
-        
+        messages = [UnifiedMessage(role="user", content="Hello", tool_results=[])]
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"had_content: {had_content}")
         # Empty list is falsy, so should not be considered as having tool content
         assert had_content is False
-    
+
     def test_adds_tool_text_for_empty_content_with_tool_calls(self):
         """
         What it does: Verifies that tool_calls are converted to text when content is empty.
         Purpose: Ensure Kiro API receives non-empty content for messages that only had tool_calls.
-        
+
         This is a critical test for issue #20 - OpenCode compaction returns 400 error
         because messages with only tool_calls become empty after stripping.
         Now we convert tool_calls to text representation instead of simple placeholder.
@@ -4234,17 +4010,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",  # Empty content - only tool_calls
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": '{"path": "test.py"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "test.py"}'},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that tool_calls are converted to text representation...")
@@ -4253,12 +4031,12 @@ class TestStripAllToolContent:
         assert '{"path": "test.py"}' in result[0].content
         assert result[0].tool_calls is None
         assert had_content is True
-    
+
     def test_adds_tool_text_for_empty_content_with_tool_results(self):
         """
         What it does: Verifies that tool_results are converted to text when content is empty.
         Purpose: Ensure Kiro API receives non-empty content for messages that only had tool_results.
-        
+
         This is a critical test for issue #20 - OpenCode compaction returns 400 error
         because messages with only tool_results become empty after stripping.
         Now we convert tool_results to text representation instead of simple placeholder.
@@ -4268,17 +4046,13 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="",  # Empty content - only tool_results
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "File contents here"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "File contents here"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that tool_results are converted to text representation...")
@@ -4287,7 +4061,7 @@ class TestStripAllToolContent:
         assert "File contents here" in result[0].content
         assert result[0].tool_results is None
         assert had_content is True
-    
+
     def test_preserves_existing_content_when_stripping_tool_calls(self):
         """
         What it does: Verifies that existing content is preserved and tool text is appended.
@@ -4298,17 +4072,15 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="I'll read the file for you",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {"id": "call_123", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that original content is preserved and tool text is appended...")
@@ -4316,7 +4088,7 @@ class TestStripAllToolContent:
         assert "[Tool: read_file" in result[0].content
         assert result[0].tool_calls is None
         assert had_content is True
-    
+
     def test_preserves_existing_content_when_stripping_tool_results(self):
         """
         What it does: Verifies that existing content is preserved and tool result text is appended.
@@ -4327,17 +4099,13 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="Here are the results you requested",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_123",
-                    "content": "Result data"
-                }]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Result data"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that original content is preserved and tool result text is appended...")
@@ -4346,12 +4114,12 @@ class TestStripAllToolContent:
         assert "Result data" in result[0].content
         assert result[0].tool_results is None
         assert had_content is True
-    
+
     def test_both_tool_calls_and_results_converted_to_text(self):
         """
         What it does: Verifies that both tool_calls and tool_results are converted to text.
         Purpose: Ensure all tool content is preserved when message has both types.
-        
+
         Note: This is an edge case - normally assistant messages have tool_calls and user messages have tool_results.
         """
         print("Setup: Message with both tool_calls and tool_results (edge case)...")
@@ -4359,14 +4127,16 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "my_tool", "arguments": '{"x": 1}'}}],
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_0", "content": "Previous result"}]
+                tool_calls=[
+                    {"id": "call_1", "type": "function", "function": {"name": "my_tool", "arguments": '{"x": 1}'}}
+                ],
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_0", "content": "Previous result"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Content after stripping: '{result[0].content}'")
         print("Checking that both tool_calls and tool_results are converted to text...")
@@ -4374,12 +4144,12 @@ class TestStripAllToolContent:
         assert "[Tool Result" in result[0].content
         assert "Previous result" in result[0].content
         assert had_content is True
-    
+
     def test_multiple_messages_with_empty_content_get_text_representation(self):
         """
         What it does: Verifies correct text representation for multiple messages in a conversation.
         Purpose: Ensure each message gets the appropriate text representation based on its tool content type.
-        
+
         This simulates the OpenCode compaction scenario from issue #20 where multiple
         tool-only messages are sent without text content.
         """
@@ -4389,57 +4159,69 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",  # Only tool_calls
-                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'}}]
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",  # Only tool_results
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "File content ABC"}]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "File content ABC"}],
             ),
             UnifiedMessage(
                 role="assistant",
                 content="",  # Only tool_calls
-                tool_calls=[{"id": "call_2", "type": "function", "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'}}]
+                tool_calls=[
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'},
+                    }
+                ],
             ),
             UnifiedMessage(
                 role="user",
                 content="",  # Only tool_results
-                tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Write completed"}]
-            )
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_2", "content": "Write completed"}],
+            ),
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print("Checking text representation for each message...")
-        
+
         print(f"Message 0 content: '{result[0].content}'")
         assert result[0].content == "Read these files"  # Original content preserved
-        
+
         print(f"Message 1 content: '{result[1].content}'")
         assert "[Tool: read_file" in result[1].content  # Text representation for tool_calls
         assert "call_1" in result[1].content
-        
+
         print(f"Message 2 content: '{result[2].content}'")
         assert "[Tool Result" in result[2].content  # Text representation for tool_results
         assert "File content ABC" in result[2].content
-        
+
         print(f"Message 3 content: '{result[3].content}'")
         assert "[Tool: write_file" in result[3].content  # Text representation for tool_calls
         assert "call_2" in result[3].content
-        
+
         print(f"Message 4 content: '{result[4].content}'")
         assert "[Tool Result" in result[4].content  # Text representation for tool_results
         assert "Write completed" in result[4].content
-        
+
         assert had_content is True
-    
+
     def test_converts_tool_calls_to_text_representation(self):
         """
         What it does: Verifies that tool_calls are converted to text representation.
         Purpose: Ensure tool context is preserved as readable text when stripping.
-        
+
         This is a critical test for issue #20 - instead of losing tool context,
         we convert it to human-readable text.
         """
@@ -4448,17 +4230,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="assistant",
                 content="",
-                tool_calls=[{
-                    "id": "call_abc123",
-                    "type": "function",
-                    "function": {"name": "read_file", "arguments": '{"path": "test.py"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "test.py"}'},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result content: '{result[0].content}'")
         print("Checking that tool name is in text representation...")
         assert "[Tool: read_file" in result[0].content
@@ -4467,12 +4251,12 @@ class TestStripAllToolContent:
         print("Checking that arguments are in text representation...")
         assert '{"path": "test.py"}' in result[0].content
         assert had_content is True
-    
+
     def test_converts_tool_results_to_text_representation(self):
         """
         What it does: Verifies that tool_results are converted to text representation.
         Purpose: Ensure tool result context is preserved as readable text when stripping.
-        
+
         This is a critical test for issue #20 - instead of losing tool context,
         we convert it to human-readable text.
         """
@@ -4481,17 +4265,19 @@ class TestStripAllToolContent:
             UnifiedMessage(
                 role="user",
                 content="",
-                tool_results=[{
-                    "type": "tool_result",
-                    "tool_use_id": "call_xyz789",
-                    "content": "File contents:\ndef hello():\n    print('world')"
-                }]
+                tool_results=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_xyz789",
+                        "content": "File contents:\ndef hello():\n    print('world')",
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_content = strip_all_tool_content(messages)
-        
+
         print(f"Result content: '{result[0].content}'")
         print("Checking that [Tool Result] marker is present...")
         assert "[Tool Result" in result[0].content
@@ -4506,9 +4292,10 @@ class TestStripAllToolContent:
 # Tests for strip_all_tool_content with images preservation (Issue #57 follow-up)
 # ==================================================================================================
 
+
 class TestStripAllToolContentPreservesImages:
     """Tests that strip_all_tool_content preserves images field (Issue #57 follow-up)."""
-    
+
     def test_preserves_images_when_stripping_tool_results(self):
         """
         What it does: Verifies images are preserved when tool_results are stripped.
@@ -4519,27 +4306,23 @@ class TestStripAllToolContentPreservesImages:
             UnifiedMessage(
                 role="user",
                 content="Screenshot result",
-                tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_123", "content": "Done"}
-                ],
-                images=[
-                    {"media_type": "image/png", "data": "screenshot_data"}
-                ]
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_123", "content": "Done"}],
+                images=[{"media_type": "image/png", "data": "screenshot_data"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_tools = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Images preserved: {result[0].images}")
-        
+
         assert had_tools is True
         assert result[0].tool_results is None  # Stripped
         assert result[0].images is not None  # PRESERVED
         assert len(result[0].images) == 1
         assert result[0].images[0]["data"] == "screenshot_data"
-    
+
     def test_preserves_images_when_stripping_tool_calls(self):
         """
         What it does: Verifies images are preserved when tool_calls are stripped.
@@ -4550,27 +4333,23 @@ class TestStripAllToolContentPreservesImages:
             UnifiedMessage(
                 role="assistant",
                 content="Using tool",
-                tool_calls=[
-                    {"id": "call_456", "type": "function", "function": {"name": "test", "arguments": "{}"}}
-                ],
-                images=[
-                    {"media_type": "image/jpeg", "data": "image_data"}
-                ]
+                tool_calls=[{"id": "call_456", "type": "function", "function": {"name": "test", "arguments": "{}"}}],
+                images=[{"media_type": "image/jpeg", "data": "image_data"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_tools = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Images preserved: {result[0].images}")
-        
+
         assert had_tools is True
         assert result[0].tool_calls is None  # Stripped
         assert result[0].images is not None  # PRESERVED
         assert len(result[0].images) == 1
         assert result[0].images[0]["data"] == "image_data"
-    
+
     def test_preserves_images_when_stripping_both_tool_calls_and_results(self):
         """
         What it does: Verifies images are preserved when both tool_calls and tool_results are stripped.
@@ -4581,31 +4360,25 @@ class TestStripAllToolContentPreservesImages:
             UnifiedMessage(
                 role="user",
                 content="Complex message",
-                tool_calls=[
-                    {"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}
-                ],
-                tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}
-                ],
-                images=[
-                    {"media_type": "image/png", "data": "complex_image"}
-                ]
+                tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "tool1", "arguments": "{}"}}],
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_1", "content": "Result"}],
+                images=[{"media_type": "image/png", "data": "complex_image"}],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_tools = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Images preserved: {result[0].images}")
-        
+
         assert had_tools is True
         assert result[0].tool_calls is None  # Stripped
         assert result[0].tool_results is None  # Stripped
         assert result[0].images is not None  # PRESERVED
         assert len(result[0].images) == 1
         assert result[0].images[0]["data"] == "complex_image"
-    
+
     def test_preserves_none_images_when_stripping(self):
         """
         What it does: Verifies None images stay None when tool content is stripped.
@@ -4616,23 +4389,21 @@ class TestStripAllToolContentPreservesImages:
             UnifiedMessage(
                 role="user",
                 content="Text only",
-                tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_789", "content": "Done"}
-                ],
-                images=None
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_789", "content": "Done"}],
+                images=None,
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_tools = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Images field: {result[0].images}")
-        
+
         assert had_tools is True
         assert result[0].tool_results is None  # Stripped
         assert result[0].images is None  # Still None (not created)
-    
+
     def test_preserves_multiple_images_when_stripping(self):
         """
         What it does: Verifies multiple images are all preserved when stripping.
@@ -4643,23 +4414,21 @@ class TestStripAllToolContentPreservesImages:
             UnifiedMessage(
                 role="user",
                 content="Multiple screenshots",
-                tool_results=[
-                    {"type": "tool_result", "tool_use_id": "call_multi", "content": "Done"}
-                ],
+                tool_results=[{"type": "tool_result", "tool_use_id": "call_multi", "content": "Done"}],
                 images=[
                     {"media_type": "image/png", "data": "image1"},
                     {"media_type": "image/jpeg", "data": "image2"},
-                    {"media_type": "image/webp", "data": "image3"}
-                ]
+                    {"media_type": "image/webp", "data": "image3"},
+                ],
             )
         ]
-        
+
         print("Action: Stripping tool content...")
         result, had_tools = strip_all_tool_content(messages)
-        
+
         print(f"Result: {result}")
         print(f"Images count: {len(result[0].images)}")
-        
+
         assert had_tools is True
         assert result[0].tool_results is None  # Stripped
         assert result[0].images is not None  # PRESERVED
@@ -4673,35 +4442,34 @@ class TestStripAllToolContentPreservesImages:
 # Tests for tool_calls_to_text
 # ==================================================================================================
 
+
 class TestToolCallsToText:
     """
     Tests for tool_calls_to_text function.
-    
+
     This function converts tool_calls to human-readable text representation.
     Used when stripping tool content from messages (when no tools are defined).
     """
-    
+
     def test_converts_single_tool_call_to_text(self):
         """
         What it does: Verifies conversion of a single tool call to text.
         Purpose: Ensure basic conversion works correctly.
         """
         print("Setup: Single tool call...")
-        tool_calls = [{
-            "id": "call_123",
-            "type": "function",
-            "function": {"name": "bash", "arguments": '{"command": "ls -la"}'}
-        }]
-        
+        tool_calls = [
+            {"id": "call_123", "type": "function", "function": {"name": "bash", "arguments": '{"command": "ls -la"}'}}
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool name is present...")
         assert "[Tool: bash" in result
         print("Checking that arguments are present...")
         assert '{"command": "ls -la"}' in result
-    
+
     def test_converts_multiple_tool_calls_to_text(self):
         """
         What it does: Verifies conversion of multiple tool calls to text.
@@ -4710,69 +4478,64 @@ class TestToolCallsToText:
         print("Setup: Multiple tool calls...")
         tool_calls = [
             {"id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'}},
-            {"id": "call_2", "type": "function", "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'}}
+            {"id": "call_2", "type": "function", "function": {"name": "write_file", "arguments": '{"path": "b.txt"}'}},
         ]
-        
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that both tools are present...")
         assert "[Tool: read_file" in result
         assert "[Tool: write_file" in result
         assert '{"path": "a.txt"}' in result
         assert '{"path": "b.txt"}' in result
-    
+
     def test_includes_tool_id_in_output(self):
         """
         What it does: Verifies that tool_id is included in output.
         Purpose: Ensure traceability between tool calls and results.
         """
         print("Setup: Tool call with id...")
-        tool_calls = [{
-            "id": "tooluse_abc123xyz",
-            "type": "function",
-            "function": {"name": "search", "arguments": "{}"}
-        }]
-        
+        tool_calls = [
+            {"id": "tooluse_abc123xyz", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool_id is present...")
         assert "tooluse_abc123xyz" in result
-    
+
     def test_handles_missing_tool_id(self):
         """
         What it does: Verifies handling of tool call without id.
         Purpose: Ensure function doesn't crash when id is missing.
         """
         print("Setup: Tool call without id...")
-        tool_calls = [{
-            "type": "function",
-            "function": {"name": "test_tool", "arguments": "{}"}
-        }]
-        
+        tool_calls = [{"type": "function", "function": {"name": "test_tool", "arguments": "{}"}}]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool name is still present...")
         assert "[Tool: test_tool]" in result
-    
+
     def test_returns_empty_string_for_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Converting to text...")
         result = tool_calls_to_text([])
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_missing_function_key(self):
         """
         What it does: Verifies handling of malformed tool call without function key.
@@ -4780,14 +4543,14 @@ class TestToolCallsToText:
         """
         print("Setup: Tool call without function key...")
         tool_calls = [{"id": "call_123", "type": "function"}]
-        
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that 'unknown' is used as fallback...")
         assert "[Tool: unknown" in result
-    
+
     def test_handles_complex_json_arguments(self):
         """
         What it does: Verifies handling of complex JSON arguments.
@@ -4795,15 +4558,13 @@ class TestToolCallsToText:
         """
         print("Setup: Tool call with complex arguments...")
         complex_args = '{"files": ["a.py", "b.py"], "options": {"recursive": true}}'
-        tool_calls = [{
-            "id": "call_123",
-            "type": "function",
-            "function": {"name": "process", "arguments": complex_args}
-        }]
-        
+        tool_calls = [
+            {"id": "call_123", "type": "function", "function": {"name": "process", "arguments": complex_args}}
+        ]
+
         print("Action: Converting to text...")
         result = tool_calls_to_text(tool_calls)
-        
+
         print(f"Result: '{result}'")
         print("Checking that complex arguments are preserved...")
         assert complex_args in result
@@ -4813,35 +4574,34 @@ class TestToolCallsToText:
 # Tests for tool_results_to_text
 # ==================================================================================================
 
+
 class TestToolResultsToText:
     """
     Tests for tool_results_to_text function.
-    
+
     This function converts tool_results to human-readable text representation.
     Used when stripping tool content from messages (when no tools are defined).
     """
-    
+
     def test_converts_single_tool_result_to_text(self):
         """
         What it does: Verifies conversion of a single tool result to text.
         Purpose: Ensure basic conversion works correctly.
         """
         print("Setup: Single tool result...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": "Operation completed successfully"
-        }]
-        
+        tool_results = [
+            {"type": "tool_result", "tool_use_id": "call_123", "content": "Operation completed successfully"}
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that [Tool Result] marker is present...")
         assert "[Tool Result" in result
         print("Checking that content is present...")
         assert "Operation completed successfully" in result
-    
+
     def test_converts_multiple_tool_results_to_text(self):
         """
         What it does: Verifies conversion of multiple tool results to text.
@@ -4850,89 +4610,78 @@ class TestToolResultsToText:
         print("Setup: Multiple tool results...")
         tool_results = [
             {"type": "tool_result", "tool_use_id": "call_1", "content": "Result 1"},
-            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"}
+            {"type": "tool_result", "tool_use_id": "call_2", "content": "Result 2"},
         ]
-        
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that both results are present...")
         assert "Result 1" in result
         assert "Result 2" in result
         assert "call_1" in result
         assert "call_2" in result
-    
+
     def test_includes_tool_use_id_in_output(self):
         """
         What it does: Verifies that tool_use_id is included in output.
         Purpose: Ensure traceability between tool calls and results.
         """
         print("Setup: Tool result with tool_use_id...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "tooluse_xyz789abc",
-            "content": "Done"
-        }]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "tooluse_xyz789abc", "content": "Done"}]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that tool_use_id is present...")
         assert "tooluse_xyz789abc" in result
-    
+
     def test_handles_missing_tool_use_id(self):
         """
         What it does: Verifies handling of tool result without tool_use_id.
         Purpose: Ensure function doesn't crash when tool_use_id is missing.
         """
         print("Setup: Tool result without tool_use_id...")
-        tool_results = [{
-            "type": "tool_result",
-            "content": "Some result"
-        }]
-        
+        tool_results = [{"type": "tool_result", "content": "Some result"}]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that content is still present...")
         assert "Some result" in result
         assert "[Tool Result]" in result
-    
+
     def test_handles_empty_content(self):
         """
         What it does: Verifies handling of empty content.
         Purpose: Ensure empty content is replaced with placeholder.
         """
         print("Setup: Tool result with empty content...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": ""
-        }]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": ""}]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that placeholder is used...")
         assert "(empty result)" in result
-    
+
     def test_returns_empty_string_for_empty_list(self):
         """
         What it does: Verifies empty list handling.
         Purpose: Ensure empty input returns empty output.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Converting to text...")
         result = tool_results_to_text([])
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_multiline_content(self):
         """
         What it does: Verifies handling of multiline content.
@@ -4940,34 +4689,28 @@ class TestToolResultsToText:
         """
         print("Setup: Tool result with multiline content...")
         multiline_content = "Line 1\nLine 2\nLine 3"
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": multiline_content
-        }]
-        
+        tool_results = [{"type": "tool_result", "tool_use_id": "call_123", "content": multiline_content}]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that multiline content is preserved...")
         assert "Line 1\nLine 2\nLine 3" in result
-    
+
     def test_handles_list_content(self):
         """
         What it does: Verifies handling of list content (multimodal format).
         Purpose: Ensure list content is extracted correctly.
         """
         print("Setup: Tool result with list content...")
-        tool_results = [{
-            "type": "tool_result",
-            "tool_use_id": "call_123",
-            "content": [{"type": "text", "text": "Extracted text"}]
-        }]
-        
+        tool_results = [
+            {"type": "tool_result", "tool_use_id": "call_123", "content": [{"type": "text", "text": "Extracted text"}]}
+        ]
+
         print("Action: Converting to text...")
         result = tool_results_to_text(tool_results)
-        
+
         print(f"Result: '{result}'")
         print("Checking that text is extracted from list...")
         assert "Extracted text" in result
@@ -4977,14 +4720,15 @@ class TestToolResultsToText:
 # Tests for build_kiro_payload with Issue #20 Scenario
 # ==================================================================================================
 
+
 class TestValidateToolNames:
     """
     Tests for validate_tool_names function.
-    
+
     This function validates tool names against Kiro API 64-character limit.
     Issue #41: 400 Improperly formed request with long tool names from MCP servers.
     """
-    
+
     def test_accepts_short_tool_names(self):
         """
         What it does: Verifies that short tool names are accepted.
@@ -4992,16 +4736,17 @@ class TestValidateToolNames:
         """
         print("Setup: Tool with short name...")
         tools = [UnifiedTool(name="get_weather", description="Get weather")]
-        
+
         print("Action: Validating tool names...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             print("Validation passed - OK")
         except ValueError as e:
             print(f"ERROR: Validation failed: {e}")
             raise AssertionError("Short tool names should be accepted")
-    
+
     def test_accepts_exactly_64_character_name(self):
         """
         What it does: Verifies that exactly 64-character names are accepted (boundary).
@@ -5010,17 +4755,18 @@ class TestValidateToolNames:
         print("Setup: Tool with exactly 64-character name...")
         name_64 = "a" * 64
         tools = [UnifiedTool(name=name_64, description="Test")]
-        
+
         print(f"Tool name length: {len(name_64)}")
         print("Action: Validating tool names...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             print("Validation passed - OK")
         except ValueError as e:
             print(f"ERROR: Validation failed: {e}")
             raise AssertionError("64-character names should be accepted")
-    
+
     def test_rejects_65_character_name(self):
         """
         What it does: Verifies that 65-character names are rejected.
@@ -5029,11 +4775,12 @@ class TestValidateToolNames:
         print("Setup: Tool with 65-character name...")
         name_65 = "a" * 65
         tools = [UnifiedTool(name=name_65, description="Test")]
-        
+
         print(f"Tool name length: {len(name_65)}")
         print("Action: Validating tool names (should raise ValueError)...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             print("ERROR: Validation passed but should have failed")
             raise AssertionError("65-character names should be rejected")
@@ -5041,7 +4788,7 @@ class TestValidateToolNames:
             print(f"Validation correctly rejected: {str(e)[:100]}...")
             assert "exceed Kiro API limit" in str(e)
             assert name_65 in str(e)
-    
+
     def test_rejects_very_long_tool_names(self):
         """
         What it does: Verifies that very long tool names are rejected.
@@ -5050,18 +4797,19 @@ class TestValidateToolNames:
         print("Setup: Tool with 100-character name...")
         name_100 = "mcp__GitHub__" + "a" * 87
         tools = [UnifiedTool(name=name_100, description="Test")]
-        
+
         print(f"Tool name length: {len(name_100)}")
         print("Action: Validating tool names (should raise ValueError)...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             raise AssertionError("Very long names should be rejected")
         except ValueError as e:
             print(f"Validation correctly rejected: {str(e)[:100]}...")
             assert "exceed Kiro API limit" in str(e)
             assert "100 characters" in str(e)
-    
+
     def test_rejects_multiple_long_names(self):
         """
         What it does: Verifies that all long names are listed in error message.
@@ -5071,54 +4819,57 @@ class TestValidateToolNames:
         tools = [
             UnifiedTool(name="a" * 65, description="Test 1"),
             UnifiedTool(name="short", description="Test 2"),
-            UnifiedTool(name="b" * 70, description="Test 3")
+            UnifiedTool(name="b" * 70, description="Test 3"),
         ]
-        
+
         print("Action: Validating tool names (should raise ValueError)...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             raise AssertionError("Should reject multiple long names")
         except ValueError as e:
             error_msg = str(e)
             print(f"Error message: {error_msg[:200]}...")
-            
+
             print("Checking that both long names are listed...")
             assert "65 characters" in error_msg
             assert "70 characters" in error_msg
-    
+
     def test_handles_none_tools(self):
         """
         What it does: Verifies that None tools list is handled gracefully.
         Purpose: Ensure function doesn't crash on None input.
         """
         print("Setup: None tools...")
-        
+
         print("Action: Validating None...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(None)
             print("Validation passed - OK")
         except Exception as e:
             print(f"ERROR: Unexpected exception: {e}")
             raise AssertionError("None should be handled gracefully")
-    
+
     def test_handles_empty_tools_list(self):
         """
         What it does: Verifies that empty tools list is handled gracefully.
         Purpose: Ensure function doesn't crash on empty list.
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Validating empty list...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names([])
             print("Validation passed - OK")
         except Exception as e:
             print(f"ERROR: Unexpected exception: {e}")
             raise AssertionError("Empty list should be handled gracefully")
-    
+
     def test_error_message_includes_solution(self):
         """
         What it does: Verifies that error message includes solution guidance.
@@ -5126,21 +4877,22 @@ class TestValidateToolNames:
         """
         print("Setup: Tool with long name...")
         tools = [UnifiedTool(name="mcp__GitHub__" + "a" * 60, description="Test")]
-        
+
         print("Action: Validating tool names (should raise ValueError)...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             raise AssertionError("Should reject long name")
         except ValueError as e:
             error_msg = str(e)
             print(f"Error message: {error_msg[:300]}...")
-            
+
             print("Checking that error message includes solution...")
             assert "Solution:" in error_msg
             assert "64 characters" in error_msg
             assert "Example:" in error_msg
-    
+
     def test_real_world_mcp_tool_names(self):
         """
         What it does: Verifies rejection of real MCP tool names from Issue #41.
@@ -5152,23 +4904,24 @@ class TestValidateToolNames:
             "mcp__GitHub__check_if_a_repository_is_starred_by_the_authenticated_user",
             "mcp__GitHub__remove_interaction_restrictions_from_your_public_repositories",
         ]
-        
+
         tools = [UnifiedTool(name=name, description="Test") for name in problematic_names]
-        
+
         print("Action: Validating real MCP tool names (should raise ValueError)...")
         try:
             from kiro.converters_core import validate_tool_names
+
             validate_tool_names(tools)
             raise AssertionError("Should reject real MCP tool names")
         except ValueError as e:
             error_msg = str(e)
             print(f"Error message length: {len(error_msg)} chars")
             print(f"Error message: {error_msg[:400]}...")
-            
+
             print("Checking that all problematic names are listed...")
             for name in problematic_names:
                 assert name in error_msg, f"Tool name '{name}' should be in error message"
-            
+
             print("Checking that character counts are shown...")
             assert "68 characters" in error_msg
             assert "71 characters" in error_msg
@@ -5178,4 +4931,3 @@ class TestValidateToolNames:
 # ==================================================================================================
 # Tests for get_truncation_recovery_system_addition (Truncation Recovery System)
 # ==================================================================================================
-

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -9,45 +9,41 @@ Tests for OpenAI-specific conversion logic:
 - Building Kiro payload from OpenAI requests
 """
 
-import pytest
 from unittest.mock import patch
 
 from kiro.converters_openai import (
+    _extract_images_from_tool_message,
     build_kiro_payload,
     convert_openai_messages_to_unified,
     convert_openai_tools_to_unified,
-    _extract_images_from_tool_message,
 )
-from kiro.models_openai import ChatMessage, ChatCompletionRequest, Tool, ToolFunction
-
+from kiro.models_openai import ChatCompletionRequest, ChatMessage, Tool, ToolFunction
 
 # ==================================================================================================
 # Tests for convert_openai_messages_to_unified
 # ==================================================================================================
 
+
 class TestConvertOpenAIMessagesToUnified:
     """Tests for convert_openai_messages_to_unified function."""
-    
+
     def test_extracts_system_prompt(self):
         """
         What it does: Verifies extraction of system prompt from messages.
         Purpose: Ensure system messages are extracted separately.
         """
         print("Setup: Messages with system prompt...")
-        messages = [
-            ChatMessage(role="system", content="You are helpful"),
-            ChatMessage(role="user", content="Hello")
-        ]
-        
+        messages = [ChatMessage(role="system", content="You are helpful"), ChatMessage(role="user", content="Hello")]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"System prompt: '{system_prompt}'")
         print(f"Unified messages: {len(unified)}")
         assert system_prompt == "You are helpful"
         assert len(unified) == 1
         assert unified[0].role == "user"
-    
+
     def test_combines_multiple_system_messages(self):
         """
         What it does: Verifies combining of multiple system messages.
@@ -57,37 +53,35 @@ class TestConvertOpenAIMessagesToUnified:
         messages = [
             ChatMessage(role="system", content="You are helpful."),
             ChatMessage(role="system", content="Be concise."),
-            ChatMessage(role="user", content="Hello")
+            ChatMessage(role="user", content="Hello"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"System prompt: '{system_prompt}'")
         assert "You are helpful." in system_prompt
         assert "Be concise." in system_prompt
         assert len(unified) == 1
-    
+
     def test_converts_tool_message_to_user_with_tool_results(self):
         """
         What it does: Verifies conversion of tool message to user message with tool_results.
         Purpose: Ensure role="tool" is converted correctly.
         """
         print("Setup: Tool message...")
-        messages = [
-            ChatMessage(role="tool", content="Tool result text", tool_call_id="call_123")
-        ]
-        
+        messages = [ChatMessage(role="tool", content="Tool result text", tool_call_id="call_123")]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert len(unified) == 1
         assert unified[0].role == "user"
         assert unified[0].tool_results is not None
         assert len(unified[0].tool_results) == 1
         assert unified[0].tool_results[0]["tool_use_id"] == "call_123"
-    
+
     def test_converts_multiple_tool_messages(self):
         """
         What it does: Verifies conversion of multiple consecutive tool messages.
@@ -97,17 +91,17 @@ class TestConvertOpenAIMessagesToUnified:
         messages = [
             ChatMessage(role="tool", content="Result 1", tool_call_id="call_1"),
             ChatMessage(role="tool", content="Result 2", tool_call_id="call_2"),
-            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3")
+            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert len(unified) == 1
         assert unified[0].role == "user"
         assert len(unified[0].tool_results) == 3
-    
+
     def test_extracts_tool_calls_from_assistant(self):
         """
         What it does: Verifies extraction of tool_calls from assistant message.
@@ -118,17 +112,19 @@ class TestConvertOpenAIMessagesToUnified:
             ChatMessage(
                 role="assistant",
                 content="I'll call a tool",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-                }]
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'},
+                    }
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert len(unified) == 1
         assert unified[0].role == "assistant"
@@ -215,39 +211,35 @@ class TestConvertOpenAIMessagesToUnified:
             }
         ]
         assert unified[3].content == "Reply with TOOL_CONTINUATION_OK"
-    
+
     def test_handles_empty_tool_call_id(self):
         """
         What it does: Verifies handling of None tool_call_id.
         Purpose: Ensure None is replaced with empty string.
         """
         print("Setup: Tool message with None tool_call_id...")
-        messages = [
-            ChatMessage(role="tool", content="Result", tool_call_id=None)
-        ]
-        
+        messages = [ChatMessage(role="tool", content="Result", tool_call_id=None)]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert unified[0].tool_results[0]["tool_use_id"] == ""
-    
+
     def test_handles_empty_tool_content(self):
         """
         What it does: Verifies handling of empty tool content.
         Purpose: Ensure empty content is replaced with "(empty result)".
         """
         print("Setup: Tool message with empty content...")
-        messages = [
-            ChatMessage(role="tool", content="", tool_call_id="call_1")
-        ]
-        
+        messages = [ChatMessage(role="tool", content="", tool_call_id="call_1")]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         assert unified[0].tool_results[0]["content"] == "(empty result)"
-    
+
     def test_tool_messages_followed_by_user_message(self):
         """
         What it does: Verifies tool messages followed by user message.
@@ -256,12 +248,12 @@ class TestConvertOpenAIMessagesToUnified:
         print("Setup: Tool messages + user message...")
         messages = [
             ChatMessage(role="tool", content="Result 1", tool_call_id="call_1"),
-            ChatMessage(role="user", content="Continue please")
+            ChatMessage(role="user", content="Continue please"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Unified messages: {unified}")
         # Tool results should be in first message, user content in second
         assert len(unified) == 2
@@ -269,58 +261,53 @@ class TestConvertOpenAIMessagesToUnified:
         assert unified[0].tool_results is not None
         assert unified[1].role == "user"
         assert unified[1].content == "Continue please"
-    
+
     # ==================================================================================
     # Image extraction tests (Issue #30 fix)
     # ==================================================================================
-    
+
     def test_extracts_images_from_user_message(self):
         """
         What it does: Verifies that images are extracted from user messages.
         Purpose: Ensure OpenAI image_url content blocks are converted to unified format.
-        
+
         This test verifies the fix for Issue #30 - 422 Validation Error for image content.
         """
         print("Setup: User message with image_url content block...")
         # Base64 1x1 pixel JPEG
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
                 content=[
                     {"type": "text", "text": "What's in this image?"},
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:image/jpeg;base64,{test_image_base64}"
-                        }
-                    }
-                ]
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}},
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         print(f"Images: {unified[0].images}")
-        
+
         assert len(unified) == 1
         assert unified[0].role == "user"
         assert unified[0].content == "What's in this image?"
-        
+
         print("Checking images field...")
         assert unified[0].images is not None, "images field should not be None"
         assert len(unified[0].images) == 1, f"Expected 1 image, got {len(unified[0].images)}"
-        
+
         image = unified[0].images[0]
         print(f"Comparing image: Expected media_type='image/jpeg', Got '{image.get('media_type')}'")
         assert image["media_type"] == "image/jpeg"
-        
+
         print(f"Comparing image data: Expected {test_image_base64[:20]}..., Got {image.get('data', '')[:20]}...")
         assert image["data"] == test_image_base64
-    
+
     def test_images_only_extracted_from_user_role(self):
         """
         What it does: Verifies that images are only extracted from user messages.
@@ -328,36 +315,30 @@ class TestConvertOpenAIMessagesToUnified:
         """
         print("Setup: Conversation with image in user message only...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
                 content=[
                     {"type": "text", "text": "Describe this image"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}
-                    }
-                ]
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}},
+                ],
             ),
-            ChatMessage(
-                role="assistant",
-                content="I can see a small image."
-            )
+            ChatMessage(role="assistant", content="I can see a small image."),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
-        
+
         print("Checking user message has images...")
         assert unified[0].images is not None
         assert len(unified[0].images) == 1
-        
+
         print("Checking assistant message has no images...")
         assert unified[1].images is None, "Assistant messages should not have images extracted"
-    
+
     def test_extracts_multiple_images_from_user_message(self):
         """
         What it does: Verifies extraction of multiple images from a single user message.
@@ -365,80 +346,65 @@ class TestConvertOpenAIMessagesToUnified:
         """
         print("Setup: User message with multiple images...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
                 content=[
                     {"type": "text", "text": "Compare these images"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/webp;base64,{test_image_base64}"}
-                    }
-                ]
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}},
+                    {"type": "image_url", "image_url": {"url": f"data:image/webp;base64,{test_image_base64}"}},
+                ],
             )
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result images count: {len(unified[0].images) if unified[0].images else 0}")
-        
+
         assert unified[0].images is not None
         assert len(unified[0].images) == 3, f"Expected 3 images, got {len(unified[0].images)}"
-        
+
         print("Checking image media types...")
         media_types = [img["media_type"] for img in unified[0].images]
         print(f"Media types: {media_types}")
         assert "image/jpeg" in media_types
         assert "image/png" in media_types
         assert "image/webp" in media_types
-    
+
     def test_counts_images_in_debug_log(self, caplog):
         """
         What it does: Verifies that image count is logged in debug message.
         Purpose: Ensure logging includes image statistics for debugging.
         """
         import logging
-        
+
         print("Setup: User message with images for logging test...")
         test_image_base64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
-        
+
         messages = [
             ChatMessage(
                 role="user",
                 content=[
                     {"type": "text", "text": "Analyze this"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}
-                    }
-                ]
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{test_image_base64}"}},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{test_image_base64}"}},
+                ],
             )
         ]
-        
+
         print("Action: Converting messages with logging enabled...")
         with caplog.at_level(logging.DEBUG):
             system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Log records: {[r.message for r in caplog.records]}")
-        
+
         # Check that images were extracted
         assert unified[0].images is not None
         assert len(unified[0].images) == 2
-        
+
         # Note: loguru doesn't integrate with caplog by default
         # The function logs "Converted X OpenAI messages: Y tool_calls, Z tool_results, W images"
         # We verify the images are extracted correctly, which proves the counting works
@@ -449,77 +415,77 @@ class TestConvertOpenAIMessagesToUnified:
 # Tests for convert_openai_tools_to_unified
 # ==================================================================================================
 
+
 class TestConvertOpenAIToolsToUnified:
     """Tests for convert_openai_tools_to_unified function."""
-    
+
     def test_returns_none_for_none(self):
         """
         What it does: Verifies handling of None.
         Purpose: Ensure None returns None.
         """
         print("Setup: None tools...")
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(None)
-        
+
         print(f"Result: {result}")
         assert result is None
-    
+
     def test_returns_none_for_empty_list(self):
         """
         What it does: Verifies handling of empty list.
         Purpose: Ensure empty list returns None.
         """
         print("Setup: Empty tools list...")
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified([])
-        
+
         print(f"Result: {result}")
         assert result is None
-    
+
     def test_converts_function_tool(self):
         """
         What it does: Verifies conversion of function tool.
         Purpose: Ensure Tool is converted to UnifiedTool.
         """
         print("Setup: Function tool...")
-        tools = [Tool(
-            type="function",
-            function=ToolFunction(
-                name="get_weather",
-                description="Get weather for a location",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}}
+        tools = [
+            Tool(
+                type="function",
+                function=ToolFunction(
+                    name="get_weather",
+                    description="Get weather for a location",
+                    parameters={"type": "object", "properties": {"location": {"type": "string"}}},
+                ),
             )
-        )]
-        
+        ]
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert len(result) == 1
         assert result[0].name == "get_weather"
         assert result[0].description == "Get weather for a location"
         assert result[0].input_schema == {"type": "object", "properties": {"location": {"type": "string"}}}
-    
+
     def test_skips_non_function_tools(self):
         """
         What it does: Verifies skipping of non-function tools.
         Purpose: Ensure only function tools are converted.
         """
         print("Setup: Non-function tool...")
-        tools = [Tool(
-            type="other_type",
-            function=ToolFunction(name="test", description="Test", parameters={})
-        )]
-        
+        tools = [Tool(type="other_type", function=ToolFunction(name="test", description="Test", parameters={}))]
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert result is None  # No function tools, so None
-    
+
     def test_converts_multiple_tools(self):
         """
         What it does: Verifies conversion of multiple tools.
@@ -529,61 +495,63 @@ class TestConvertOpenAIToolsToUnified:
         tools = [
             Tool(type="function", function=ToolFunction(name="tool1", description="Tool 1", parameters={})),
             Tool(type="function", function=ToolFunction(name="tool2", description="Tool 2", parameters={})),
-            Tool(type="function", function=ToolFunction(name="tool3", description="Tool 3", parameters={}))
+            Tool(type="function", function=ToolFunction(name="tool3", description="Tool 3", parameters={})),
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert len(result) == 3
         assert result[0].name == "tool1"
         assert result[1].name == "tool2"
         assert result[2].name == "tool3"
-    
+
     # ==================================================================================
     # Cursor IDE Flat Tool Format Tests (PR #49)
     # ==================================================================================
-    
+
     def test_converts_flat_format_tool(self):
         """
         What it does: Verifies conversion of flat format tool (Cursor-style).
         Purpose: Ensure Cursor IDE flat format is supported.
-        
+
         Cursor IDE sends tools in flat format:
         {"type": "function", "name": "...", "description": "...", "input_schema": {...}}
         instead of standard OpenAI nested format.
         """
         print("Setup: Flat format tool (Cursor-style)...")
-        tools = [Tool(
-            type="function",
-            name="cursor_tool",
-            description="A tool from Cursor IDE",
-            input_schema={"type": "object", "properties": {"param": {"type": "string"}}}
-        )]
-        
+        tools = [
+            Tool(
+                type="function",
+                name="cursor_tool",
+                description="A tool from Cursor IDE",
+                input_schema={"type": "object", "properties": {"param": {"type": "string"}}},
+            )
+        ]
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 1, Got {len(result) if result else 0}")
         assert result is not None
         assert len(result) == 1
-        
+
         print(f"Comparing name: Expected 'cursor_tool', Got '{result[0].name}'")
         assert result[0].name == "cursor_tool"
-        
+
         print(f"Comparing description: Expected 'A tool from Cursor IDE', Got '{result[0].description}'")
         assert result[0].description == "A tool from Cursor IDE"
-        
+
         print(f"Comparing input_schema: Got {result[0].input_schema}")
         assert result[0].input_schema == {"type": "object", "properties": {"param": {"type": "string"}}}
-    
+
     def test_converts_mixed_format_tools(self):
         """
         What it does: Verifies conversion of mixed format tools.
         Purpose: Ensure both standard and flat format can coexist in same request.
-        
+
         This simulates a scenario where some tools are in standard OpenAI format
         and some are in Cursor flat format (though unlikely in practice).
         """
@@ -593,115 +561,102 @@ class TestConvertOpenAIToolsToUnified:
             Tool(
                 type="function",
                 function=ToolFunction(
-                    name="standard_tool",
-                    description="Standard format",
-                    parameters={"type": "object"}
-                )
+                    name="standard_tool", description="Standard format", parameters={"type": "object"}
+                ),
             ),
             # Cursor flat format
-            Tool(
-                type="function",
-                name="flat_tool",
-                description="Flat format",
-                input_schema={"type": "object"}
-            )
+            Tool(type="function", name="flat_tool", description="Flat format", input_schema={"type": "object"}),
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 2, Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking standard format tool...")
         assert result[0].name == "standard_tool"
         assert result[0].description == "Standard format"
-        
+
         print("Checking flat format tool...")
         assert result[1].name == "flat_tool"
         assert result[1].description == "Flat format"
-    
+
     def test_standard_format_takes_priority(self):
         """
         What it does: Verifies that standard format takes priority over flat format.
         Purpose: Ensure function field is used when both formats are present (edge case).
-        
+
         This is an edge case where a tool has BOTH function and name fields.
         The standard format (function) should take priority.
         """
         print("Setup: Tool with BOTH formats (edge case)...")
-        tools = [Tool(
-            type="function",
-            # Standard format
-            function=ToolFunction(
-                name="standard_name",
-                description="Standard description",
-                parameters={"type": "object", "properties": {"a": {"type": "string"}}}
-            ),
-            # Flat format (should be ignored)
-            name="flat_name",
-            description="Flat description",
-            input_schema={"type": "object", "properties": {"b": {"type": "string"}}}
-        )]
-        
+        tools = [
+            Tool(
+                type="function",
+                # Standard format
+                function=ToolFunction(
+                    name="standard_name",
+                    description="Standard description",
+                    parameters={"type": "object", "properties": {"a": {"type": "string"}}},
+                ),
+                # Flat format (should be ignored)
+                name="flat_name",
+                description="Flat description",
+                input_schema={"type": "object", "properties": {"b": {"type": "string"}}},
+            )
+        ]
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
-        
+
         print("Checking that standard format was used (not flat)...")
         print(f"Comparing name: Expected 'standard_name', Got '{result[0].name}'")
         assert result[0].name == "standard_name"
-        
+
         print(f"Comparing description: Expected 'Standard description', Got '{result[0].description}'")
         assert result[0].description == "Standard description"
-        
+
         print(f"Comparing input_schema: Got {result[0].input_schema}")
         assert result[0].input_schema == {"type": "object", "properties": {"a": {"type": "string"}}}
-    
+
     def test_skips_invalid_tools(self):
         """
         What it does: Verifies that tools without function OR name are skipped.
         Purpose: Ensure invalid tools don't crash the conversion.
-        
+
         This tests the error handling when a tool has neither function nor name field.
         """
         print("Setup: Invalid tool (no function, no name)...")
         tools = [
             # Valid tool
-            Tool(
-                type="function",
-                function=ToolFunction(name="valid_tool", description="Valid")
-            ),
+            Tool(type="function", function=ToolFunction(name="valid_tool", description="Valid")),
             # Invalid tool (neither function nor name)
             Tool(type="function"),
             # Another valid tool
-            Tool(
-                type="function",
-                name="another_valid",
-                description="Also valid",
-                input_schema={}
-            )
+            Tool(type="function", name="another_valid", description="Also valid", input_schema={}),
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         print(f"Comparing count: Expected 2 (invalid skipped), Got {len(result)}")
         assert len(result) == 2
-        
+
         print("Checking that only valid tools were converted...")
         assert result[0].name == "valid_tool"
         assert result[1].name == "another_valid"
-    
+
     def test_backward_compat_standard_openai_tools(self):
         """
         What it does: Verifies that standard OpenAI format is not broken.
         Purpose: Regression test for existing clients (non-Cursor).
-        
+
         This is a critical backward compatibility test. After adding support for
         Cursor's flat format, we must ensure standard OpenAI format still works.
         """
@@ -714,28 +669,26 @@ class TestConvertOpenAIToolsToUnified:
                     description="Get weather for a location",
                     parameters={
                         "type": "object",
-                        "properties": {
-                            "location": {"type": "string", "description": "City name"}
-                        },
-                        "required": ["location"]
-                    }
-                )
+                        "properties": {"location": {"type": "string", "description": "City name"}},
+                        "required": ["location"],
+                    },
+                ),
             )
         ]
-        
+
         print("Action: Converting tools...")
         result = convert_openai_tools_to_unified(tools)
-        
+
         print(f"Result: {result}")
         assert result is not None
         assert len(result) == 1
-        
+
         print(f"Comparing name: Expected 'get_weather', Got '{result[0].name}'")
         assert result[0].name == "get_weather"
-        
+
         print(f"Comparing description: Expected 'Get weather for a location', Got '{result[0].description}'")
         assert result[0].description == "Get weather for a location"
-        
+
         print(f"Comparing input_schema: Got {result[0].input_schema}")
         assert result[0].input_schema["required"] == ["location"]
         assert result[0].input_schema["properties"]["location"]["type"] == "string"
@@ -745,9 +698,10 @@ class TestConvertOpenAIToolsToUnified:
 # Tests for build_kiro_payload
 # ==================================================================================================
 
+
 class TestToolMessageHandling:
     """Tests for OpenAI tool message (role="tool") handling."""
-    
+
     def test_converts_multiple_tool_messages_to_single_user_message(self):
         """
         What it does: Verifies merging of multiple tool messages into single user message.
@@ -757,26 +711,26 @@ class TestToolMessageHandling:
         messages = [
             ChatMessage(role="tool", content="Result 1", tool_call_id="call_1"),
             ChatMessage(role="tool", content="Result 2", tool_call_id="call_2"),
-            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3")
+            ChatMessage(role="tool", content="Result 3", tool_call_id="call_3"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         print(f"Comparing length: Expected 1, Got {len(unified)}")
         assert len(unified) == 1
         assert unified[0].role == "user"
-        
+
         print("Checking content contains all tool_results...")
         assert unified[0].tool_results is not None
         assert len(unified[0].tool_results) == 3
-        
+
         tool_use_ids = [item["tool_use_id"] for item in unified[0].tool_results]
         assert "call_1" in tool_use_ids
         assert "call_2" in tool_use_ids
         assert "call_3" in tool_use_ids
-    
+
     def test_assistant_tool_user_sequence(self):
         """
         What it does: Verifies assistant -> tool -> user sequence.
@@ -786,12 +740,12 @@ class TestToolMessageHandling:
         messages = [
             ChatMessage(role="assistant", content="I'll call a tool"),
             ChatMessage(role="tool", content="Tool output", tool_call_id="call_abc"),
-            ChatMessage(role="user", content="Thanks!")
+            ChatMessage(role="user", content="Thanks!"),
         ]
-        
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         # assistant stays, tool becomes user with tool_results, then user
         assert len(unified) == 3
@@ -799,37 +753,33 @@ class TestToolMessageHandling:
         assert unified[1].role == "user"
         assert unified[1].tool_results is not None
         assert unified[2].role == "user"
-    
+
     def test_tool_message_with_empty_content(self):
         """
         What it does: Verifies tool message with empty content.
         Purpose: Ensure empty result is replaced with "(empty result)".
         """
         print("Setup: Tool message with empty content...")
-        messages = [
-            ChatMessage(role="tool", content="", tool_call_id="call_empty")
-        ]
-        
+        messages = [ChatMessage(role="tool", content="", tool_call_id="call_empty")]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         assert len(unified) == 1
         assert unified[0].tool_results[0]["content"] == "(empty result)"
-    
+
     def test_tool_message_with_none_tool_call_id(self):
         """
         What it does: Verifies tool message without tool_call_id.
         Purpose: Ensure missing tool_call_id is replaced with empty string.
         """
         print("Setup: Tool message without tool_call_id...")
-        messages = [
-            ChatMessage(role="tool", content="Result", tool_call_id=None)
-        ]
-        
+        messages = [ChatMessage(role="tool", content="Result", tool_call_id=None)]
+
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
-        
+
         print(f"Result: {unified}")
         assert len(unified) == 1
         assert unified[0].tool_results[0]["tool_use_id"] == ""
@@ -839,14 +789,15 @@ class TestToolMessageHandling:
 # Tests for tool description handling
 # ==================================================================================================
 
+
 class TestToolDescriptionHandling:
     """Tests for handling empty/whitespace tool descriptions."""
-    
+
     def test_empty_description_replaced_with_placeholder(self):
         """
         What it does: Verifies replacement of empty description with placeholder.
         Purpose: Ensure empty description is replaced with "Tool: {name}".
-        
+
         This is a critical test for a Cline bug where tool focus_chain had
         empty description "", which caused a 400 error from Kiro API.
         """
@@ -854,25 +805,25 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="focus_chain",
-                    description="",
-                    parameters={"type": "object", "properties": {}}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="focus_chain", description="", parameters={"type": "object", "properties": {}}
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is replaced with placeholder...")
         context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Tool: focus_chain"
-    
+
     def test_whitespace_only_description_replaced_with_placeholder(self):
         """
         What it does: Verifies replacement of whitespace-only description with placeholder.
@@ -882,25 +833,20 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="whitespace_tool",
-                    description="   ",
-                    parameters={}
-                )
-            )]
+            tools=[
+                Tool(type="function", function=ToolFunction(name="whitespace_tool", description="   ", parameters={}))
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is replaced with placeholder...")
         context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Tool: whitespace_tool"
-    
+
     def test_none_description_replaced_with_placeholder(self):
         """
         What it does: Verifies replacement of None description with placeholder.
@@ -910,25 +856,20 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="none_desc_tool",
-                    description=None,
-                    parameters={}
-                )
-            )]
+            tools=[
+                Tool(type="function", function=ToolFunction(name="none_desc_tool", description=None, parameters={}))
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is replaced with placeholder...")
         context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Tool: none_desc_tool"
-    
+
     def test_non_empty_description_preserved(self):
         """
         What it does: Verifies preservation of non-empty description.
@@ -938,25 +879,23 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="get_weather",
-                    description="Get weather for a location",
-                    parameters={}
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(name="get_weather", description="Get weather for a location", parameters={}),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that description is preserved...")
         context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
         tool_spec = context["tools"][0]["toolSpecification"]
         assert tool_spec["description"] == "Get weather for a location"
-    
+
     def test_sanitizes_tool_parameters(self):
         """
         What it does: Verifies sanitization of parameters from problematic fields.
@@ -966,36 +905,33 @@ class TestToolDescriptionHandling:
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
             messages=[ChatMessage(role="user", content="Hello")],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="test_tool",
-                    description="Test tool",
-                    parameters={
-                        "type": "object",
-                        "properties": {},
-                        "required": [],
-                        "additionalProperties": False
-                    }
+            tools=[
+                Tool(
+                    type="function",
+                    function=ToolFunction(
+                        name="test_tool",
+                        description="Test tool",
+                        parameters={"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+                    ),
                 )
-            )]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking that parameters are sanitized...")
         context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
         input_schema = context["tools"][0]["toolSpecification"]["inputSchema"]["json"]
         assert "required" not in input_schema
         assert "additionalProperties" not in input_schema
-    
+
     def test_mixed_tools_with_empty_and_normal_descriptions(self):
         """
         What it does: Verifies handling of mixed tools list.
         Purpose: Ensure empty descriptions are replaced while normal ones are preserved.
-        
+
         This is a real scenario from Cline where most tools have
         normal descriptions, but focus_chain has an empty one.
         """
@@ -1006,34 +942,19 @@ class TestToolDescriptionHandling:
             tools=[
                 Tool(
                     type="function",
-                    function=ToolFunction(
-                        name="read_file",
-                        description="Read contents of a file",
-                        parameters={}
-                    )
+                    function=ToolFunction(name="read_file", description="Read contents of a file", parameters={}),
                 ),
+                Tool(type="function", function=ToolFunction(name="focus_chain", description="", parameters={})),
                 Tool(
                     type="function",
-                    function=ToolFunction(
-                        name="focus_chain",
-                        description="",
-                        parameters={}
-                    )
+                    function=ToolFunction(name="write_file", description="Write content to a file", parameters={}),
                 ),
-                Tool(
-                    type="function",
-                    function=ToolFunction(
-                        name="write_file",
-                        description="Write content to a file",
-                        parameters={}
-                    )
-                )
-            ]
+            ],
         )
-        
+
         print("Action: Building payload...")
         result = build_kiro_payload(request, "conv-123", "")
-        
+
         print(f"Result: {result}")
         print("Checking descriptions...")
         context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]
@@ -1047,12 +968,13 @@ class TestToolDescriptionHandling:
 # Integration tests for full flow
 # ==================================================================================================
 
+
 class TestBuildKiroPayloadToolCallsIntegration:
     """
     Integration tests for build_kiro_payload with tool_calls.
     Tests full flow from OpenAI format to Kiro format.
     """
-    
+
     def test_multiple_assistant_tool_calls_with_results(self):
         """
         What it does: Verifies full scenario with multiple assistant tool_calls and their results.
@@ -1070,25 +992,29 @@ class TestBuildKiroPayloadToolCallsIntegration:
                 ChatMessage(
                     role="assistant",
                     content=None,
-                    tool_calls=[{
-                        "id": "tooluse_first",
-                        "type": "function",
-                        "function": {"name": "shell", "arguments": '{"command": ["ls"]}'}
-                    }]
+                    tool_calls=[
+                        {
+                            "id": "tooluse_first",
+                            "type": "function",
+                            "function": {"name": "shell", "arguments": '{"command": ["ls"]}'},
+                        }
+                    ],
                 ),
                 # Second assistant with tool_call (consecutive!)
                 ChatMessage(
                     role="assistant",
                     content=None,
-                    tool_calls=[{
-                        "id": "tooluse_second",
-                        "type": "function",
-                        "function": {"name": "shell", "arguments": '{"command": ["pwd"]}'}
-                    }]
+                    tool_calls=[
+                        {
+                            "id": "tooluse_second",
+                            "type": "function",
+                            "function": {"name": "shell", "arguments": '{"command": ["pwd"]}'},
+                        }
+                    ],
                 ),
                 # Results of both tool_calls
                 ChatMessage(role="tool", content="file1.txt\nfile2.txt", tool_call_id="tooluse_first"),
-                ChatMessage(role="tool", content="/home/user", tool_call_id="tooluse_second")
+                ChatMessage(role="tool", content="/home/user", tool_call_id="tooluse_second"),
             ],
             # Tools must be defined for tool_results to be preserved
             tools=[
@@ -1097,41 +1023,41 @@ class TestBuildKiroPayloadToolCallsIntegration:
                     function=ToolFunction(
                         name="shell",
                         description="Run a shell command",
-                        parameters={"type": "object", "properties": {"command": {"type": "array"}}}
-                    )
+                        parameters={"type": "object", "properties": {"command": {"type": "array"}}},
+                    ),
                 )
-            ]
+            ],
         )
-        
+
         print("Action: Building Kiro payload...")
         result = build_kiro_payload(request, "conv-123", "arn:aws:test")
-        
+
         print(f"Result: {result}")
-        
+
         # Check history
         history = result["conversationState"].get("history", [])
         print(f"History: {history}")
-        
+
         # Should have userInputMessage and assistantResponseMessage in history
         assert len(history) >= 2, f"Expected at least 2 elements in history, got {len(history)}"
-        
+
         # Find assistantResponseMessage
         assistant_msgs = [h for h in history if "assistantResponseMessage" in h]
         print(f"Assistant messages in history: {assistant_msgs}")
         assert len(assistant_msgs) >= 1, "Should have at least one assistantResponseMessage"
-        
+
         # Check that assistantResponseMessage has both toolUses
         assistant_msg = assistant_msgs[0]["assistantResponseMessage"]
         tool_uses = assistant_msg.get("toolUses", [])
         print(f"ToolUses in assistant: {tool_uses}")
         print(f"Comparing toolUses count: Expected 2, Got {len(tool_uses)}")
         assert len(tool_uses) == 2, f"Should have 2 toolUses, got {len(tool_uses)}"
-        
+
         tool_use_ids = [tu["toolUseId"] for tu in tool_uses]
         print(f"ToolUse IDs: {tool_use_ids}")
         assert "tooluse_first" in tool_use_ids
         assert "tooluse_second" in tool_use_ids
-        
+
         # Check currentMessage contains toolResults
         current_msg = result["conversationState"]["currentMessage"]["userInputMessage"]
         context = current_msg.get("userInputMessageContext", {})
@@ -1139,13 +1065,13 @@ class TestBuildKiroPayloadToolCallsIntegration:
         print(f"ToolResults in currentMessage: {tool_results}")
         print(f"Comparing toolResults count: Expected 2, Got {len(tool_results)}")
         assert len(tool_results) == 2, f"Should have 2 toolResults, got {len(tool_results)}"
-        
+
         # Note: tool_results in Kiro payload use camelCase (toolUseId)
         tool_result_ids = [tr["toolUseId"] for tr in tool_results]
         print(f"ToolResult IDs: {tool_result_ids}")
         assert "tooluse_first" in tool_result_ids
         assert "tooluse_second" in tool_result_ids
-    
+
     def test_long_tool_description_added_to_system_prompt(self):
         """
         What it does: Verifies integration of long tool descriptions into payload.
@@ -1155,38 +1081,33 @@ class TestBuildKiroPayloadToolCallsIntegration:
         long_desc = "X" * 15000
         request = ChatCompletionRequest(
             model="claude-sonnet-4-5",
-            messages=[
-                ChatMessage(role="system", content="You are helpful"),
-                ChatMessage(role="user", content="Hello")
+            messages=[ChatMessage(role="system", content="You are helpful"), ChatMessage(role="user", content="Hello")],
+            tools=[
+                Tool(type="function", function=ToolFunction(name="long_tool", description=long_desc, parameters={}))
             ],
-            tools=[Tool(
-                type="function",
-                function=ToolFunction(
-                    name="long_tool",
-                    description=long_desc,
-                    parameters={}
-                )
-            )]
         )
-        
+
         print("Action: Building payload...")
-        with patch('kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH', 10000):
+        with patch("kiro.converters_core.TOOL_DESCRIPTION_MAX_LENGTH", 10000):
             result = build_kiro_payload(request, "conv-123", "")
-        
+
         print("Checking that system prompt contains tool documentation...")
         current_content = result["conversationState"]["currentMessage"]["userInputMessage"]["content"]
         assert "You are helpful" in current_content
         assert "## Tool: long_tool" in current_content
         assert long_desc in current_content
-        
+
         print("Checking that tool in context has reference description...")
-        tools_context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"]["tools"]
+        tools_context = result["conversationState"]["currentMessage"]["userInputMessage"]["userInputMessageContext"][
+            "tools"
+        ]
         assert "[Full documentation in system prompt" in tools_context[0]["toolSpecification"]["description"]
 
 
 # ==================================================================================================
 # Tests for _extract_images_from_tool_message (MCP screenshot support)
 # ==================================================================================================
+
 
 class TestExtractImagesFromToolMessage:
     """Tests for _extract_images_from_tool_message function."""
@@ -1199,10 +1120,7 @@ class TestExtractImagesFromToolMessage:
         print("Setup: Tool message with single image...")
         content = [
             {"type": "text", "text": "Screenshot captured"},
-            {
-                "type": "image_url",
-                "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="}
-            }
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="}},
         ]
 
         print("Action: Extracting images from tool message...")
@@ -1220,14 +1138,8 @@ class TestExtractImagesFromToolMessage:
         """
         print("Setup: Tool message with multiple images...")
         content = [
-            {
-                "type": "image_url",
-                "image_url": {"url": "data:image/png;base64,png_data"}
-            },
-            {
-                "type": "image_url",
-                "image_url": {"url": "data:image/jpeg;base64,jpeg_data"}
-            }
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,png_data"}},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,jpeg_data"}},
         ]
 
         print("Action: Extracting images from tool message...")
@@ -1246,9 +1158,7 @@ class TestExtractImagesFromToolMessage:
         Purpose: Ensure text-only tool messages don't produce spurious images.
         """
         print("Setup: Tool message with text only...")
-        content = [
-            {"type": "text", "text": "Operation completed successfully"}
-        ]
+        content = [{"type": "text", "text": "Operation completed successfully"}]
 
         print("Action: Extracting images from tool message...")
         result = _extract_images_from_tool_message(content)
@@ -1292,11 +1202,8 @@ class TestExtractImagesFromToolMessage:
         print("Setup: Tool message with text and image...")
         content = [
             {"type": "text", "text": "Screenshot captured"},
-            {
-                "type": "image_url",
-                "image_url": {"url": "data:image/png;base64,screenshot_data"}
-            },
-            {"type": "text", "text": "Analysis complete"}
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,screenshot_data"}},
+            {"type": "text", "text": "Analysis complete"},
         ]
 
         print("Action: Extracting images from tool message...")
@@ -1321,23 +1228,18 @@ class TestConvertOpenAIMessagesWithToolImages:
             ChatMessage(
                 role="assistant",
                 content="Taking screenshot",
-                tool_calls=[{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {"name": "screenshot", "arguments": "{}"}
-                }]
+                tool_calls=[
+                    {"id": "call_123", "type": "function", "function": {"name": "screenshot", "arguments": "{}"}}
+                ],
             ),
             ChatMessage(
                 role="tool",
                 tool_call_id="call_123",
                 content=[
                     {"type": "text", "text": "Screenshot captured"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": "data:image/png;base64,test_image"}
-                    }
-                ]
-            )
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,test_image"}},
+                ],
+            ),
         ]
 
         print("Action: Converting messages...")
@@ -1345,13 +1247,13 @@ class TestConvertOpenAIMessagesWithToolImages:
 
         print(f"Unified messages: {len(unified)}")
         print(f"Last message images: {unified[-1].images}")
-        
+
         # Tool messages are converted to user messages with tool_results
         assert len(unified) == 3
         assert unified[-1].role == "user"
         assert unified[-1].tool_results is not None
         assert len(unified[-1].tool_results) == 1
-        
+
         # Images should be present
         assert unified[-1].images is not None
         assert len(unified[-1].images) == 1
@@ -1367,17 +1269,13 @@ class TestConvertOpenAIMessagesWithToolImages:
             ChatMessage(
                 role="tool",
                 tool_call_id="call_1",
-                content=[
-                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,image1"}}
-                ]
+                content=[{"type": "image_url", "image_url": {"url": "data:image/png;base64,image1"}}],
             ),
             ChatMessage(
                 role="tool",
                 tool_call_id="call_2",
-                content=[
-                    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,image2"}}
-                ]
-            )
+                content=[{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,image2"}}],
+            ),
         ]
 
         print("Action: Converting messages...")
@@ -1385,11 +1283,11 @@ class TestConvertOpenAIMessagesWithToolImages:
 
         print(f"Unified messages: {len(unified)}")
         print(f"Images count: {len(unified[0].images) if unified[0].images else 0}")
-        
+
         # All tool messages should be merged into one user message
         assert len(unified) == 1
         assert unified[0].role == "user"
-        
+
         # Both images should be present
         assert unified[0].images is not None
         assert len(unified[0].images) == 2
@@ -1408,20 +1306,17 @@ class TestConvertOpenAIMessagesWithToolImages:
                 tool_call_id="call_123",
                 content=[
                     {"type": "text", "text": "Screenshot captured successfully"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": "data:image/png;base64,screenshot_data"}
-                    }
-                ]
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,screenshot_data"}},
+                ],
             ),
-            ChatMessage(role="user", content="What do you see?")
+            ChatMessage(role="user", content="What do you see?"),
         ]
 
         print("Action: Converting messages...")
         system_prompt, unified = convert_openai_messages_to_unified(messages)
 
         print(f"Unified messages: {len(unified)}")
-        
+
         # First message is user with tool_results and images
         assert unified[0].role == "user"
         assert unified[0].tool_results is not None
@@ -1429,7 +1324,7 @@ class TestConvertOpenAIMessagesWithToolImages:
         assert unified[0].images is not None
         assert len(unified[0].images) == 1
         assert unified[0].images[0]["data"] == "screenshot_data"
-        
+
         # Second message is regular user message
         assert unified[1].role == "user"
         assert unified[1].content == "What do you see?"

--- a/tests/unit/test_dashboard_request_logs.py
+++ b/tests/unit/test_dashboard_request_logs.py
@@ -24,9 +24,7 @@ def test_reports_total_and_window(dashboard):
 
     with dashboard._db() as conn:
         total = conn.execute("SELECT COUNT(*) FROM request_logs").fetchone()[0]
-        page = conn.execute(
-            "SELECT latency_ms FROM request_logs ORDER BY id DESC LIMIT ? OFFSET ?", (10, 0)
-        ).fetchall()
+        page = conn.execute("SELECT latency_ms FROM request_logs ORDER BY id DESC LIMIT ? OFFSET ?", (10, 0)).fetchall()
 
     assert total == 30
     # Newest first, so the highest seeded latency leads the first page.
@@ -37,9 +35,7 @@ def test_offset_pages_do_not_overlap(dashboard):
     _seed(dashboard, 12)
 
     with dashboard._db() as conn:
-        first = conn.execute(
-            "SELECT latency_ms FROM request_logs ORDER BY id DESC LIMIT ? OFFSET ?", (5, 0)
-        ).fetchall()
+        first = conn.execute("SELECT latency_ms FROM request_logs ORDER BY id DESC LIMIT ? OFFSET ?", (5, 0)).fetchall()
         second = conn.execute(
             "SELECT latency_ms FROM request_logs ORDER BY id DESC LIMIT ? OFFSET ?", (5, 5)
         ).fetchall()
@@ -95,10 +91,12 @@ def test_prune_is_safe_on_an_empty_table(dashboard):
 
 def test_rate_observations_round_trip(dashboard):
     now = time.time()
-    dashboard.record_rate_observations([
-        ("/creds/a.json", now - 10, 12, 0, "success"),
-        ("/creds/a.json", now - 5, 13, 1, "rate_limited"),
-    ])
+    dashboard.record_rate_observations(
+        [
+            ("/creds/a.json", now - 10, 12, 0, "success"),
+            ("/creds/a.json", now - 5, 13, 1, "rate_limited"),
+        ]
+    )
 
     rows = dashboard.load_rate_observations(now - 60)
 
@@ -110,10 +108,12 @@ def test_rate_observations_round_trip(dashboard):
 
 def test_rate_observations_outside_the_window_are_not_loaded(dashboard):
     now = time.time()
-    dashboard.record_rate_observations([
-        ("/creds/a.json", now - 100000, 40, 1, "rate_limited"),
-        ("/creds/a.json", now - 5, 13, 1, "rate_limited"),
-    ])
+    dashboard.record_rate_observations(
+        [
+            ("/creds/a.json", now - 100000, 40, 1, "rate_limited"),
+            ("/creds/a.json", now - 5, 13, 1, "rate_limited"),
+        ]
+    )
 
     rows = dashboard.load_rate_observations(now - 3600)
 
@@ -128,11 +128,13 @@ def test_recording_no_rate_observations_is_a_noop(dashboard):
 
 def test_prune_rate_observations_respects_retention(dashboard, monkeypatch):
     now = time.time()
-    dashboard.record_rate_observations([
-        ("/creds/a.json", now - 30 * 86400, 40, 1, "rate_limited"),
-        ("/creds/a.json", now - 2 * 86400, 20, 1, "rate_limited"),
-        ("/creds/a.json", now, 10, 0, "success"),
-    ])
+    dashboard.record_rate_observations(
+        [
+            ("/creds/a.json", now - 30 * 86400, 40, 1, "rate_limited"),
+            ("/creds/a.json", now - 2 * 86400, 20, 1, "rate_limited"),
+            ("/creds/a.json", now, 10, 0, "success"),
+        ]
+    )
 
     monkeypatch.setattr(dashboard, "RATE_OBSERVATION_RETENTION_DAYS", 7)
     removed = dashboard.prune_rate_observations()

--- a/tests/unit/test_debug_logger.py
+++ b/tests/unit/test_debug_logger.py
@@ -5,64 +5,67 @@ Unit-тесты для DebugLogger.
 Проверяет логику буферизации и записи debug логов в разных режимах.
 """
 
-import json
 import asyncio
 import base64
+import json
 import os
 import time
-import pytest
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 from loguru import logger as logger_module
-from unittest.mock import patch, MagicMock
 
 
 class TestDebugLoggerModeOff:
     """Тесты для режима DEBUG_MODE=off."""
-    
+
     def test_prepare_new_request_does_nothing(self, tmp_path):
         """
         Что он делает: Проверяет, что prepare_new_request ничего не делает в режиме off.
         Цель: Убедиться, что в режиме off директория не создаётся.
         """
         print("Настройка: Режим off...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
-            with patch('kiro.debug_logger.DEBUG_DIR', str(tmp_path / "debug_logs")):
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
+            with patch("kiro.debug_logger.DEBUG_DIR", str(tmp_path / "debug_logs")):
                 # Пересоздаём экземпляр с новыми настройками
                 from kiro.debug_logger import DebugLogger
+
                 logger = DebugLogger.__new__(DebugLogger)
                 logger._initialized = False
                 logger.__init__()
                 logger.debug_dir = tmp_path / "debug_logs"
-                
+
                 print("Действие: Вызов prepare_new_request...")
                 logger.prepare_new_request()
-                
-                print(f"Проверяем, что директория не создана...")
+
+                print("Проверяем, что директория не создана...")
                 assert not (tmp_path / "debug_logs").exists()
-    
+
     def test_log_request_body_does_nothing(self, tmp_path):
         """
         Что он делает: Проверяет, что log_request_body ничего не делает в режиме off.
         Цель: Убедиться, что данные не записываются.
         """
         print("Настройка: Режим off...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = tmp_path / "debug_logs"
-            
+
             print("Действие: Вызов log_request_body...")
             logger.log_request_body(b'{"test": "data"}')
-            
-            print(f"Проверяем, что файл не создан...")
+
+            print("Проверяем, что файл не создан...")
             assert not (tmp_path / "debug_logs" / "request_body.json").exists()
 
 
 class TestDebugLoggerModeAll:
     """Тесты для режима DEBUG_MODE=all."""
-    
+
     def test_prepare_new_request_clears_directory(self, tmp_path):
         """
         Что он делает: Проверяет, что prepare_new_request очищает директорию в режиме all.
@@ -73,22 +76,23 @@ class TestDebugLoggerModeAll:
         debug_dir.mkdir()
         old_file = debug_dir / "old_file.txt"
         old_file.write_text("old content")
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов prepare_new_request...")
             logger.prepare_new_request()
-            
-            print(f"Проверяем, что старый файл удалён...")
+
+            print("Проверяем, что старый файл удалён...")
             assert not old_file.exists()
-            print(f"Проверяем, что директория существует...")
+            print("Проверяем, что директория существует...")
             assert debug_dir.exists()
-    
+
     def test_log_request_body_writes_immediately(self, tmp_path):
         """
         Что он делает: Проверяет, что log_request_body пишет сразу в файл в режиме all.
@@ -97,26 +101,27 @@ class TestDebugLoggerModeAll:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body...")
             test_data = b'{"model": "test", "messages": []}'
             logger.log_request_body(test_data)
-            
-            print(f"Проверяем, что файл создан...")
+
+            print("Проверяем, что файл создан...")
             file_path = debug_dir / "request_body.json"
             assert file_path.exists()
-            
-            print(f"Проверяем содержимое файла...")
+
+            print("Проверяем содержимое файла...")
             content = json.loads(file_path.read_text())
             assert content["model"] == "test"
-    
+
     def test_log_kiro_request_body_writes_immediately(self, tmp_path):
         """
         Что он делает: Проверяет, что log_kiro_request_body пишет сразу в файл в режиме all.
@@ -125,22 +130,23 @@ class TestDebugLoggerModeAll:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_kiro_request_body...")
             test_data = b'{"conversationState": {}}'
             logger.log_kiro_request_body(test_data)
-            
-            print(f"Проверяем, что файл создан...")
+
+            print("Проверяем, что файл создан...")
             file_path = debug_dir / "kiro_request_body.json"
             assert file_path.exists()
-    
+
     def test_log_raw_chunk_appends_to_file(self, tmp_path):
         """
         Что он делает: Проверяет, что log_raw_chunk дописывает в файл в режиме all.
@@ -149,27 +155,28 @@ class TestDebugLoggerModeAll:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_raw_chunk дважды...")
-            logger.log_raw_chunk(b'chunk1')
-            logger.log_raw_chunk(b'chunk2')
-            
-            print(f"Проверяем содержимое файла...")
+            logger.log_raw_chunk(b"chunk1")
+            logger.log_raw_chunk(b"chunk2")
+
+            print("Проверяем содержимое файла...")
             file_path = debug_dir / "response_stream_raw.txt"
             content = file_path.read_bytes()
-            assert content == b'chunk1chunk2'
+            assert content == b"chunk1chunk2"
 
 
 class TestDebugLoggerModeErrors:
     """Тесты для режима DEBUG_MODE=errors."""
-    
+
     def test_log_request_body_buffers_data(self, tmp_path):
         """
         Что он делает: Проверяет, что log_request_body буферизует данные в режиме errors.
@@ -177,27 +184,28 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
+
         with (
-            patch('kiro.debug_logger.DEBUG_MODE', 'errors'),
-            patch('kiro.debug_logger.DEBUG_CAPTURE_CONTENT', True),
+            patch("kiro.debug_logger.DEBUG_MODE", "errors"),
+            patch("kiro.debug_logger.DEBUG_CAPTURE_CONTENT", True),
         ):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body...")
             test_data = b'{"test": "buffered"}'
             logger.log_request_body(test_data)
-            
-            print(f"Проверяем, что файл НЕ создан...")
+
+            print("Проверяем, что файл НЕ создан...")
             assert not debug_dir.exists()
-            
-            print(f"Проверяем, что данные в буфере...")
+
+            print("Проверяем, что данные в буфере...")
             assert logger._request_body_buffer == test_data
-    
+
     def test_flush_on_error_writes_buffers(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error записывает буферы в файлы.
@@ -205,38 +213,39 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors, заполняем буферы...")
         debug_dir = tmp_path / "debug_logs"
-        
+
         with (
-            patch('kiro.debug_logger.DEBUG_MODE', 'errors'),
-            patch('kiro.debug_logger.DEBUG_CAPTURE_CONTENT', True),
+            patch("kiro.debug_logger.DEBUG_MODE", "errors"),
+            patch("kiro.debug_logger.DEBUG_CAPTURE_CONTENT", True),
         ):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             # Заполняем буферы
             logger.log_request_body(b'{"request": "body"}')
             logger.log_kiro_request_body(b'{"kiro": "request"}')
-            logger.log_raw_chunk(b'raw_chunk')
-            logger.log_modified_chunk(b'modified_chunk')
-            
+            logger.log_raw_chunk(b"raw_chunk")
+            logger.log_modified_chunk(b"modified_chunk")
+
             print("Действие: Вызов flush_on_error...")
             logger.flush_on_error(400, "Bad Request")
-            
-            print(f"Проверяем, что все файлы созданы...")
+
+            print("Проверяем, что все файлы созданы...")
             assert (debug_dir / "request_body.json").exists()
             assert (debug_dir / "kiro_request_body.json").exists()
             assert (debug_dir / "response_stream_raw.txt").exists()
             assert (debug_dir / "response_stream_modified.txt").exists()
             assert (debug_dir / "error_info.json").exists()
-            
-            print(f"Проверяем error_info.json...")
+
+            print("Проверяем error_info.json...")
             error_info = json.loads((debug_dir / "error_info.json").read_text())
             assert error_info["status_code"] == 400
             assert error_info["error_message"] == "Bad Request"
-    
+
     def test_flush_on_error_clears_buffers(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error очищает буферы после записи.
@@ -244,25 +253,26 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             logger.log_request_body(b'{"test": "data"}')
-            
+
             print("Действие: Вызов flush_on_error...")
             logger.flush_on_error(500, "Error")
-            
-            print(f"Проверяем, что буферы очищены...")
+
+            print("Проверяем, что буферы очищены...")
             assert logger._request_body_buffer is None
             assert logger._kiro_request_body_buffer is None
             assert len(logger._raw_chunks_buffer) == 0
             assert len(logger._modified_chunks_buffer) == 0
-    
+
     def test_discard_buffers_clears_without_writing(self, tmp_path):
         """
         Что он делает: Проверяет, что discard_buffers очищает буферы без записи.
@@ -270,27 +280,28 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим errors, заполняем буферы...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             logger.log_request_body(b'{"test": "data"}')
-            logger.log_raw_chunk(b'chunk')
-            
+            logger.log_raw_chunk(b"chunk")
+
             print("Действие: Вызов discard_buffers...")
             logger.discard_buffers()
-            
-            print(f"Проверяем, что директория НЕ создана...")
+
+            print("Проверяем, что директория НЕ создана...")
             assert not debug_dir.exists()
-            
-            print(f"Проверяем, что буферы очищены...")
+
+            print("Проверяем, что буферы очищены...")
             assert logger._request_body_buffer is None
             assert len(logger._raw_chunks_buffer) == 0
-    
+
     def test_flush_on_error_writes_error_info_in_mode_all(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error записывает error_info.json в режиме all.
@@ -298,21 +309,22 @@ class TestDebugLoggerModeErrors:
         """
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов flush_on_error...")
             logger.flush_on_error(400, "Bad Request")
-            
-            print(f"Проверяем, что error_info.json создан...")
+
+            print("Проверяем, что error_info.json создан...")
             assert (debug_dir / "error_info.json").exists()
-            
-            print(f"Проверяем содержимое error_info.json...")
+
+            print("Проверяем содержимое error_info.json...")
             error_info = json.loads((debug_dir / "error_info.json").read_text())
             assert error_info["status_code"] == 400
             assert error_info["error_message"] == "Bad Request"
@@ -320,7 +332,7 @@ class TestDebugLoggerModeErrors:
 
 class TestDebugLoggerLogErrorInfo:
     """Тесты для метода log_error_info()."""
-    
+
     def test_log_error_info_writes_in_mode_all(self, tmp_path):
         """
         Что он делает: Проверяет, что log_error_info записывает файл в режиме all.
@@ -328,26 +340,27 @@ class TestDebugLoggerLogErrorInfo:
         """
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_error_info...")
             logger.log_error_info(500, "Internal Server Error")
-            
-            print(f"Проверяем, что error_info.json создан...")
+
+            print("Проверяем, что error_info.json создан...")
             error_file = debug_dir / "error_info.json"
             assert error_file.exists()
-            
-            print(f"Проверяем содержимое...")
+
+            print("Проверяем содержимое...")
             error_info = json.loads(error_file.read_text())
             assert error_info["status_code"] == 500
             assert error_info["error_message"] == "Internal Server Error"
-    
+
     def test_log_error_info_writes_in_mode_errors(self, tmp_path):
         """
         Что он делает: Проверяет, что log_error_info записывает файл в режиме errors.
@@ -355,21 +368,22 @@ class TestDebugLoggerLogErrorInfo:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_error_info...")
             logger.log_error_info(404, "Not Found")
-            
-            print(f"Проверяем, что error_info.json создан...")
+
+            print("Проверяем, что error_info.json создан...")
             error_file = debug_dir / "error_info.json"
             assert error_file.exists()
-    
+
     def test_log_error_info_does_nothing_in_mode_off(self, tmp_path):
         """
         Что он делает: Проверяет, что log_error_info ничего не делает в режиме off.
@@ -377,103 +391,109 @@ class TestDebugLoggerLogErrorInfo:
         """
         print("Настройка: Режим off...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_error_info...")
             logger.log_error_info(500, "Error")
-            
-            print(f"Проверяем, что директория НЕ создана...")
+
+            print("Проверяем, что директория НЕ создана...")
             assert not debug_dir.exists()
 
 
 class TestDebugLoggerHelperMethods:
     """Тесты для вспомогательных методов DebugLogger."""
-    
+
     def test_is_enabled_returns_true_for_errors(self):
         """
         Что он делает: Проверяет _is_enabled() для режима errors.
         Цель: Убедиться, что режим errors считается включённым.
         """
         print("Настройка: Режим errors...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_enabled()...")
+
+            print("Проверяем _is_enabled()...")
             assert logger._is_enabled() is True
-    
+
     def test_is_enabled_returns_true_for_all(self):
         """
         Что он делает: Проверяет _is_enabled() для режима all.
         Цель: Убедиться, что режим all считается включённым.
         """
         print("Настройка: Режим all...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_enabled()...")
+
+            print("Проверяем _is_enabled()...")
             assert logger._is_enabled() is True
-    
+
     def test_is_enabled_returns_false_for_off(self):
         """
         Что он делает: Проверяет _is_enabled() для режима off.
         Цель: Убедиться, что режим off считается выключенным.
         """
         print("Настройка: Режим off...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'off'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "off"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_enabled()...")
+
+            print("Проверяем _is_enabled()...")
             assert logger._is_enabled() is False
-    
+
     def test_is_immediate_write_returns_true_for_all(self):
         """
         Что он делает: Проверяет _is_immediate_write() для режима all.
         Цель: Убедиться, что режим all пишет сразу.
         """
         print("Настройка: Режим all...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_immediate_write()...")
+
+            print("Проверяем _is_immediate_write()...")
             assert logger._is_immediate_write() is True
-    
+
     def test_is_immediate_write_returns_false_for_errors(self):
         """
         Что он делает: Проверяет _is_immediate_write() для режима errors.
         Цель: Убедиться, что режим errors буферизует.
         """
         print("Настройка: Режим errors...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
-            
-            print(f"Проверяем _is_immediate_write()...")
+
+            print("Проверяем _is_immediate_write()...")
             assert logger._is_immediate_write() is False
 
 
 class TestDebugLoggerJsonHandling:
     """Тесты для обработки JSON в DebugLogger."""
-    
+
     def test_log_request_body_formats_json_pretty(self, tmp_path):
         """
         Что он делает: Проверяет, что JSON форматируется красиво.
@@ -482,22 +502,23 @@ class TestDebugLoggerJsonHandling:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body с JSON...")
             logger.log_request_body(b'{"key":"value"}')
-            
-            print(f"Проверяем форматирование...")
+
+            print("Проверяем форматирование...")
             content = (debug_dir / "request_body.json").read_text()
             # Должен быть отформатирован с отступами
             assert "  " in content or "\n" in content
-    
+
     def test_log_request_body_handles_invalid_json(self, tmp_path):
         """
         Что он делает: Проверяет обработку невалидного JSON.
@@ -506,26 +527,27 @@ class TestDebugLoggerJsonHandling:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             logger = DebugLogger.__new__(DebugLogger)
             logger._initialized = False
             logger.__init__()
             logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов log_request_body с невалидным JSON...")
-            invalid_data = b'not a json {{'
+            invalid_data = b"not a json {{"
             logger.log_request_body(invalid_data)
-            
-            print(f"Проверяем, что данные записаны как есть...")
+
+            print("Проверяем, что данные записаны как есть...")
             content = (debug_dir / "request_body.json").read_bytes()
             assert content == invalid_data
 
 
 class TestDebugLoggerAppLogsCapture:
     """Тесты для захвата логов приложения (app_logs.txt)."""
-    
+
     def test_prepare_new_request_sets_up_log_capture(self, tmp_path):
         """
         Что он делает: Проверяет, что prepare_new_request настраивает захват логов.
@@ -533,23 +555,24 @@ class TestDebugLoggerAppLogsCapture:
         """
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             print("Действие: Вызов prepare_new_request...")
             dbg_logger.prepare_new_request()
-            
-            print(f"Проверяем, что sink создан...")
+
+            print("Проверяем, что sink создан...")
             assert dbg_logger._loguru_sink_id is not None
-            
+
             # Очистка
             dbg_logger._clear_app_logs_buffer()
-    
+
     def test_flush_on_error_writes_app_logs_in_mode_errors(self, tmp_path):
         """
         Что он делает: Проверяет, что flush_on_error записывает app_logs.txt в режиме errors.
@@ -557,32 +580,31 @@ class TestDebugLoggerAppLogsCapture:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
+
         with (
-            patch('kiro.debug_logger.DEBUG_MODE', 'errors'),
-            patch('kiro.debug_logger.DEBUG_CAPTURE_CONTENT', True),
+            patch("kiro.debug_logger.DEBUG_MODE", "errors"),
+            patch("kiro.debug_logger.DEBUG_CAPTURE_CONTENT", True),
         ):
             from kiro.debug_logger import DebugLogger
-            from loguru import logger as loguru_logger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
-            
+
             # Добавляем данные в буфер чтобы flush сработал
             dbg_logger.log_request_body(b'{"test": "data"}')
-            
+
             # Пишем тестовый лог напрямую в буфер (имитация)
             dbg_logger._app_logs_buffer.write("Test log message\n")
-            
+
             print("Действие: Вызов flush_on_error...")
             dbg_logger.flush_on_error(500, "Test Error")
-            
-            print(f"Проверяем, что app_logs.txt создан в bundle...")
+
+            print("Проверяем, что app_logs.txt создан в bundle...")
             captures = [
                 path
                 for path in (debug_dir / "failures").iterdir()
@@ -591,11 +613,11 @@ class TestDebugLoggerAppLogsCapture:
             assert len(captures) == 1
             app_logs_file = captures[0] / "app_logs.txt"
             assert app_logs_file.exists()
-            
-            print(f"Проверяем содержимое...")
+
+            print("Проверяем содержимое...")
             content = app_logs_file.read_text()
             assert "Test log message" in content
-    
+
     def test_discard_buffers_saves_logs_in_mode_all(self, tmp_path):
         """
         Что он делает: Проверяет, что discard_buffers сохраняет логи в режиме all.
@@ -604,32 +626,32 @@ class TestDebugLoggerAppLogsCapture:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
-            
+
             # Пишем тестовый лог напрямую в буфер
             dbg_logger._app_logs_buffer.write("Success log message\n")
-            
+
             print("Действие: Вызов discard_buffers...")
             dbg_logger.discard_buffers()
-            
-            print(f"Проверяем, что app_logs.txt создан...")
+
+            print("Проверяем, что app_logs.txt создан...")
             app_logs_file = debug_dir / "app_logs.txt"
             assert app_logs_file.exists()
-            
-            print(f"Проверяем содержимое...")
+
+            print("Проверяем содержимое...")
             content = app_logs_file.read_text()
             assert "Success log message" in content
-    
+
     def test_discard_buffers_does_not_save_logs_in_mode_errors(self, tmp_path):
         """
         Что он делает: Проверяет, что discard_buffers НЕ сохраняет логи в режиме errors.
@@ -637,52 +659,52 @@ class TestDebugLoggerAppLogsCapture:
         """
         print("Настройка: Режим errors...")
         debug_dir = tmp_path / "debug_logs"
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "errors"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
-            
+
             # Пишем тестовый лог напрямую в буфер
             dbg_logger._app_logs_buffer.write("Should not be saved\n")
-            
+
             print("Действие: Вызов discard_buffers...")
             dbg_logger.discard_buffers()
-            
-            print(f"Проверяем, что директория НЕ создана...")
+
+            print("Проверяем, что директория НЕ создана...")
             assert not debug_dir.exists()
-    
+
     def test_clear_app_logs_buffer_removes_sink(self, tmp_path):
         """
         Что он делает: Проверяет, что _clear_app_logs_buffer удаляет sink.
         Цель: Убедиться, что sink корректно удаляется.
         """
         print("Настройка: Режим all...")
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = tmp_path / "debug_logs"
-            
+
             # Настраиваем захват логов
             dbg_logger.prepare_new_request()
             sink_id = dbg_logger._loguru_sink_id
             assert sink_id is not None
-            
+
             print("Действие: Вызов _clear_app_logs_buffer...")
             dbg_logger._clear_app_logs_buffer()
-            
-            print(f"Проверяем, что sink_id сброшен...")
+
+            print("Проверяем, что sink_id сброшен...")
             assert dbg_logger._loguru_sink_id is None
-    
+
     def test_app_logs_not_saved_when_empty(self, tmp_path):
         """
         Что он делает: Проверяет, что пустые логи не создают файл.
@@ -691,21 +713,21 @@ class TestDebugLoggerAppLogsCapture:
         print("Настройка: Режим all...")
         debug_dir = tmp_path / "debug_logs"
         debug_dir.mkdir()
-        
-        with patch('kiro.debug_logger.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_logger.DEBUG_MODE", "all"):
             from kiro.debug_logger import DebugLogger
-            
+
             dbg_logger = DebugLogger.__new__(DebugLogger)
             dbg_logger._initialized = False
             dbg_logger.__init__()
             dbg_logger.debug_dir = debug_dir
-            
+
             # НЕ пишем ничего в буфер
-            
+
             print("Действие: Вызов _write_app_logs_to_file...")
             dbg_logger._write_app_logs_to_file()
-            
-            print(f"Проверяем, что app_logs.txt НЕ создан...")
+
+            print("Проверяем, что app_logs.txt НЕ создан...")
             app_logs_file = debug_dir / "app_logs.txt"
             assert not app_logs_file.exists()
 
@@ -792,9 +814,7 @@ class TestDebugLoggerRedaction:
             capture = logger.flush_on_error(500, "stream failure")
 
         assert capture is not None
-        stored = b"\n".join(
-            path.read_bytes() for path in capture.iterdir() if path.is_file()
-        )
+        stored = b"\n".join(path.read_bytes() for path in capture.iterdir() if path.is_file())
         assert b"preserved prompt" in stored
         assert b"secret-token" not in stored
         assert b"refresh-secret" not in stored
@@ -811,24 +831,22 @@ class TestDebugLoggerRedaction:
         ):
             logger = _capture_logger(debug_dir)
             logger.prepare_new_request()
-            logger.log_request_body(json.dumps({
-                "accessToken": "camel-access-secret",
-                "refreshToken": "camel-refresh-secret",
-                "clientSecret": "camel-client-secret",
-                "password": "password-secret",
-            }).encode())
-            logger.log_raw_chunk(
-                b'[MCP REQUEST] {"accessToken":"mcp-access-secret"}'
+            logger.log_request_body(
+                json.dumps(
+                    {
+                        "accessToken": "camel-access-secret",
+                        "refreshToken": "camel-refresh-secret",
+                        "clientSecret": "camel-client-secret",
+                        "password": "password-secret",
+                    }
+                ).encode()
             )
-            logger.log_parsed_event({
-                "thinking_signature": "opaque-thinking-signature"
-            })
+            logger.log_raw_chunk(b'[MCP REQUEST] {"accessToken":"mcp-access-secret"}')
+            logger.log_parsed_event({"thinking_signature": "opaque-thinking-signature"})
             capture = logger.flush_on_error(500, "stream failure")
 
         assert capture is not None
-        stored = b"\n".join(
-            path.read_bytes() for path in capture.iterdir() if path.is_file()
-        )
+        stored = b"\n".join(path.read_bytes() for path in capture.iterdir() if path.is_file())
         for secret in (
             b"camel-access-secret",
             b"camel-refresh-secret",
@@ -891,9 +909,7 @@ class TestDebugLoggerBounds:
             capture = logger.flush_on_error(500, "stream failure")
 
         assert capture is not None
-        total_size = sum(
-            path.stat().st_size for path in capture.iterdir() if path.is_file()
-        )
+        total_size = sum(path.stat().st_size for path in capture.iterdir() if path.is_file())
         assert total_size <= 70000
         manifest = json.loads((capture / "manifest.json").read_text())
         assert manifest["artifacts"]["upstream_chunks.jsonl"]["truncated"] is True
@@ -914,9 +930,7 @@ class TestDebugLoggerBounds:
             capture = logger.flush_on_error(500, "stream failure")
 
         assert capture is not None
-        total_size = sum(
-            path.stat().st_size for path in capture.iterdir() if path.is_file()
-        )
+        total_size = sum(path.stat().st_size for path in capture.iterdir() if path.is_file())
         assert total_size <= 70000
 
 
@@ -1037,19 +1051,13 @@ class TestDebugLoggerPersistence:
                 captures.append(logger.flush_on_error(500, f"failure-{index}"))
 
         completed = [
-            path
-            for path in (debug_dir / "failures").iterdir()
-            if path.is_dir() and not path.name.startswith(".tmp-")
+            path for path in (debug_dir / "failures").iterdir() if path.is_dir() and not path.name.startswith(".tmp-")
         ]
         assert len(completed) == 2
         assert not list((debug_dir / "failures").glob(".tmp-*"))
         for capture in completed:
             assert capture.stat().st_mode & 0o777 == 0o700
-            assert all(
-                path.stat().st_mode & 0o777 == 0o600
-                for path in capture.iterdir()
-                if path.is_file()
-            )
+            assert all(path.stat().st_mode & 0o777 == 0o600 for path in capture.iterdir() if path.is_file())
         assert captures[-1] in completed
 
 
@@ -1092,19 +1100,13 @@ class TestDebugLoggerReplay:
             logger = _capture_logger(debug_dir)
             logger.prepare_new_request()
             logger.log_request_body(b'{"model":"claude-opus-5"}')
-            logger.log_modified_chunk(
-                b'data: {"choices":[{"delta":{},'
-                b'"finish_reason":"stop"}]}\n\n'
-            )
+            logger.log_modified_chunk(b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n')
             logger.log_modified_chunk(b"data: [DONE]\n\n")
             capture = logger.flush_on_error(500, "historical failure")
 
         assert capture is not None
         replay = json.loads((capture / "replay.json").read_text())
-        decoded = b"".join(
-            base64.b64decode(record["payload_base64"])
-            for record in replay["translated_sse"]
-        )
+        decoded = b"".join(base64.b64decode(record["payload_base64"]) for record in replay["translated_sse"])
         assert replay["validation"] == {"valid": True, "failure": None}
         assert b'"finish_reason":"stop"' in decoded
         assert b"data: [DONE]" in decoded

--- a/tests/unit/test_debug_middleware.py
+++ b/tests/unit/test_debug_middleware.py
@@ -5,15 +5,16 @@ Unit tests for DebugLoggerMiddleware.
 Tests debug logging initialization at the middleware level.
 """
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 from starlette.requests import Request
 from starlette.responses import Response
 
 
 class TestDebugLoggerMiddlewareEndpointFiltering:
     """Tests for endpoint filtering in middleware."""
-    
+
     @pytest.mark.asyncio
     async def test_skips_health_endpoint(self):
         """
@@ -21,34 +22,34 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure health checks are not logged.
         """
         print("Setup: Creating mock request for /health...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             # Mock request
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/health"
-            
+
             # Mock call_next
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
+
             # Mock debug_logger at the source module
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /health...")
                 response = await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-                
+
                 print("Verifying call_next was called...")
                 mock_call_next.assert_called_once_with(mock_request)
-                
+
                 print(f"Comparing response: Expected {mock_response}, Got {response}")
                 assert response == mock_response
-    
+
     @pytest.mark.asyncio
     async def test_skips_docs_endpoint(self):
         """
@@ -56,25 +57,25 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure documentation is not logged.
         """
         print("Setup: Creating mock request for /docs...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/docs"
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /docs...")
-                response = await middleware.dispatch(mock_request, mock_call_next)
-                
+                await middleware.dispatch(mock_request, mock_call_next)
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_skips_root_endpoint(self):
         """
@@ -82,25 +83,25 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure root endpoint is not logged.
         """
         print("Setup: Creating mock request for /...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/"
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_processes_chat_completions_endpoint(self):
         """
@@ -108,29 +109,29 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure OpenAI endpoint is logged.
         """
         print("Setup: Creating mock request for /v1/chat/completions...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(return_value=b'{"model": "test"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /v1/chat/completions...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-                
+
                 print("Verifying log_request_body was called...")
                 mock_logger.log_request_body.assert_called_once_with(b'{"model": "test"}')
-    
+
     @pytest.mark.asyncio
     async def test_processes_messages_endpoint(self):
         """
@@ -138,30 +139,30 @@ class TestDebugLoggerMiddlewareEndpointFiltering:
         Purpose: Ensure Anthropic endpoint is logged.
         """
         print("Setup: Creating mock request for /v1/messages...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/messages"
             mock_request.body = AsyncMock(return_value=b'{"model": "claude"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch for /v1/messages...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
 
 
 class TestDebugLoggerMiddlewareModeHandling:
     """Tests for DEBUG_MODE handling in middleware."""
-    
+
     @pytest.mark.asyncio
     async def test_skips_when_debug_mode_off(self):
         """
@@ -169,28 +170,28 @@ class TestDebugLoggerMiddlewareModeHandling:
         Purpose: Ensure logging is disabled in off mode.
         """
         print("Setup: DEBUG_MODE=off...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'off'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "off"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with DEBUG_MODE=off...")
-                response = await middleware.dispatch(mock_request, mock_call_next)
-                
+                await middleware.dispatch(mock_request, mock_call_next)
+
                 print("Verifying prepare_new_request was NOT called...")
                 mock_logger.prepare_new_request.assert_not_called()
-                
+
                 print("Verifying call_next was called...")
                 mock_call_next.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_processes_when_debug_mode_errors(self):
         """
@@ -198,26 +199,26 @@ class TestDebugLoggerMiddlewareModeHandling:
         Purpose: Ensure errors mode activates logging.
         """
         print("Setup: DEBUG_MODE=errors...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'errors'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "errors"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with DEBUG_MODE=errors...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_processes_when_debug_mode_all(self):
         """
@@ -225,30 +226,30 @@ class TestDebugLoggerMiddlewareModeHandling:
         Purpose: Ensure all mode activates logging.
         """
         print("Setup: DEBUG_MODE=all...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/messages"
             mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with DEBUG_MODE=all...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
 
 
 class TestDebugLoggerMiddlewareErrorHandling:
     """Tests for error handling in middleware."""
-    
+
     @pytest.mark.asyncio
     async def test_handles_body_read_error_gracefully(self):
         """
@@ -256,32 +257,32 @@ class TestDebugLoggerMiddlewareErrorHandling:
         Purpose: Ensure body read errors don't break the request.
         """
         print("Setup: Simulating body read error...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(side_effect=Exception("Body read error"))
-            
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with body read error...")
-                response = await middleware.dispatch(mock_request, mock_call_next)
-                
+                await middleware.dispatch(mock_request, mock_call_next)
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-                
+
                 print("Verifying log_request_body was NOT called (due to error)...")
                 mock_logger.log_request_body.assert_not_called()
-                
+
                 print("Verifying call_next was called (request continued)...")
                 mock_call_next.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_skips_empty_body(self):
         """
@@ -289,33 +290,33 @@ class TestDebugLoggerMiddlewareErrorHandling:
         Purpose: Ensure empty requests don't create unnecessary logs.
         """
         print("Setup: Creating request with empty body...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
-            mock_request.body = AsyncMock(return_value=b'')  # Empty body
-            
+            mock_request.body = AsyncMock(return_value=b"")  # Empty body
+
             mock_response = MagicMock(spec=Response)
             mock_call_next = AsyncMock(return_value=mock_response)
-            
-            with patch('kiro.debug_logger.debug_logger') as mock_logger:
+
+            with patch("kiro.debug_logger.debug_logger") as mock_logger:
                 print("Action: Calling dispatch with empty body...")
                 await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print("Verifying prepare_new_request was called...")
                 mock_logger.prepare_new_request.assert_called_once()
-                
+
                 print("Verifying log_request_body was NOT called (body is empty)...")
                 mock_logger.log_request_body.assert_not_called()
 
 
 class TestDebugLoggerMiddlewareResponsePassthrough:
     """Tests for transparent response passthrough."""
-    
+
     @pytest.mark.asyncio
     async def test_returns_response_from_call_next(self):
         """
@@ -323,24 +324,24 @@ class TestDebugLoggerMiddlewareResponsePassthrough:
         Purpose: Ensure middleware doesn't modify the response.
         """
         print("Setup: Creating mock response...")
-        
-        with patch('kiro.debug_middleware.DEBUG_MODE', 'all'):
+
+        with patch("kiro.debug_middleware.DEBUG_MODE", "all"):
             from kiro.debug_middleware import DebugLoggerMiddleware
-            
+
             middleware = DebugLoggerMiddleware(app=MagicMock())
-            
+
             mock_request = MagicMock(spec=Request)
             mock_request.url.path = "/v1/chat/completions"
             mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-            
+
             expected_response = MagicMock(spec=Response)
             expected_response.status_code = 200
             mock_call_next = AsyncMock(return_value=expected_response)
-            
-            with patch('kiro.debug_logger.debug_logger'):
+
+            with patch("kiro.debug_logger.debug_logger"):
                 print("Action: Calling dispatch...")
                 actual_response = await middleware.dispatch(mock_request, mock_call_next)
-                
+
                 print(f"Comparing response: Expected {expected_response}, Got {actual_response}")
                 assert actual_response == expected_response
                 assert actual_response.status_code == 200
@@ -348,7 +349,7 @@ class TestDebugLoggerMiddlewareResponsePassthrough:
 
 class TestLoggedEndpointsConstant:
     """Tests for LOGGED_ENDPOINTS constant."""
-    
+
     def test_logged_endpoints_contains_chat_completions(self):
         """
         What it does: Verifies that LOGGED_ENDPOINTS contains /v1/chat/completions.
@@ -356,10 +357,10 @@ class TestLoggedEndpointsConstant:
         """
         print("Checking LOGGED_ENDPOINTS...")
         from kiro.debug_middleware import LOGGED_ENDPOINTS
-        
+
         print(f"LOGGED_ENDPOINTS contents: {LOGGED_ENDPOINTS}")
         assert "/v1/chat/completions" in LOGGED_ENDPOINTS
-    
+
     def test_logged_endpoints_contains_messages(self):
         """
         What it does: Verifies that LOGGED_ENDPOINTS contains /v1/messages.
@@ -367,10 +368,10 @@ class TestLoggedEndpointsConstant:
         """
         print("Checking LOGGED_ENDPOINTS...")
         from kiro.debug_middleware import LOGGED_ENDPOINTS
-        
+
         print(f"LOGGED_ENDPOINTS contents: {LOGGED_ENDPOINTS}")
         assert "/v1/messages" in LOGGED_ENDPOINTS
-    
+
     def test_logged_endpoints_is_frozenset(self):
         """
         What it does: Verifies that LOGGED_ENDPOINTS is a frozenset.
@@ -378,6 +379,6 @@ class TestLoggedEndpointsConstant:
         """
         print("Checking LOGGED_ENDPOINTS type...")
         from kiro.debug_middleware import LOGGED_ENDPOINTS
-        
+
         print(f"LOGGED_ENDPOINTS type: {type(LOGGED_ENDPOINTS)}")
         assert isinstance(LOGGED_ENDPOINTS, frozenset)

--- a/tests/unit/test_debug_replay.py
+++ b/tests/unit/test_debug_replay.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kiro.debug_replay import main
 from kiro.debug_sanitize import sanitize_bytes, sanitize_value
 from kiro.sse_validation import (
@@ -46,9 +47,7 @@ def _write_replay(
         "client_request": {},
         "kiro_request": {},
         "upstream_chunks": [],
-        "translated_sse": [
-            _record(index, chunk) for index, chunk in enumerate(chunks)
-        ],
+        "translated_sse": [_record(index, chunk) for index, chunk in enumerate(chunks)],
     }
     path.write_text(json.dumps(replay))
     return replay
@@ -79,34 +78,34 @@ class TestDebugReplay:
 
     def test_openai_rejects_content_after_finish_reason(self):
         validator = OpenAIStreamValidator()
-        validator.accept({
-            "choices": [
-                {
-                    "delta": {},
-                    "finish_reason": "stop",
-                }
-            ]
-        })
-
-        with pytest.raises(StreamProtocolError):
-            validator.accept({
+        validator.accept(
+            {
                 "choices": [
                     {
-                        "delta": {"content": "late"},
-                        "finish_reason": None,
+                        "delta": {},
+                        "finish_reason": "stop",
                     }
                 ]
-            })
+            }
+        )
+
+        with pytest.raises(StreamProtocolError):
+            validator.accept(
+                {
+                    "choices": [
+                        {
+                            "delta": {"content": "late"},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            )
 
     @pytest.mark.asyncio
     async def test_fixed_translator_replays_capture_without_order_failure(
         self,
     ):
-        fixture_path = (
-            Path(__file__).parents[1]
-            / "fixtures"
-            / "invalid_assistant_content_event_order.json"
-        )
+        fixture_path = Path(__file__).parents[1] / "fixtures" / "invalid_assistant_content_event_order.json"
         fixture = json.loads(fixture_path.read_text())
 
         async def raw_events(*args, **kwargs):
@@ -131,25 +130,16 @@ class TestDebugReplay:
             ):
                 chunks.append(chunk)
 
-        records = [
-            _record(index, chunk)
-            for index, chunk in enumerate(chunks)
-        ]
+        records = [_record(index, chunk) for index, chunk in enumerate(chunks)]
         validate_anthropic_records(records)
 
     def test_historical_fixture_replays_invalid_order(self, capsys):
-        fixture = (
-            Path(__file__).parents[1]
-            / "fixtures"
-            / "invalid_assistant_content_event_order.json"
-        )
+        fixture = Path(__file__).parents[1] / "fixtures" / "invalid_assistant_content_event_order.json"
 
         exit_code = main(["validate", str(fixture)])
 
         assert exit_code == 3
-        assert capsys.readouterr().err.strip() == (
-            "Invalid assistant content event order"
-        )
+        assert capsys.readouterr().err.strip() == ("Invalid assistant content event order")
 
     def test_replays_invalid_assistant_content_order(
         self,
@@ -183,9 +173,7 @@ class TestDebugReplay:
         exit_code = main(["validate", str(replay_path)])
 
         assert exit_code == 3
-        assert capsys.readouterr().err.strip() == (
-            "Invalid assistant content event order"
-        )
+        assert capsys.readouterr().err.strip() == ("Invalid assistant content event order")
 
     def test_valid_capture_exits_cleanly(self, tmp_path):
         replay_path = tmp_path / "replay.json"
@@ -247,14 +235,16 @@ class TestDebugReplay:
         ]
         _write_replay(replay_path, chunks)
 
-        exit_code = main([
-            "replay",
-            str(replay_path),
-            "--protocol",
-            "anthropic",
-            "--output",
-            str(output),
-        ])
+        exit_code = main(
+            [
+                "replay",
+                str(replay_path),
+                "--protocol",
+                "anthropic",
+                "--output",
+                str(output),
+            ]
+        )
 
         assert exit_code == 3
         assert output.read_text() == "".join(chunks)
@@ -268,11 +258,13 @@ class TestDebugReplay:
         output = tmp_path / "fixture.json"
         _write_replay(replay_path, [], capture_content=True)
 
-        exit_code = main([
-            "export-fixture",
-            str(replay_path),
-            str(output),
-        ])
+        exit_code = main(
+            [
+                "export-fixture",
+                str(replay_path),
+                str(output),
+            ]
+        )
 
         assert exit_code == 2
         assert "content enabled" in capsys.readouterr().err
@@ -290,11 +282,13 @@ class TestDebugReplay:
             ["Authorization: Bearer encoded-secret-token\n"],
         )
 
-        exit_code = main([
-            "export-fixture",
-            str(replay_path),
-            str(output),
-        ])
+        exit_code = main(
+            [
+                "export-fixture",
+                str(replay_path),
+                str(output),
+            ]
+        )
 
         assert exit_code == 2
         assert "credential pattern" in capsys.readouterr().err
@@ -308,16 +302,21 @@ class TestDebugReplay:
         assert "private-prefix" not in prefixed
         assert '"chars":15' in prefixed
 
-        sanitized = sanitize_value({
-            "providerToken": "provider-value",
-            "awsAccessKeyId": "aws-value",
-            "browserSession": "session-value",
-            "customSignature": "signature-value",
-            "arguments": json.dumps({
-                "nestedProviderToken": "nested-value",
-                "message": "visible",
-            }),
-        }, capture_content=True)
+        sanitized = sanitize_value(
+            {
+                "providerToken": "provider-value",
+                "awsAccessKeyId": "aws-value",
+                "browserSession": "session-value",
+                "customSignature": "signature-value",
+                "arguments": json.dumps(
+                    {
+                        "nestedProviderToken": "nested-value",
+                        "message": "visible",
+                    }
+                ),
+            },
+            capture_content=True,
+        )
         assert sanitized["providerToken"] == "[REDACTED]"
         assert sanitized["awsAccessKeyId"] == "[REDACTED]"
         assert sanitized["browserSession"] == "[REDACTED]"
@@ -339,9 +338,7 @@ class TestDebugReplay:
         replay["translated_sse"][0]["payload_base64"] = payload
         replay_path.write_text(json.dumps(replay))
 
-        assert main([
-            "export-fixture", str(replay_path), str(output)
-        ]) == 2
+        assert main(["export-fixture", str(replay_path), str(output)]) == 2
         assert "invalid base64" in capsys.readouterr().err
         assert not output.exists()
 
@@ -364,9 +361,7 @@ class TestDebugReplay:
             replay["client_request"] = {"aws_session_token": "opaque-value"}
             replay_path.write_text(json.dumps(replay))
 
-        assert main([
-            "export-fixture", str(replay_path), str(output)
-        ]) == 2
+        assert main(["export-fixture", str(replay_path), str(output)]) == 2
         assert "credential pattern" in capsys.readouterr().err
         assert not output.exists()
 
@@ -385,9 +380,7 @@ class TestDebugReplay:
             real_replace(source, destination)
 
         with patch("kiro.debug_replay.os.replace", inspect_replace):
-            assert main([
-                "export-fixture", str(replay_path), str(output)
-            ]) == 0
+            assert main(["export-fixture", str(replay_path), str(output)]) == 0
 
         assert observed and observed[0][1] == output
         assert output.stat().st_mode & 0o777 == 0o600
@@ -407,12 +400,17 @@ class TestDebugReplay:
             ],
         )
 
-        assert main([
-            "replay",
-            str(replay_path),
-            "--protocol",
-            "anthropic",
-            "--output",
-            str(output),
-        ]) == 0
+        assert (
+            main(
+                [
+                    "replay",
+                    str(replay_path),
+                    "--protocol",
+                    "anthropic",
+                    "--output",
+                    str(output),
+                ]
+            )
+            == 0
+        )
         assert output.stat().st_mode & 0o777 == 0o600

--- a/tests/unit/test_device_login.py
+++ b/tests/unit/test_device_login.py
@@ -39,7 +39,13 @@ APPROVED = {
     "identityProvider": "Google",
 }
 
-PENDING = {"status": "authorization_pending", "accessToken": None, "refreshToken": None, "profileArn": None, "identityProvider": None}
+PENDING = {
+    "status": "authorization_pending",
+    "accessToken": None,
+    "refreshToken": None,
+    "profileArn": None,
+    "identityProvider": None,
+}
 
 
 class _Response:
@@ -456,6 +462,7 @@ async def test_writing_credentials_for_an_unapproved_flow_is_refused(tmp_path):
 # Host routing: an account with no profile must not use the runtime host
 # =============================================================================
 
+
 def test_builder_id_host_differs_from_the_profile_host():
     from kiro.config import get_kiro_api_host, get_kiro_q_host
 
@@ -480,14 +487,16 @@ def test_builder_id_credentials_route_to_the_q_host(tmp_path):
 
     path = tmp_path / "builder.json"
     path.write_text(
-        _json.dumps({
-            "refreshToken": "refresh-token-value-long-enough",
-            "accessToken": "access-token",
-            "region": "us-east-1",
-            "clientId": "client-id",
-            "clientSecret": "client-secret",
-            "startUrl": "https://view.awsapps.com/start",
-        })
+        _json.dumps(
+            {
+                "refreshToken": "refresh-token-value-long-enough",
+                "accessToken": "access-token",
+                "region": "us-east-1",
+                "clientId": "client-id",
+                "clientSecret": "client-secret",
+                "startUrl": "https://view.awsapps.com/start",
+            }
+        )
     )
 
     manager = KiroAuthManager(creds_file=str(path))
@@ -516,11 +525,13 @@ def test_an_account_with_a_profile_keeps_the_runtime_host(tmp_path):
 
     path = tmp_path / "social.json"
     path.write_text(
-        _json.dumps({
-            "refreshToken": "refresh-token-value-long-enough",
-            "accessToken": "access-token",
-            "region": "us-east-1",
-        })
+        _json.dumps(
+            {
+                "refreshToken": "refresh-token-value-long-enough",
+                "accessToken": "access-token",
+                "region": "us-east-1",
+            }
+        )
     )
 
     manager = KiroAuthManager(

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -5,15 +5,16 @@ Unit tests for exception handlers.
 Tests validation error handling and debug logging integration.
 """
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 
 
 class TestSanitizeValidationErrors:
     """Tests for sanitize_validation_errors function."""
-    
+
     def test_sanitizes_bytes_in_input_field(self):
         """
         What it does: Verifies that bytes in 'input' field are converted to strings.
@@ -21,23 +22,16 @@ class TestSanitizeValidationErrors:
         """
         print("Setup: Creating error with bytes in input field...")
         from kiro.exceptions import sanitize_validation_errors
-        
-        errors = [
-            {
-                "type": "json_invalid",
-                "loc": ["body", 0],
-                "msg": "Invalid JSON",
-                "input": b'{"invalid": json}'
-            }
-        ]
-        
+
+        errors = [{"type": "json_invalid", "loc": ["body", 0], "msg": "Invalid JSON", "input": b'{"invalid": json}'}]
+
         print("Action: Calling sanitize_validation_errors...")
         result = sanitize_validation_errors(errors)
-        
+
         print(f"Comparing input type: Expected str, Got {type(result[0]['input'])}")
         assert isinstance(result[0]["input"], str)
         assert result[0]["input"] == '{"invalid": json}'
-    
+
     def test_sanitizes_bytes_in_list_values(self):
         """
         What it does: Verifies that bytes in list values are converted to strings.
@@ -45,22 +39,22 @@ class TestSanitizeValidationErrors:
         """
         print("Setup: Creating error with bytes in list...")
         from kiro.exceptions import sanitize_validation_errors
-        
+
         errors = [
             {
                 "type": "value_error",
                 "loc": ["body", "messages"],
                 "msg": "Invalid value",
-                "input": [b'bytes1', "string", b'bytes2']
+                "input": [b"bytes1", "string", b"bytes2"],
             }
         ]
-        
+
         print("Action: Calling sanitize_validation_errors...")
         result = sanitize_validation_errors(errors)
-        
-        print(f"Checking list values are converted...")
+
+        print("Checking list values are converted...")
         assert result[0]["input"] == ["bytes1", "string", "bytes2"]
-    
+
     def test_preserves_non_bytes_values(self):
         """
         What it does: Verifies that non-bytes values are preserved.
@@ -68,27 +62,20 @@ class TestSanitizeValidationErrors:
         """
         print("Setup: Creating error with normal values...")
         from kiro.exceptions import sanitize_validation_errors
-        
-        errors = [
-            {
-                "type": "missing",
-                "loc": ["body", "model"],
-                "msg": "Field required",
-                "input": {"messages": []}
-            }
-        ]
-        
+
+        errors = [{"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {"messages": []}}]
+
         print("Action: Calling sanitize_validation_errors...")
         result = sanitize_validation_errors(errors)
-        
-        print(f"Checking values are preserved...")
+
+        print("Checking values are preserved...")
         assert result[0]["input"] == {"messages": []}
         assert result[0]["type"] == "missing"
 
 
 class TestValidationExceptionHandler:
     """Tests for validation_exception_handler function."""
-    
+
     @pytest.mark.asyncio
     async def test_returns_422_status_code(self):
         """
@@ -97,23 +84,21 @@ class TestValidationExceptionHandler:
         """
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"invalid": json}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
-        mock_exc.errors.return_value = [
-            {"type": "json_invalid", "loc": ["body"], "msg": "Invalid JSON", "input": {}}
-        ]
-        
+        mock_exc.errors.return_value = [{"type": "json_invalid", "loc": ["body"], "msg": "Invalid JSON", "input": {}}]
+
         # Patch debug_logger at the source module
-        with patch('kiro.debug_logger.debug_logger') as mock_logger:
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
+
             print(f"Comparing status_code: Expected 422, Got {response.status_code}")
             assert response.status_code == 422
-    
+
     @pytest.mark.asyncio
     async def test_calls_flush_on_error_with_422(self):
         """
@@ -122,25 +107,25 @@ class TestValidationExceptionHandler:
         """
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
             {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
         ]
-        
+
         # Patch debug_logger at the source module
-        with patch('kiro.debug_logger.debug_logger') as mock_logger:
+        with patch("kiro.debug_logger.debug_logger") as mock_logger:
             print("Action: Calling validation_exception_handler...")
             await validation_exception_handler(mock_request, mock_exc)
-            
+
             print("Verifying flush_on_error was called with 422...")
             mock_logger.flush_on_error.assert_called_once()
             call_args = mock_logger.flush_on_error.call_args
             assert call_args[0][0] == 422  # First positional argument is status_code
-    
+
     @pytest.mark.asyncio
     async def test_includes_sanitized_errors_in_response(self):
         """
@@ -148,29 +133,30 @@ class TestValidationExceptionHandler:
         Purpose: Ensure error details are returned to client.
         """
         print("Setup: Creating mock request and exception...")
-        from kiro.exceptions import validation_exception_handler
         import json
-        
+
+        from kiro.exceptions import validation_exception_handler
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
             {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
+
             print("Parsing response body...")
             body = json.loads(response.body.decode())
-            
-            print(f"Verifying 'detail' is in response...")
+
+            print("Verifying 'detail' is in response...")
             assert "detail" in body
             assert len(body["detail"]) == 1
             assert body["detail"][0]["type"] == "missing"
-    
+
     @pytest.mark.asyncio
     async def test_truncates_body_in_response(self):
         """
@@ -178,33 +164,32 @@ class TestValidationExceptionHandler:
         Purpose: Ensure large bodies don't bloat error responses.
         """
         print("Setup: Creating mock request with large body...")
-        from kiro.exceptions import validation_exception_handler
         import json
-        
-        large_body = b'{"data": "' + b'x' * 1000 + b'"}'
-        
+
+        from kiro.exceptions import validation_exception_handler
+
+        large_body = b'{"data": "' + b"x" * 1000 + b'"}'
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=large_body)
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
-        mock_exc.errors.return_value = [
-            {"type": "json_invalid", "loc": ["body"], "msg": "Invalid", "input": {}}
-        ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
+        mock_exc.errors.return_value = [{"type": "json_invalid", "loc": ["body"], "msg": "Invalid", "input": {}}]
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
+
             print("Parsing response body...")
             body = json.loads(response.body.decode())
-            
-            print(f"Verifying body is truncated to 500 chars...")
+
+            print("Verifying body is truncated to 500 chars...")
             assert len(body["body"]) <= 500
 
 
 class TestValidationExceptionHandlerLogging:
     """Tests for logging behavior in validation_exception_handler."""
-    
+
     @pytest.mark.asyncio
     async def test_logs_error_at_error_level(self):
         """
@@ -213,27 +198,27 @@ class TestValidationExceptionHandlerLogging:
         """
         print("Setup: Creating mock request and exception...")
         from kiro.exceptions import validation_exception_handler
-        
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
             {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
-            with patch('kiro.exceptions.logger') as mock_logger:
+
+        with patch("kiro.debug_logger.debug_logger"):
+            with patch("kiro.exceptions.logger") as mock_logger:
                 print("Action: Calling validation_exception_handler...")
                 await validation_exception_handler(mock_request, mock_exc)
-                
+
                 print("Verifying logger.error was called...")
                 mock_logger.error.assert_called()
 
 
 class TestValidationExceptionHandlerEdgeCases:
     """Tests for edge cases in validation_exception_handler."""
-    
+
     @pytest.mark.asyncio
     async def test_handles_empty_errors_list(self):
         """
@@ -241,25 +226,26 @@ class TestValidationExceptionHandlerEdgeCases:
         Purpose: Ensure edge case doesn't cause crash.
         """
         print("Setup: Creating mock request with empty errors...")
-        from kiro.exceptions import validation_exception_handler
         import json
-        
+
+        from kiro.exceptions import validation_exception_handler
+
         mock_request = MagicMock(spec=Request)
-        mock_request.body = AsyncMock(return_value=b'{}')
-        
+        mock_request.body = AsyncMock(return_value=b"{}")
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = []
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
-            print(f"Verifying response is valid...")
+
+            print("Verifying response is valid...")
             assert response.status_code == 422
-            
+
             body = json.loads(response.body.decode())
             assert body["detail"] == []
-    
+
     @pytest.mark.asyncio
     async def test_handles_unicode_in_body(self):
         """
@@ -267,25 +253,26 @@ class TestValidationExceptionHandlerEdgeCases:
         Purpose: Ensure international characters are handled.
         """
         print("Setup: Creating mock request with unicode body...")
-        from kiro.exceptions import validation_exception_handler
         import json
-        
-        unicode_body = '{"message": "Привет мир 🌍"}'.encode('utf-8')
-        
+
+        from kiro.exceptions import validation_exception_handler
+
+        unicode_body = '{"message": "Привет мир 🌍"}'.encode("utf-8")
+
         mock_request = MagicMock(spec=Request)
         mock_request.body = AsyncMock(return_value=unicode_body)
-        
+
         mock_exc = MagicMock(spec=RequestValidationError)
         mock_exc.errors.return_value = [
             {"type": "missing", "loc": ["body", "model"], "msg": "Field required", "input": {}}
         ]
-        
-        with patch('kiro.debug_logger.debug_logger'):
+
+        with patch("kiro.debug_logger.debug_logger"):
             print("Action: Calling validation_exception_handler...")
             response = await validation_exception_handler(mock_request, mock_exc)
-            
-            print(f"Verifying response is valid...")
+
+            print("Verifying response is valid...")
             assert response.status_code == 422
-            
+
             body = json.loads(response.body.decode())
             assert "Привет мир" in body["body"]

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -5,18 +5,16 @@ Unit tests for KiroHttpClient.
 Tests retry logic, error handling, and HTTP client management.
 """
 
-import asyncio
 import json
-import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
+import pytest
 from fastapi import HTTPException
 
-from kiro.http_client import KiroHttpClient
 from kiro.auth import KiroAuthManager
-from kiro.config import MAX_RETRIES, BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.config import BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.http_client import KiroHttpClient
 
 
 @pytest.fixture
@@ -32,7 +30,7 @@ def mock_auth_manager_for_http():
 
 class TestKiroHttpClientInitialization:
     """Tests for KiroHttpClient initialization."""
-    
+
     def test_initialization_stores_auth_manager(self, mock_auth_manager_for_http):
         """
         What it does: Verifies auth_manager is stored during initialization.
@@ -40,10 +38,10 @@ class TestKiroHttpClientInitialization:
         """
         print("Setup: Creating KiroHttpClient...")
         client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Verification: auth_manager is stored...")
         assert client.auth_manager is mock_auth_manager_for_http
-    
+
     def test_initialization_client_is_none(self, mock_auth_manager_for_http):
         """
         What it does: Verifies that HTTP client is initially None.
@@ -51,14 +49,14 @@ class TestKiroHttpClientInitialization:
         """
         print("Setup: Creating KiroHttpClient...")
         client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Verification: client is initially None...")
         assert client.client is None
 
 
 class TestKiroHttpClientGetClient:
     """Tests for _get_client method."""
-    
+
     @pytest.mark.asyncio
     async def test_get_client_creates_new_client(self, mock_auth_manager_for_http):
         """
@@ -67,19 +65,19 @@ class TestKiroHttpClientGetClient:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Action: Getting client...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_instance = AsyncMock()
             mock_instance.is_closed = False
             mock_async_client.return_value = mock_instance
-            
+
             client = await http_client._get_client()
-            
+
             print("Verification: Client created...")
             mock_async_client.assert_called_once()
             assert client is mock_instance
-    
+
     @pytest.mark.asyncio
     async def test_get_client_reuses_existing_client(self, mock_auth_manager_for_http):
         """
@@ -88,17 +86,17 @@ class TestKiroHttpClientGetClient:
         """
         print("Setup: Creating KiroHttpClient with existing client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_existing = AsyncMock()
         mock_existing.is_closed = False
         http_client.client = mock_existing
-        
+
         print("Action: Getting client...")
         client = await http_client._get_client()
-        
+
         print("Verification: Existing client returned...")
         assert client is mock_existing
-    
+
     @pytest.mark.asyncio
     async def test_get_client_recreates_closed_client(self, mock_auth_manager_for_http):
         """
@@ -107,19 +105,19 @@ class TestKiroHttpClientGetClient:
         """
         print("Setup: Creating KiroHttpClient with closed client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_closed = AsyncMock()
         mock_closed.is_closed = True
         http_client.client = mock_closed
-        
+
         print("Action: Getting client...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_new = AsyncMock()
             mock_new.is_closed = False
             mock_async_client.return_value = mock_new
-            
+
             client = await http_client._get_client()
-            
+
             print("Verification: New client created...")
             mock_async_client.assert_called_once()
             assert client is mock_new
@@ -127,7 +125,7 @@ class TestKiroHttpClientGetClient:
 
 class TestKiroHttpClientClose:
     """Tests for close method."""
-    
+
     @pytest.mark.asyncio
     async def test_close_closes_client(self, mock_auth_manager_for_http):
         """
@@ -136,18 +134,18 @@ class TestKiroHttpClientClose:
         """
         print("Setup: Creating KiroHttpClient with client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock()
         http_client.client = mock_client
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() called...")
         mock_client.aclose.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_close_does_nothing_for_none_client(self, mock_auth_manager_for_http):
         """
@@ -156,12 +154,12 @@ class TestKiroHttpClientClose:
         """
         print("Setup: Creating KiroHttpClient without client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Action: Closing client...")
         await http_client.close()  # Should not raise an error
-        
+
         print("Verification: No errors...")
-    
+
     @pytest.mark.asyncio
     async def test_close_does_nothing_for_closed_client(self, mock_auth_manager_for_http):
         """
@@ -170,21 +168,21 @@ class TestKiroHttpClientClose:
         """
         print("Setup: Creating KiroHttpClient with closed client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = True
         http_client.client = mock_client
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() NOT called...")
         mock_client.aclose.assert_not_called()
 
 
 class TestKiroHttpClientRequestWithRetry:
     """Tests for request_with_retry method."""
-    
+
     @pytest.mark.asyncio
     async def test_successful_request_returns_response(self, mock_auth_manager_for_http):
         """
@@ -193,27 +191,25 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"}
+                    "POST", "https://api.example.com/test", {"data": "value"}
                 )
-        
+
         print("Verification: Response received...")
         assert response.status_code == 200
         mock_client.request.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_403_triggers_token_refresh(self, mock_auth_manager_for_http):
         """
@@ -222,30 +218,28 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_403 = AsyncMock()
         mock_response_403.status_code = 403
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=[mock_response_403, mock_response_200])
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"}
+                    "POST", "https://api.example.com/test", {"data": "value"}
                 )
-        
+
         print("Verification: force_refresh() called...")
         mock_auth_manager_for_http.force_refresh.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_429_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -254,31 +248,29 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_429 = AsyncMock()
         mock_response_429.status_code = 429
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=[mock_response_429, mock_response_200])
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_5xx_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -287,31 +279,29 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_500 = AsyncMock()
         mock_response_500.status_code = 500
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=[mock_response_500, mock_response_200])
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_timeout_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -320,31 +310,26 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[
-            httpx.TimeoutException("Timeout"),
-            mock_response_200
-        ])
-        
+        mock_client.request = AsyncMock(side_effect=[httpx.TimeoutException("Timeout"), mock_response_200])
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_request_error_triggers_backoff(self, mock_auth_manager_for_http):
         """
@@ -353,31 +338,26 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
-        mock_client.request = AsyncMock(side_effect=[
-            httpx.RequestError("Connection error"),
-            mock_response_200
-        ])
-        
+        mock_client.request = AsyncMock(side_effect=[httpx.RequestError("Connection error"), mock_response_200])
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
+                        "POST", "https://api.example.com/test", {"data": "value"}
                     )
-        
+
         print("Verification: sleep() called for backoff...")
         mock_sleep.assert_called_once()
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_max_retries_exceeded_raises_502(self, mock_auth_manager_for_http):
         """
@@ -386,27 +366,23 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
                     with pytest.raises(HTTPException) as exc_info:
-                        await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"}
-                        )
-        
-        print(f"Verification: HTTPException with code 504 (timeout errors now return 504)...")
+                        await http_client.request_with_retry("POST", "https://api.example.com/test", {"data": "value"})
+
+        print("Verification: HTTPException with code 504 (timeout errors now return 504)...")
         assert exc_info.value.status_code == 504
-        print(f"Verification: Error detail contains user-friendly message...")
+        print("Verification: Error detail contains user-friendly message...")
         assert "timeout" in exc_info.value.detail.lower()
-    
+
     @pytest.mark.asyncio
     async def test_other_status_codes_returned_as_is(self, mock_auth_manager_for_http):
         """
@@ -415,27 +391,25 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 400
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"}
+                    "POST", "https://api.example.com/test", {"data": "value"}
                 )
-        
+
         print("Verification: 400 response returned without retry...")
         assert response.status_code == 400
         mock_client.request.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_streaming_request_uses_send(self, mock_auth_manager_for_http):
         """
@@ -444,27 +418,24 @@ class TestKiroHttpClientRequestWithRetry:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing streaming request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"},
-                    stream=True
+                    "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                 )
-        
+
         print("Verification: build_request and send called...")
         mock_client.build_request.assert_called_once()
         mock_client.send.assert_called_once_with(mock_request, stream=True)
@@ -473,7 +444,7 @@ class TestKiroHttpClientRequestWithRetry:
 
 class TestKiroHttpClientContextManager:
     """Tests for async context manager."""
-    
+
     @pytest.mark.asyncio
     async def test_context_manager_returns_self(self, mock_auth_manager_for_http):
         """
@@ -482,13 +453,13 @@ class TestKiroHttpClientContextManager:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Action: Entering context...")
         result = await http_client.__aenter__()
-        
+
         print("Verification: self returned...")
         assert result is http_client
-    
+
     @pytest.mark.asyncio
     async def test_context_manager_closes_on_exit(self, mock_auth_manager_for_http):
         """
@@ -497,22 +468,22 @@ class TestKiroHttpClientContextManager:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock()
         http_client.client = mock_client
-        
+
         print("Action: Exiting context...")
         await http_client.__aexit__(None, None, None)
-        
+
         print("Verification: aclose() called...")
         mock_client.aclose.assert_called_once()
 
 
 class TestKiroHttpClientExponentialBackoff:
     """Tests for exponential backoff logic."""
-    
+
     @pytest.mark.asyncio
     async def test_backoff_delay_increases_exponentially(self, mock_auth_manager_for_http):
         """
@@ -521,47 +492,39 @@ class TestKiroHttpClientExponentialBackoff:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response_429 = AsyncMock()
         mock_response_429.status_code = 429
-        
+
         mock_response_200 = AsyncMock()
         mock_response_200.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         # 2 errors 429, then success (to verify 2 backoff delays)
-        mock_client.request = AsyncMock(side_effect=[
-            mock_response_429,
-            mock_response_429,
-            mock_response_200
-        ])
-        
+        mock_client.request = AsyncMock(side_effect=[mock_response_429, mock_response_429, mock_response_200])
+
         sleep_delays = []
-        
+
         async def capture_sleep(delay):
             sleep_delays.append(delay)
-        
+
         print("Action: Executing request with multiple retries...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', side_effect=capture_sleep):
-                    response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"}
-                    )
-        
-        print(f"Verification: Delays increase exponentially...")
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", side_effect=capture_sleep):
+                    await http_client.request_with_retry("POST", "https://api.example.com/test", {"data": "value"})
+
+        print("Verification: Delays increase exponentially...")
         print(f"Delays: {sleep_delays}")
         assert len(sleep_delays) == 2
-        assert sleep_delays[0] == BASE_RETRY_DELAY * (2 ** 0)  # 1.0
-        assert sleep_delays[1] == BASE_RETRY_DELAY * (2 ** 1)  # 2.0
+        assert sleep_delays[0] == BASE_RETRY_DELAY * (2**0)  # 1.0
+        assert sleep_delays[1] == BASE_RETRY_DELAY * (2**1)  # 2.0
 
 
 class TestKiroHttpClientStreamingTimeout:
     """Tests for streaming request timeout logic."""
-    
+
     @pytest.mark.asyncio
     async def test_streaming_uses_streaming_read_timeout(self, mock_auth_manager_for_http):
         """
@@ -570,40 +533,39 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing streaming request...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_async_client.return_value = mock_client
-            
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"},
-                    stream=True
+                    "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                 )
-        
+
         print("Verification: AsyncClient created with httpx.Timeout for streaming...")
         call_args = mock_async_client.call_args
-        timeout_arg = call_args.kwargs.get('timeout')
+        timeout_arg = call_args.kwargs.get("timeout")
         assert timeout_arg is not None, f"timeout not found in call_args: {call_args}"
         print(f"Comparing connect: Expected 30.0, Got {timeout_arg.connect}")
         assert timeout_arg.connect == 30.0, f"Expected connect=30.0, got {timeout_arg.connect}"
         print(f"Comparing read: Expected {STREAMING_READ_TIMEOUT}, Got {timeout_arg.read}")
-        assert timeout_arg.read == STREAMING_READ_TIMEOUT, f"Expected read={STREAMING_READ_TIMEOUT}, got {timeout_arg.read}"
-        assert call_args.kwargs.get('follow_redirects') == True
+        assert timeout_arg.read == STREAMING_READ_TIMEOUT, (
+            f"Expected read={STREAMING_READ_TIMEOUT}, got {timeout_arg.read}"
+        )
+        assert call_args.kwargs.get("follow_redirects") is True
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_streaming_uses_first_token_max_retries(self, mock_auth_manager_for_http):
         """
@@ -612,33 +574,30 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
-        
+
         print("Action: Executing streaming request with timeouts...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
                     with pytest.raises(HTTPException) as exc_info:
                         await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"},
-                            stream=True
+                            "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                         )
-        
-        print(f"Verification: HTTPException with code 504...")
+
+        print("Verification: HTTPException with code 504...")
         assert exc_info.value.status_code == 504
         assert str(FIRST_TOKEN_MAX_RETRIES) in exc_info.value.detail
-        
+
         print(f"Verification: Attempt count = FIRST_TOKEN_MAX_RETRIES ({FIRST_TOKEN_MAX_RETRIES})...")
         assert mock_client.send.call_count == FIRST_TOKEN_MAX_RETRIES
-    
+
     @pytest.mark.asyncio
     async def test_streaming_timeout_retry_without_delay(self, mock_auth_manager_for_http):
         """
@@ -647,42 +606,36 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         # First timeout, then success
-        mock_client.send = AsyncMock(side_effect=[
-            httpx.TimeoutException("Timeout"),
-            mock_response
-        ])
-        
+        mock_client.send = AsyncMock(side_effect=[httpx.TimeoutException("Timeout"), mock_response])
+
         sleep_called = False
-        
+
         async def capture_sleep(delay):
             nonlocal sleep_called
             sleep_called = True
-        
+
         print("Action: Executing streaming request with one timeout...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', side_effect=capture_sleep):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", side_effect=capture_sleep):
                     response = await http_client.request_with_retry(
-                        "POST",
-                        "https://api.example.com/test",
-                        {"data": "value"},
-                        stream=True
+                        "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                     )
-        
+
         print("Verification: sleep() IS called for timeout retry (new behavior)...")
         assert sleep_called
         assert response.status_code == 200
-        
+
     @pytest.mark.asyncio
     async def test_non_streaming_uses_default_timeout(self, mock_auth_manager_for_http):
         """
@@ -691,36 +644,33 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing non-streaming request...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             mock_async_client.return_value = mock_client
-            
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
+
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"},
-                    stream=False
+                    "POST", "https://api.example.com/test", {"data": "value"}, stream=False
                 )
-        
+
         print("Verification: AsyncClient created with httpx.Timeout(timeout=300)...")
         call_args = mock_async_client.call_args
-        timeout_arg = call_args.kwargs.get('timeout')
+        timeout_arg = call_args.kwargs.get("timeout")
         assert timeout_arg is not None, f"timeout not found in call_args: {call_args}"
         # httpx.Timeout(timeout=300) sets all timeouts to 300
         print(f"Comparing timeout: Expected 300.0 for all, Got connect={timeout_arg.connect}")
         assert timeout_arg.connect == 300.0
         assert timeout_arg.read == 300.0
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_connect_timeout_logged_correctly(self, mock_auth_manager_for_http):
         """
@@ -729,38 +679,34 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         # First ConnectTimeout, then success
-        mock_client.send = AsyncMock(side_effect=[
-            httpx.ConnectTimeout("Connection timeout"),
-            mock_response
-        ])
-        
+        mock_client.send = AsyncMock(side_effect=[httpx.ConnectTimeout("Connection timeout"), mock_response])
+
         print("Action: Executing streaming request with ConnectTimeout...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
-                    with patch('kiro.http_client.logger') as mock_logger:
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
+                    with patch("kiro.http_client.logger") as mock_logger:
                         response = await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"},
-                            stream=True
+                            "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                         )
-        
+
         print("Verification: logger.warning called with user-friendly timeout message...")
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-        assert any("timeout" in call.lower() for call in warning_calls), f"Timeout message not found in: {warning_calls}"
+        assert any("timeout" in call.lower() for call in warning_calls), (
+            f"Timeout message not found in: {warning_calls}"
+        )
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_read_timeout_logged_correctly(self, mock_auth_manager_for_http):
         """
@@ -769,38 +715,34 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         # First ReadTimeout, then success
-        mock_client.send = AsyncMock(side_effect=[
-            httpx.ReadTimeout("Read timeout"),
-            mock_response
-        ])
-        
+        mock_client.send = AsyncMock(side_effect=[httpx.ReadTimeout("Read timeout"), mock_response])
+
         print("Action: Executing streaming request with ReadTimeout...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
-                    with patch('kiro.http_client.logger') as mock_logger:
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
+                    with patch("kiro.http_client.logger") as mock_logger:
                         response = await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"},
-                            stream=True
+                            "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                         )
-        
+
         print("Verification: logger.warning called with user-friendly timeout message...")
         warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
-        assert any("timeout" in call.lower() for call in warning_calls), f"Timeout message not found in: {warning_calls}"
+        assert any("timeout" in call.lower() for call in warning_calls), (
+            f"Timeout message not found in: {warning_calls}"
+        )
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_streaming_timeout_returns_504_with_error_type(self, mock_auth_manager_for_http):
         """
@@ -809,33 +751,30 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_request = Mock()
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(return_value=mock_request)
         mock_client.send = AsyncMock(side_effect=httpx.ReadTimeout("Timeout"))
-        
+
         print("Action: Executing streaming request with persistent timeouts...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
                     with pytest.raises(HTTPException) as exc_info:
                         await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"},
-                            stream=True
+                            "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                         )
-        
+
         print("Verification: HTTPException with code 504 and user-friendly message...")
         print(f"Comparing status_code: Expected 504, Got {exc_info.value.status_code}")
         assert exc_info.value.status_code == 504
         print(f"Comparing detail: Expected timeout message with troubleshooting in '{exc_info.value.detail}'")
         assert "timeout" in exc_info.value.detail.lower()
         assert "Troubleshooting" in exc_info.value.detail or "Technical details" in exc_info.value.detail
-    
+
     @pytest.mark.asyncio
     async def test_non_streaming_timeout_returns_502(self, mock_auth_manager_for_http):
         """
@@ -844,30 +783,27 @@ class TestKiroHttpClientStreamingTimeout:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
-        
+
         print("Action: Executing non-streaming request with persistent timeouts...")
-        with patch('kiro.http_client.httpx.AsyncClient', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={}):
-                with patch('kiro.http_client.asyncio.sleep', new_callable=AsyncMock):
+        with patch("kiro.http_client.httpx.AsyncClient", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                with patch("kiro.http_client.asyncio.sleep", new_callable=AsyncMock):
                     with pytest.raises(HTTPException) as exc_info:
                         await http_client.request_with_retry(
-                            "POST",
-                            "https://api.example.com/test",
-                            {"data": "value"},
-                            stream=False
+                            "POST", "https://api.example.com/test", {"data": "value"}, stream=False
                         )
-        
+
         print("Verification: HTTPException with code 504 (timeouts now consistently return 504)...")
         assert exc_info.value.status_code == 504
 
 
 class TestKiroHttpClientSharedClient:
     """Tests for shared client functionality (connection pooling support)."""
-    
+
     def test_initialization_with_shared_client(self, mock_auth_manager_for_http):
         """
         What it does: Verifies shared_client is stored during initialization.
@@ -876,16 +812,16 @@ class TestKiroHttpClientSharedClient:
         print("Setup: Creating mock shared client...")
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+
         print("Verification: shared_client is stored...")
         print(f"Comparing _shared_client: Expected mock_shared, Got {http_client._shared_client}")
         assert http_client._shared_client is mock_shared
         print(f"Comparing client: Expected mock_shared, Got {http_client.client}")
         assert http_client.client is mock_shared
-    
+
     def test_initialization_without_shared_client_owns_client(self, mock_auth_manager_for_http):
         """
         What it does: Verifies _owns_client is True when no shared client provided.
@@ -893,13 +829,13 @@ class TestKiroHttpClientSharedClient:
         """
         print("Setup: Creating KiroHttpClient without shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         print("Verification: _owns_client is True...")
         print(f"Comparing _owns_client: Expected True, Got {http_client._owns_client}")
         assert http_client._owns_client is True
         print(f"Comparing _shared_client: Expected None, Got {http_client._shared_client}")
         assert http_client._shared_client is None
-    
+
     def test_initialization_with_shared_client_does_not_own(self, mock_auth_manager_for_http):
         """
         What it does: Verifies _owns_client is False when shared client provided.
@@ -908,14 +844,14 @@ class TestKiroHttpClientSharedClient:
         print("Setup: Creating mock shared client...")
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+
         print("Verification: _owns_client is False...")
         print(f"Comparing _owns_client: Expected False, Got {http_client._owns_client}")
         assert http_client._owns_client is False
-    
+
     @pytest.mark.asyncio
     async def test_get_client_returns_shared_client(self, mock_auth_manager_for_http):
         """
@@ -925,19 +861,19 @@ class TestKiroHttpClientSharedClient:
         print("Setup: Creating mock shared client...")
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+
         print("Action: Getting client...")
-        with patch('kiro.http_client.httpx.AsyncClient') as mock_async_client:
+        with patch("kiro.http_client.httpx.AsyncClient") as mock_async_client:
             client = await http_client._get_client(stream=True)
-            
+
             print("Verification: Shared client returned, no new client created...")
             print(f"Comparing client: Expected mock_shared, Got {client}")
             assert client is mock_shared
             mock_async_client.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_close_does_not_close_shared_client(self, mock_auth_manager_for_http):
         """
@@ -948,16 +884,16 @@ class TestKiroHttpClientSharedClient:
         mock_shared = AsyncMock()
         mock_shared.is_closed = False
         mock_shared.aclose = AsyncMock()
-        
+
         print("Action: Creating KiroHttpClient with shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http, shared_client=mock_shared)
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() NOT called on shared client...")
         mock_shared.aclose.assert_not_called()
-    
+
     @pytest.mark.asyncio
     async def test_close_closes_owned_client(self, mock_auth_manager_for_http):
         """
@@ -966,22 +902,22 @@ class TestKiroHttpClientSharedClient:
         """
         print("Setup: Creating KiroHttpClient without shared client...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_owned = AsyncMock()
         mock_owned.is_closed = False
         mock_owned.aclose = AsyncMock()
         http_client.client = mock_owned
-        
+
         print("Action: Closing client...")
         await http_client.close()
-        
+
         print("Verification: aclose() called on owned client...")
         mock_owned.aclose.assert_called_once()
 
 
 class TestKiroHttpClientGracefulClose:
     """Tests for graceful exception handling in close() method."""
-    
+
     @pytest.mark.asyncio
     async def test_close_handles_aclose_exception_gracefully(self, mock_auth_manager_for_http):
         """
@@ -990,20 +926,20 @@ class TestKiroHttpClientGracefulClose:
         """
         print("Setup: Creating KiroHttpClient with client that raises on close...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock(side_effect=Exception("Connection reset"))
         http_client.client = mock_client
-        
+
         print("Action: Closing client (should not raise)...")
         # Should not raise - exception should be caught
         await http_client.close()
-        
+
         print("Verification: No exception propagated...")
         # If we get here, the test passed
         assert True
-    
+
     @pytest.mark.asyncio
     async def test_close_logs_warning_on_exception(self, mock_auth_manager_for_http):
         """
@@ -1012,16 +948,16 @@ class TestKiroHttpClientGracefulClose:
         """
         print("Setup: Creating KiroHttpClient with client that raises on close...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.aclose = AsyncMock(side_effect=Exception("Connection reset"))
         http_client.client = mock_client
-        
+
         print("Action: Closing client with logger mock...")
-        with patch('kiro.http_client.logger') as mock_logger:
+        with patch("kiro.http_client.logger") as mock_logger:
             await http_client.close()
-            
+
             print("Verification: logger.warning called...")
             mock_logger.warning.assert_called_once()
             warning_message = str(mock_logger.warning.call_args)
@@ -1031,7 +967,7 @@ class TestKiroHttpClientGracefulClose:
 
 class TestKiroHttpClientConnectionCloseHeader:
     """Tests for Connection: close header on streaming requests (issue #38)."""
-    
+
     @pytest.mark.asyncio
     async def test_streaming_request_includes_connection_close_header(self, mock_auth_manager_for_http):
         """
@@ -1040,39 +976,36 @@ class TestKiroHttpClientConnectionCloseHeader:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
         captured_headers = {}
-        
+
         def capture_build_request(method, url, content, headers):
             captured_headers.update(headers)
             return mock_request
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(side_effect=capture_build_request)
         mock_client.send = AsyncMock(return_value=mock_response)
-        
+
         print("Action: Executing streaming request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={"Authorization": "Bearer test"}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={"Authorization": "Bearer test"}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"},
-                    stream=True
+                    "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                 )
-        
+
         print("Verification: Connection: close header is present...")
         print(f"Captured headers: {captured_headers}")
         assert "Connection" in captured_headers, f"Connection header not found in: {captured_headers}"
         print(f"Comparing Connection: Expected 'close', Got '{captured_headers['Connection']}'")
         assert captured_headers["Connection"] == "close"
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_non_streaming_request_does_not_include_connection_close_header(self, mock_auth_manager_for_http):
         """
@@ -1081,35 +1014,34 @@ class TestKiroHttpClientConnectionCloseHeader:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         captured_headers = {}
-        
+
         async def capture_request(method, url, content, headers):
             captured_headers.update(headers)
             return mock_response
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=capture_request)
-        
+
         print("Action: Executing non-streaming request...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={"Authorization": "Bearer test"}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={"Authorization": "Bearer test"}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"},
-                    stream=False
+                    "POST", "https://api.example.com/test", {"data": "value"}, stream=False
                 )
-        
+
         print("Verification: Connection: close header is NOT present...")
         print(f"Captured headers: {captured_headers}")
-        assert "Connection" not in captured_headers, f"Connection header should not be present for non-streaming: {captured_headers}"
+        assert "Connection" not in captured_headers, (
+            f"Connection header should not be present for non-streaming: {captured_headers}"
+        )
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_streaming_connection_close_preserves_other_headers(self, mock_auth_manager_for_http):
         """
@@ -1118,38 +1050,35 @@ class TestKiroHttpClientConnectionCloseHeader:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         mock_request = Mock()
         captured_headers = {}
-        
+
         def capture_build_request(method, url, content, headers):
             captured_headers.update(headers)
             return mock_request
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.build_request = Mock(side_effect=capture_build_request)
         mock_client.send = AsyncMock(return_value=mock_response)
-        
+
         original_headers = {
             "Authorization": "Bearer test_token",
             "Content-Type": "application/json",
-            "X-Custom-Header": "custom_value"
+            "X-Custom-Header": "custom_value",
         }
-        
+
         print("Action: Executing streaming request with multiple headers...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value=original_headers.copy()):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value=original_headers.copy()):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    {"data": "value"},
-                    stream=True
+                    "POST", "https://api.example.com/test", {"data": "value"}, stream=True
                 )
-        
+
         print("Verification: All original headers preserved plus Connection: close...")
         print(f"Captured headers: {captured_headers}")
         assert captured_headers["Authorization"] == "Bearer test_token"
@@ -1161,7 +1090,7 @@ class TestKiroHttpClientConnectionCloseHeader:
 
 class TestKiroHttpClientRequestParameters:
     """Tests for request_with_retry method with params and optional json_data (Account System)."""
-    
+
     @pytest.mark.asyncio
     async def test_request_with_retry_get_with_params(self, mock_auth_manager_for_http):
         """
@@ -1170,31 +1099,31 @@ class TestKiroHttpClientRequestParameters:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value={"models": []})
-        
+
         captured_kwargs = {}
-        
+
         async def capture_request(method, url, **kwargs):
             captured_kwargs.update(kwargs)
             return mock_response
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=capture_request)
-        
+
         print("Action: Executing GET request with params...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={"Authorization": "Bearer test"}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={"Authorization": "Bearer test"}):
                 response = await http_client.request_with_retry(
                     "GET",
                     "https://api.example.com/ListAvailableModels",
                     json_data=None,
-                    params={"origin": "AI_EDITOR", "profileArn": "arn:aws:..."}
+                    params={"origin": "AI_EDITOR", "profileArn": "arn:aws:..."},
                 )
-        
+
         print("Verification: params passed, json NOT passed...")
         print(f"Captured kwargs: {captured_kwargs}")
         assert "params" in captured_kwargs, f"params not found in kwargs: {captured_kwargs}"
@@ -1202,7 +1131,7 @@ class TestKiroHttpClientRequestParameters:
         assert captured_kwargs["params"]["profileArn"] == "arn:aws:..."
         assert "json" not in captured_kwargs, f"json should not be present for GET: {captured_kwargs}"
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_request_with_retry_post_without_json(self, mock_auth_manager_for_http):
         """
@@ -1211,37 +1140,34 @@ class TestKiroHttpClientRequestParameters:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         captured_kwargs = {}
-        
+
         async def capture_request(method, url, **kwargs):
             captured_kwargs.update(kwargs)
             return mock_response
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=capture_request)
-        
+
         print("Action: Executing POST request without json_data...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={"Authorization": "Bearer test"}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={"Authorization": "Bearer test"}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    json_data=None,
-                    params=None
+                    "POST", "https://api.example.com/test", json_data=None, params=None
                 )
-        
+
         print("Verification: Only headers passed, no json or params...")
         print(f"Captured kwargs: {captured_kwargs}")
         assert "headers" in captured_kwargs
         assert "json" not in captured_kwargs, f"json should not be present when None: {captured_kwargs}"
         assert "params" not in captured_kwargs, f"params should not be present when None: {captured_kwargs}"
         assert response.status_code == 200
-    
+
     @pytest.mark.asyncio
     async def test_request_with_retry_params_and_json(self, mock_auth_manager_for_http):
         """
@@ -1250,30 +1176,27 @@ class TestKiroHttpClientRequestParameters:
         """
         print("Setup: Creating KiroHttpClient...")
         http_client = KiroHttpClient(mock_auth_manager_for_http)
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         captured_kwargs = {}
-        
+
         async def capture_request(method, url, **kwargs):
             captured_kwargs.update(kwargs)
             return mock_response
-        
+
         mock_client = AsyncMock()
         mock_client.is_closed = False
         mock_client.request = AsyncMock(side_effect=capture_request)
-        
+
         print("Action: Executing request with both params and json...")
-        with patch.object(http_client, '_get_client', return_value=mock_client):
-            with patch('kiro.http_client.get_kiro_headers', return_value={"Authorization": "Bearer test"}):
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={"Authorization": "Bearer test"}):
                 response = await http_client.request_with_retry(
-                    "POST",
-                    "https://api.example.com/test",
-                    json_data={"data": "value"},
-                    params={"filter": "active"}
+                    "POST", "https://api.example.com/test", json_data={"data": "value"}, params={"filter": "active"}
                 )
-        
+
         print("Verification: Both params and content passed...")
         print(f"Captured kwargs: {captured_kwargs}")
         assert "params" in captured_kwargs, f"params not found: {captured_kwargs}"
@@ -1294,9 +1217,7 @@ class TestStreamRetryCleanup:
         http_client = KiroHttpClient(mock_auth_manager_for_http)
         events = []
         first_response = Mock(status_code=status_code)
-        first_response.aclose = AsyncMock(
-            side_effect=lambda: events.append("close-first")
-        )
+        first_response.aclose = AsyncMock(side_effect=lambda: events.append("close-first"))
         success_response = Mock(status_code=200)
         success_response.aclose = AsyncMock()
         mock_client = Mock()

--- a/tests/unit/test_key_model_usage.py
+++ b/tests/unit/test_key_model_usage.py
@@ -184,9 +184,7 @@ async def test_openai_stream_records_usage_for_the_calling_key(dashboard, stream
     current_api_key_id.set(ROOT_KEY_ID)
     with patch("kiro.streaming_openai.parse_kiro_stream", upstream):
         with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
-            async for _chunk in stream_kiro_to_openai(
-                client, response, "claude-sonnet-4", cache, auth
-            ):
+            async for _chunk in stream_kiro_to_openai(client, response, "claude-sonnet-4", cache, auth):
                 pass
 
     dashboard.flush_key_model_usage()
@@ -210,9 +208,7 @@ async def test_anthropic_stream_records_usage_for_the_calling_key(dashboard, str
     current_api_key_id.set(ROOT_KEY_ID)
     with patch("kiro.streaming_anthropic.parse_kiro_stream", upstream):
         with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
-            async for _chunk in stream_kiro_to_anthropic(
-                response, "claude-opus-5", cache, auth
-            ):
+            async for _chunk in stream_kiro_to_anthropic(response, "claude-opus-5", cache, auth):
                 pass
 
     dashboard.flush_key_model_usage()

--- a/tests/unit/test_kiro_errors.py
+++ b/tests/unit/test_kiro_errors.py
@@ -5,87 +5,70 @@ Unit tests for Kiro API error enhancement system.
 Tests enhance_kiro_error() function and KiroErrorInfo dataclass.
 """
 
-import pytest
-
-from kiro.kiro_errors import (
-    KiroErrorInfo,
-    enhance_kiro_error
-)
+from kiro.kiro_errors import KiroErrorInfo, enhance_kiro_error
 
 
 class TestEnhanceKiroErrorContentLength:
     """Tests for CONTENT_LENGTH_EXCEEDS_THRESHOLD error enhancement."""
-    
+
     def test_content_length_error_enhanced_successfully(self):
         """
         What it does: Verifies CONTENT_LENGTH_EXCEEDS_THRESHOLD is enhanced with user-friendly message.
         Purpose: Ensure cryptic Amazon error is replaced with clear, actionable message (issue #63).
         """
         print("Setup: Creating error JSON with CONTENT_LENGTH_EXCEEDS_THRESHOLD...")
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: User message is enhanced...")
         print(f"Comparing user_message: Expected 'Model context limit reached...', Got '{error_info.user_message}'")
         assert error_info.user_message == "Model context limit reached. Conversation size exceeds model capacity."
         assert error_info.reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
         assert error_info.original_message == "Input is too long."
-    
+
     def test_content_length_error_preserves_original_message(self):
         """
         What it does: Verifies original message is preserved for logging.
         Purpose: Ensure debugging information is not lost during enhancement.
         """
         print("Setup: Creating error JSON...")
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Original message preserved...")
         assert error_info.original_message == "Input is too long."
         assert error_info.original_message != error_info.user_message
-    
+
     def test_content_length_error_reason_string_correct(self):
         """
         What it does: Verifies reason is correctly preserved as string.
         Purpose: Ensure reason field can be used for programmatic error handling.
         """
         print("Setup: Creating error JSON...")
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Reason is correct string value...")
         assert error_info.reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
         assert isinstance(error_info.reason, str)
-    
+
     def test_content_length_error_no_reason_suffix(self):
         """
         What it does: Verifies enhanced message doesn't include (reason: ...) suffix.
         Purpose: Ensure clean, user-friendly message without technical codes.
         """
         print("Setup: Creating error JSON...")
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: No (reason: ...) in user message...")
         assert "(reason:" not in error_info.user_message
         assert "CONTENT_LENGTH_EXCEEDS_THRESHOLD" not in error_info.user_message
@@ -93,40 +76,34 @@ class TestEnhanceKiroErrorContentLength:
 
 class TestEnhanceKiroErrorMonthlyLimit:
     """Tests for MONTHLY_REQUEST_COUNT error enhancement."""
-    
+
     def test_monthly_limit_error_enhanced_successfully(self):
         """
         What it does: Verifies MONTHLY_REQUEST_COUNT is enhanced with user-friendly message.
         Purpose: Ensure monthly quota error is clear and actionable.
         """
         print("Setup: Creating error JSON with MONTHLY_REQUEST_COUNT...")
-        error_json = {
-            "message": "You have reached the limit.",
-            "reason": "MONTHLY_REQUEST_COUNT"
-        }
-        
+        error_json = {"message": "You have reached the limit.", "reason": "MONTHLY_REQUEST_COUNT"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: User message is enhanced...")
         assert error_info.user_message == "Monthly request limit exceeded. Account has reached its monthly quota."
         assert error_info.reason == "MONTHLY_REQUEST_COUNT"
         assert error_info.original_message == "You have reached the limit."
-    
+
     def test_monthly_limit_error_no_reason_suffix(self):
         """
         What it does: Verifies enhanced message doesn't include (reason: ...) suffix.
         Purpose: Ensure clean, user-friendly message without technical codes.
         """
         print("Setup: Creating error JSON...")
-        error_json = {
-            "message": "You have reached the limit.",
-            "reason": "MONTHLY_REQUEST_COUNT"
-        }
-        
+        error_json = {"message": "You have reached the limit.", "reason": "MONTHLY_REQUEST_COUNT"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: No (reason: ...) in user message...")
         assert "(reason:" not in error_info.user_message
         assert "MONTHLY_REQUEST_COUNT" not in error_info.user_message
@@ -134,7 +111,7 @@ class TestEnhanceKiroErrorMonthlyLimit:
 
 class TestEnhanceKiroErrorInvalidModelId:
     """Tests for INVALID_MODEL_ID error enhancement."""
-    
+
     def test_invalid_model_id_enhanced_successfully(self):
         """
         What it does: Verifies INVALID_MODEL_ID is enhanced with user-friendly message.
@@ -143,18 +120,20 @@ class TestEnhanceKiroErrorInvalidModelId:
         print("Setup: Creating error JSON with INVALID_MODEL_ID...")
         error_json = {
             "message": "Invalid model ID. Please select a different model to continue.",
-            "reason": "INVALID_MODEL_ID"
+            "reason": "INVALID_MODEL_ID",
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: User message is enhanced...")
-        print(f"Comparing user_message: Expected 'Invalid model ID or insufficient subscription level to use it.', Got '{error_info.user_message}'")
+        print(
+            f"Comparing user_message: Expected 'Invalid model ID or insufficient subscription level to use it.', Got '{error_info.user_message}'"
+        )
         assert error_info.user_message == "Invalid model ID or insufficient subscription level to use it."
         assert error_info.reason == "INVALID_MODEL_ID"
         assert error_info.original_message == "Invalid model ID. Please select a different model to continue."
-    
+
     def test_invalid_model_id_preserves_original_message(self):
         """
         What it does: Verifies original message is preserved for logging.
@@ -163,16 +142,16 @@ class TestEnhanceKiroErrorInvalidModelId:
         print("Setup: Creating error JSON...")
         error_json = {
             "message": "Invalid model ID. Please select a different model to continue.",
-            "reason": "INVALID_MODEL_ID"
+            "reason": "INVALID_MODEL_ID",
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Original message preserved...")
         assert error_info.original_message == "Invalid model ID. Please select a different model to continue."
         assert error_info.original_message != error_info.user_message
-    
+
     def test_invalid_model_id_reason_string_correct(self):
         """
         What it does: Verifies reason is correctly preserved as string.
@@ -181,16 +160,16 @@ class TestEnhanceKiroErrorInvalidModelId:
         print("Setup: Creating error JSON...")
         error_json = {
             "message": "Invalid model ID. Please select a different model to continue.",
-            "reason": "INVALID_MODEL_ID"
+            "reason": "INVALID_MODEL_ID",
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Reason is correct string value...")
         assert error_info.reason == "INVALID_MODEL_ID"
         assert isinstance(error_info.reason, str)
-    
+
     def test_invalid_model_id_no_reason_suffix(self):
         """
         What it does: Verifies enhanced message doesn't include (reason: ...) suffix.
@@ -199,16 +178,16 @@ class TestEnhanceKiroErrorInvalidModelId:
         print("Setup: Creating error JSON...")
         error_json = {
             "message": "Invalid model ID. Please select a different model to continue.",
-            "reason": "INVALID_MODEL_ID"
+            "reason": "INVALID_MODEL_ID",
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: No (reason: ...) in user message...")
         assert "(reason:" not in error_info.user_message
         assert "INVALID_MODEL_ID" not in error_info.user_message
-    
+
     def test_invalid_model_id_mentions_both_causes(self):
         """
         What it does: Verifies message mentions both possible causes (invalid ID and subscription).
@@ -217,33 +196,30 @@ class TestEnhanceKiroErrorInvalidModelId:
         print("Setup: Creating error JSON...")
         error_json = {
             "message": "Invalid model ID. Please select a different model to continue.",
-            "reason": "INVALID_MODEL_ID"
+            "reason": "INVALID_MODEL_ID",
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Message mentions both causes...")
         message_lower = error_info.user_message.lower()
         # Should mention "invalid" or "model id"
         assert "invalid" in message_lower or "model id" in message_lower
         # Should mention "subscription" or "level"
         assert "subscription" in message_lower or "level" in message_lower
-    
+
     def test_invalid_model_id_with_different_original_message(self):
         """
         What it does: Verifies enhancement works regardless of original message text.
         Purpose: Ensure enhancement is based on reason code, not message text.
         """
         print("Setup: Creating error JSON with different original message...")
-        error_json = {
-            "message": "Model not found.",
-            "reason": "INVALID_MODEL_ID"
-        }
-        
+        error_json = {"message": "Model not found.", "reason": "INVALID_MODEL_ID"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Same enhanced message regardless of original...")
         assert error_info.user_message == "Invalid model ID or insufficient subscription level to use it."
         assert error_info.original_message == "Model not found."
@@ -251,27 +227,24 @@ class TestEnhanceKiroErrorInvalidModelId:
 
 class TestEnhanceKiroErrorUnknown:
     """Tests for unknown error handling."""
-    
+
     def test_unknown_reason_keeps_original_with_suffix(self):
         """
         What it does: Verifies unknown reasons keep original message with (reason: ...) suffix.
         Purpose: Ensure unrecognized errors are passed through with context.
         """
         print("Setup: Creating error JSON with unknown reason...")
-        error_json = {
-            "message": "Something went wrong.",
-            "reason": "UNKNOWN_FUTURE_ERROR"
-        }
-        
+        error_json = {"message": "Something went wrong.", "reason": "UNKNOWN_FUTURE_ERROR"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Original message with reason suffix...")
         print(f"User message: {error_info.user_message}")
         assert error_info.user_message == "Something went wrong. (reason: UNKNOWN_FUTURE_ERROR)"
         assert error_info.reason == "UNKNOWN_FUTURE_ERROR"
         assert error_info.original_message == "Something went wrong."
-    
+
     def test_unknown_reason_preserved_as_string(self):
         """
         What it does: Verifies unknown reasons are preserved as-is (not mapped to "UNKNOWN").
@@ -280,48 +253,43 @@ class TestEnhanceKiroErrorUnknown:
         print("Setup: Creating error JSON with unknown reason...")
         error_json = {
             "message": "Error occurred.",
-            "reason": "RATE_LIMIT_EXCEEDED"  # Future error not yet enhanced
+            "reason": "RATE_LIMIT_EXCEEDED",  # Future error not yet enhanced
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Reason preserved as original string...")
         assert error_info.reason == "RATE_LIMIT_EXCEEDED"
         assert error_info.user_message == "Error occurred. (reason: RATE_LIMIT_EXCEEDED)"
-    
+
     def test_missing_reason_field_uses_unknown(self):
         """
         What it does: Verifies missing reason field defaults to UNKNOWN.
         Purpose: Ensure graceful handling of errors without reason field.
         """
         print("Setup: Creating error JSON without reason field...")
-        error_json = {
-            "message": "An error occurred."
-        }
-        
+        error_json = {"message": "An error occurred."}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Reason is UNKNOWN, no suffix in message...")
         assert error_info.reason == "UNKNOWN"
         assert error_info.user_message == "An error occurred."
         assert "(reason:" not in error_info.user_message
-    
+
     def test_reason_unknown_string_no_suffix(self):
         """
         What it does: Verifies reason="UNKNOWN" doesn't add redundant suffix.
         Purpose: Ensure clean message when reason is explicitly UNKNOWN.
         """
         print("Setup: Creating error JSON with reason='UNKNOWN'...")
-        error_json = {
-            "message": "Unknown error.",
-            "reason": "UNKNOWN"
-        }
-        
+        error_json = {"message": "Unknown error.", "reason": "UNKNOWN"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: No redundant (reason: UNKNOWN) suffix...")
         assert error_info.user_message == "Unknown error."
         assert "(reason: UNKNOWN)" not in error_info.user_message
@@ -329,7 +297,7 @@ class TestEnhanceKiroErrorUnknown:
 
 class TestEnhanceKiroErrorEdgeCases:
     """Tests for edge cases and malformed input."""
-    
+
     def test_empty_error_json_uses_defaults(self):
         """
         What it does: Verifies empty error JSON uses default values.
@@ -337,69 +305,61 @@ class TestEnhanceKiroErrorEdgeCases:
         """
         print("Setup: Creating empty error JSON...")
         error_json = {}
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Default values used...")
         assert error_info.original_message == "Unknown error"
         assert error_info.reason == "UNKNOWN"
         assert error_info.user_message == "Unknown error"
-    
+
     def test_missing_message_field_uses_default(self):
         """
         What it does: Verifies missing message field uses "Unknown error" default.
         Purpose: Ensure graceful handling when message field is absent.
         """
         print("Setup: Creating error JSON without message field...")
-        error_json = {
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Default message used, but enhancement still applied...")
         assert error_info.original_message == "Unknown error"
         # Enhancement should still work based on reason
         assert error_info.user_message == "Model context limit reached. Conversation size exceeds model capacity."
-    
+
     def test_empty_message_string_preserved(self):
         """
         What it does: Verifies empty message string is preserved (not replaced with default).
         Purpose: Ensure explicit empty strings are distinguished from missing fields.
         """
         print("Setup: Creating error JSON with empty message...")
-        error_json = {
-            "message": "",
-            "reason": "SOME_ERROR"
-        }
-        
+        error_json = {"message": "", "reason": "SOME_ERROR"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Empty string preserved...")
         assert error_info.original_message == ""
         assert error_info.user_message == " (reason: SOME_ERROR)"
-    
+
     def test_none_values_handled_gracefully(self):
         """
         What it does: Verifies None values in error JSON are handled gracefully.
         Purpose: Ensure robustness against unexpected None values.
         """
         print("Setup: Creating error JSON with None values...")
-        error_json = {
-            "message": None,
-            "reason": None
-        }
-        
+        error_json = {"message": None, "reason": None}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Defaults used for None values...")
         assert error_info.original_message == "Unknown error"
         assert error_info.reason == "UNKNOWN"
-    
+
     def test_extra_fields_ignored(self):
         """
         What it does: Verifies extra fields in error JSON are ignored.
@@ -410,16 +370,16 @@ class TestEnhanceKiroErrorEdgeCases:
             "message": "Error occurred.",
             "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD",
             "extra_field": "extra_value",
-            "another_field": 123
+            "another_field": 123,
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Extra fields don't affect enhancement...")
         assert error_info.user_message == "Model context limit reached. Conversation size exceeds model capacity."
         assert error_info.reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-    
+
     def test_case_sensitive_reason_matching(self):
         """
         What it does: Verifies reason matching is case-sensitive.
@@ -428,12 +388,12 @@ class TestEnhanceKiroErrorEdgeCases:
         print("Setup: Creating error JSON with lowercase reason...")
         error_json = {
             "message": "Error.",
-            "reason": "content_length_exceeds_threshold"  # lowercase
+            "reason": "content_length_exceeds_threshold",  # lowercase
         }
-        
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Lowercase reason not matched, passed through as-is...")
         assert error_info.reason == "content_length_exceeds_threshold"
         assert error_info.user_message == "Error. (reason: content_length_exceeds_threshold)"
@@ -441,21 +401,18 @@ class TestEnhanceKiroErrorEdgeCases:
 
 class TestEnhanceKiroErrorMessageQuality:
     """Tests for message quality and user experience."""
-    
+
     def test_enhanced_message_is_user_friendly(self):
         """
         What it does: Verifies enhanced message is clear and non-technical.
         Purpose: Ensure end users can understand the error without technical knowledge.
         """
         print("Setup: Creating CONTENT_LENGTH_EXCEEDS_THRESHOLD error...")
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Message is user-friendly...")
         message = error_info.user_message
         # Should mention "context limit" (technical but understandable)
@@ -465,40 +422,34 @@ class TestEnhanceKiroErrorMessageQuality:
         # Should NOT contain technical jargon
         assert "threshold" not in message.lower()
         assert "input" not in message.lower()
-    
+
     def test_enhanced_message_indicates_model_limitation(self):
         """
         What it does: Verifies message indicates it's a model limitation, not gateway error.
         Purpose: Ensure users understand the error is from the model, not our service.
         """
         print("Setup: Creating CONTENT_LENGTH_EXCEEDS_THRESHOLD error...")
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Message indicates model limitation...")
         message = error_info.user_message
         assert "model" in message.lower()
         assert "limit" in message.lower()
-    
+
     def test_unknown_error_preserves_original_context(self):
         """
         What it does: Verifies unknown errors preserve original message for context.
         Purpose: Ensure users get Amazon's original error when we can't enhance it.
         """
         print("Setup: Creating unknown error...")
-        error_json = {
-            "message": "Service temporarily unavailable.",
-            "reason": "SERVICE_UNAVAILABLE"
-        }
-        
+        error_json = {"message": "Service temporarily unavailable.", "reason": "SERVICE_UNAVAILABLE"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Original message preserved with reason...")
         assert "Service temporarily unavailable" in error_info.user_message
         assert "SERVICE_UNAVAILABLE" in error_info.user_message
@@ -506,7 +457,7 @@ class TestEnhanceKiroErrorMessageQuality:
 
 class TestKiroErrorInfoDataclass:
     """Tests for KiroErrorInfo dataclass."""
-    
+
     def test_kiro_error_info_creation(self):
         """
         What it does: Verifies KiroErrorInfo can be created with all fields.
@@ -514,37 +465,31 @@ class TestKiroErrorInfoDataclass:
         """
         print("Setup: Creating KiroErrorInfo...")
         error_info = KiroErrorInfo(
-            reason="CONTENT_LENGTH_EXCEEDS_THRESHOLD",
-            user_message="Test message",
-            original_message="Original message"
+            reason="CONTENT_LENGTH_EXCEEDS_THRESHOLD", user_message="Test message", original_message="Original message"
         )
-        
+
         print("Verification: All fields accessible...")
         assert error_info.reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
         assert error_info.user_message == "Test message"
         assert error_info.original_message == "Original message"
-    
+
     def test_kiro_error_info_fields_accessible(self):
         """
         What it does: Verifies KiroErrorInfo fields can be accessed.
         Purpose: Ensure error info structure is usable.
         """
         print("Setup: Creating KiroErrorInfo...")
-        error_info = KiroErrorInfo(
-            reason="UNKNOWN",
-            user_message="Message",
-            original_message="Original"
-        )
-        
+        error_info = KiroErrorInfo(reason="UNKNOWN", user_message="Message", original_message="Original")
+
         print("Verification: Fields are accessible...")
-        assert hasattr(error_info, 'reason')
-        assert hasattr(error_info, 'user_message')
-        assert hasattr(error_info, 'original_message')
+        assert hasattr(error_info, "reason")
+        assert hasattr(error_info, "user_message")
+        assert hasattr(error_info, "original_message")
 
 
 class TestEnhanceKiroErrorIntegration:
     """Integration tests for real-world scenarios."""
-    
+
     def test_real_world_content_length_error(self):
         """
         What it does: Verifies enhancement works with real Kiro API error format.
@@ -552,19 +497,16 @@ class TestEnhanceKiroErrorIntegration:
         """
         print("Setup: Creating real-world error JSON from Kiro API...")
         # This is the actual format from issue #63
-        error_json = {
-            "message": "Input is too long.",
-            "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-        }
-        
+        error_json = {"message": "Input is too long.", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
+
         print("Action: Enhancing error...")
         error_info = enhance_kiro_error(error_json)
-        
+
         print("Verification: Real-world error enhanced correctly...")
         assert "Model context limit reached" in error_info.user_message
         assert "Conversation size exceeds model capacity" in error_info.user_message
         assert error_info.reason == "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
-    
+
     def test_multiple_errors_enhanced_independently(self):
         """
         What it does: Verifies multiple errors can be enhanced independently.
@@ -574,12 +516,12 @@ class TestEnhanceKiroErrorIntegration:
         error1 = {"message": "Error 1", "reason": "CONTENT_LENGTH_EXCEEDS_THRESHOLD"}
         error2 = {"message": "Error 2", "reason": "UNKNOWN_ERROR"}
         error3 = {"message": "Error 3"}
-        
+
         print("Action: Enhancing all errors...")
         info1 = enhance_kiro_error(error1)
         info2 = enhance_kiro_error(error2)
         info3 = enhance_kiro_error(error3)
-        
+
         print("Verification: Each error enhanced independently...")
         assert info1.user_message == "Model context limit reached. Conversation size exceeds model capacity."
         assert info2.user_message == "Error 2 (reason: UNKNOWN_ERROR)"

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -5,16 +5,16 @@ Unit tests for main.py CLI functions.
 Tests for parse_cli_args(), resolve_server_config(), and print_startup_banner().
 """
 
-import pytest
 import argparse
 import sys
-from unittest.mock import patch, MagicMock
-from io import StringIO
+from unittest.mock import patch
+
+import pytest
 
 
 class TestParseCliArgs:
     """Tests for parse_cli_args() function."""
-    
+
     def test_default_values_are_none(self):
         """
         What it does: Verifies that default values for host and port are None.
@@ -22,17 +22,17 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with no arguments...")
-        with patch.object(sys, 'argv', ['main.py']):
+        with patch.object(sys, "argv", ["main.py"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"args.port: {args.port}")
-        print(f"Comparing: Expected host=None, port=None")
+        print("Comparing: Expected host=None, port=None")
         assert args.host is None
         assert args.port is None
-    
+
     def test_port_argument_long_form(self):
         """
         What it does: Verifies that --port argument is parsed correctly.
@@ -40,15 +40,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --port 9000...")
-        with patch.object(sys, 'argv', ['main.py', '--port', '9000']):
+        with patch.object(sys, "argv", ["main.py", "--port", "9000"]):
             args = parse_cli_args()
-        
+
         print(f"args.port: {args.port}")
         print(f"Comparing: Expected 9000, Got {args.port}")
         assert args.port == 9000
-    
+
     def test_port_argument_short_form(self):
         """
         What it does: Verifies that -p argument is parsed correctly.
@@ -56,15 +56,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with -p 8080...")
-        with patch.object(sys, 'argv', ['main.py', '-p', '8080']):
+        with patch.object(sys, "argv", ["main.py", "-p", "8080"]):
             args = parse_cli_args()
-        
+
         print(f"args.port: {args.port}")
         print(f"Comparing: Expected 8080, Got {args.port}")
         assert args.port == 8080
-    
+
     def test_host_argument_long_form(self):
         """
         What it does: Verifies that --host argument is parsed correctly.
@@ -72,15 +72,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --host 127.0.0.1...")
-        with patch.object(sys, 'argv', ['main.py', '--host', '127.0.0.1']):
+        with patch.object(sys, "argv", ["main.py", "--host", "127.0.0.1"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"Comparing: Expected '127.0.0.1', Got '{args.host}'")
         assert args.host == "127.0.0.1"
-    
+
     def test_host_argument_short_form(self):
         """
         What it does: Verifies that -H argument is parsed correctly.
@@ -88,15 +88,15 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with -H 192.168.1.1...")
-        with patch.object(sys, 'argv', ['main.py', '-H', '192.168.1.1']):
+        with patch.object(sys, "argv", ["main.py", "-H", "192.168.1.1"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"Comparing: Expected '192.168.1.1', Got '{args.host}'")
         assert args.host == "192.168.1.1"
-    
+
     def test_both_arguments_together(self):
         """
         What it does: Verifies that both --host and --port can be used together.
@@ -104,16 +104,16 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --host 0.0.0.0 --port 3000...")
-        with patch.object(sys, 'argv', ['main.py', '--host', '0.0.0.0', '--port', '3000']):
+        with patch.object(sys, "argv", ["main.py", "--host", "0.0.0.0", "--port", "3000"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"args.port: {args.port}")
         assert args.host == "0.0.0.0"
         assert args.port == 3000
-    
+
     def test_short_forms_together(self):
         """
         What it does: Verifies that both -H and -p can be used together.
@@ -121,11 +121,11 @@ class TestParseCliArgs:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with -H 127.0.0.1 -p 5000...")
-        with patch.object(sys, 'argv', ['main.py', '-H', '127.0.0.1', '-p', '5000']):
+        with patch.object(sys, "argv", ["main.py", "-H", "127.0.0.1", "-p", "5000"]):
             args = parse_cli_args()
-        
+
         print(f"args.host: {args.host}")
         print(f"args.port: {args.port}")
         assert args.host == "127.0.0.1"
@@ -134,7 +134,7 @@ class TestParseCliArgs:
 
 class TestResolveServerConfig:
     """Tests for resolve_server_config() function - priority hierarchy."""
-    
+
     def test_cli_args_take_priority_over_env(self):
         """
         What it does: Verifies that CLI arguments have highest priority.
@@ -142,24 +142,26 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=127.0.0.1, port=9000...")
         args = argparse.Namespace(host="127.0.0.1", port=9000)
-        
+
         print("Action: Calling resolve_server_config with CLI args...")
         # Even if env vars are set, CLI should win
-        with patch('main.SERVER_HOST', '0.0.0.0'), \
-             patch('main.SERVER_PORT', 8000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "0.0.0.0"),
+            patch("main.SERVER_PORT", 8000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('127.0.0.1', 9000)")
+        print("Comparing: Expected ('127.0.0.1', 9000)")
         assert host == "127.0.0.1"
         assert port == 9000
-    
+
     def test_env_vars_take_priority_over_defaults(self):
         """
         What it does: Verifies that env vars have priority over defaults.
@@ -167,24 +169,26 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=None, port=None (no CLI args)...")
         args = argparse.Namespace(host=None, port=None)
-        
+
         print("Action: Calling resolve_server_config with env vars set...")
         # SERVER_HOST and SERVER_PORT are different from defaults
-        with patch('main.SERVER_HOST', '192.168.1.100'), \
-             patch('main.SERVER_PORT', 3000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "192.168.1.100"),
+            patch("main.SERVER_PORT", 3000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('192.168.1.100', 3000)")
+        print("Comparing: Expected ('192.168.1.100', 3000)")
         assert host == "192.168.1.100"
         assert port == 3000
-    
+
     def test_defaults_used_when_nothing_set(self):
         """
         What it does: Verifies that defaults are used when nothing else is set.
@@ -192,24 +196,26 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=None, port=None...")
         args = argparse.Namespace(host=None, port=None)
-        
+
         print("Action: Calling resolve_server_config with defaults...")
         # SERVER_HOST and SERVER_PORT equal to defaults (no env override)
-        with patch('main.SERVER_HOST', '0.0.0.0'), \
-             patch('main.SERVER_PORT', 8000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "0.0.0.0"),
+            patch("main.SERVER_PORT", 8000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('0.0.0.0', 8000)")
+        print("Comparing: Expected ('0.0.0.0', 8000)")
         assert host == "0.0.0.0"
         assert port == 8000
-    
+
     def test_cli_host_only_env_port(self):
         """
         What it does: Verifies mixed priority - CLI host with env port.
@@ -217,23 +223,25 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host='127.0.0.1', port=None...")
         args = argparse.Namespace(host="127.0.0.1", port=None)
-        
+
         print("Action: Calling resolve_server_config...")
-        with patch('main.SERVER_HOST', '0.0.0.0'), \
-             patch('main.SERVER_PORT', 9000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "0.0.0.0"),
+            patch("main.SERVER_PORT", 9000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('127.0.0.1', 9000)")
+        print("Comparing: Expected ('127.0.0.1', 9000)")
         assert host == "127.0.0.1"  # From CLI
         assert port == 9000  # From env (different from default)
-    
+
     def test_cli_port_only_env_host(self):
         """
         What it does: Verifies mixed priority - CLI port with env host.
@@ -241,27 +249,29 @@ class TestResolveServerConfig:
         """
         print("Setup: Importing resolve_server_config...")
         from main import resolve_server_config
-        
+
         print("Setup: Creating args with host=None, port=5000...")
         args = argparse.Namespace(host=None, port=5000)
-        
+
         print("Action: Calling resolve_server_config...")
-        with patch('main.SERVER_HOST', '192.168.1.1'), \
-             patch('main.SERVER_PORT', 8000), \
-             patch('main.DEFAULT_SERVER_HOST', '0.0.0.0'), \
-             patch('main.DEFAULT_SERVER_PORT', 8000):
+        with (
+            patch("main.SERVER_HOST", "192.168.1.1"),
+            patch("main.SERVER_PORT", 8000),
+            patch("main.DEFAULT_SERVER_HOST", "0.0.0.0"),
+            patch("main.DEFAULT_SERVER_PORT", 8000),
+        ):
             host, port = resolve_server_config(args)
-        
+
         print(f"Resolved host: {host}")
         print(f"Resolved port: {port}")
-        print(f"Comparing: Expected ('192.168.1.1', 5000)")
+        print("Comparing: Expected ('192.168.1.1', 5000)")
         assert host == "192.168.1.1"  # From env (different from default)
         assert port == 5000  # From CLI
 
 
 class TestPrintStartupBanner:
     """Tests for print_startup_banner() function."""
-    
+
     def test_banner_contains_url(self, capsys):
         """
         What it does: Verifies that banner contains the server URL.
@@ -269,16 +279,16 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('0.0.0.0', 8000)...")
         print_startup_banner("0.0.0.0", 8000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output length: {len(captured.out)}")
-        
+
         # When host is 0.0.0.0, display should show localhost
         assert "localhost:8000" in captured.out or "8000" in captured.out
-    
+
     def test_banner_contains_custom_port(self, capsys):
         """
         What it does: Verifies that banner shows custom port.
@@ -286,15 +296,15 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('127.0.0.1', 9000)...")
         print_startup_banner("127.0.0.1", 9000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output contains '9000': {'9000' in captured.out}")
-        
+
         assert "9000" in captured.out
-    
+
     def test_banner_contains_docs_url(self, capsys):
         """
         What it does: Verifies that banner contains API docs URL.
@@ -302,15 +312,15 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('0.0.0.0', 8000)...")
         print_startup_banner("0.0.0.0", 8000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output contains '/docs': {'/docs' in captured.out}")
-        
+
         assert "/docs" in captured.out
-    
+
     def test_banner_contains_health_url(self, capsys):
         """
         What it does: Verifies that banner contains health check URL.
@@ -318,19 +328,19 @@ class TestPrintStartupBanner:
         """
         print("Setup: Importing print_startup_banner...")
         from main import print_startup_banner
-        
+
         print("Action: Calling print_startup_banner('0.0.0.0', 8000)...")
         print_startup_banner("0.0.0.0", 8000)
-        
+
         captured = capsys.readouterr()
         print(f"Captured output contains '/health': {'/health' in captured.out}")
-        
+
         assert "/health" in captured.out
 
 
 class TestCliHelp:
     """Tests for CLI help output."""
-    
+
     def test_help_shows_port_option(self):
         """
         What it does: Verifies that --help shows port option.
@@ -338,16 +348,16 @@ class TestCliHelp:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --help...")
-        with patch.object(sys, 'argv', ['main.py', '--help']):
+        with patch.object(sys, "argv", ["main.py", "--help"]):
             with pytest.raises(SystemExit) as exc_info:
                 parse_cli_args()
-        
+
         print(f"Exit code: {exc_info.value.code}")
         # --help exits with code 0
         assert exc_info.value.code == 0
-    
+
     def test_help_shows_host_option(self, capsys):
         """
         What it does: Verifies that --help output contains host option.
@@ -355,23 +365,23 @@ class TestCliHelp:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --help...")
-        with patch.object(sys, 'argv', ['main.py', '--help']):
+        with patch.object(sys, "argv", ["main.py", "--help"]):
             with pytest.raises(SystemExit):
                 parse_cli_args()
-        
+
         captured = capsys.readouterr()
         print(f"Help output contains '--host': {'--host' in captured.out}")
         print(f"Help output contains '-H': {'-H' in captured.out}")
-        
+
         assert "--host" in captured.out
         assert "-H" in captured.out
 
 
 class TestCliVersion:
     """Tests for CLI version output."""
-    
+
     def test_version_flag_exits_with_zero(self):
         """
         What it does: Verifies that --version exits with code 0.
@@ -379,31 +389,31 @@ class TestCliVersion:
         """
         print("Setup: Importing parse_cli_args...")
         from main import parse_cli_args
-        
+
         print("Action: Calling parse_cli_args with --version...")
-        with patch.object(sys, 'argv', ['main.py', '--version']):
+        with patch.object(sys, "argv", ["main.py", "--version"]):
             with pytest.raises(SystemExit) as exc_info:
                 parse_cli_args()
-        
+
         print(f"Exit code: {exc_info.value.code}")
         assert exc_info.value.code == 0
-    
+
     def test_version_shows_app_version(self, capsys):
         """
         What it does: Verifies that --version shows application version.
         Purpose: Ensure version is displayed.
         """
         print("Setup: Importing parse_cli_args and APP_VERSION...")
-        from main import parse_cli_args
         from kiro.config import APP_VERSION
-        
+        from main import parse_cli_args
+
         print("Action: Calling parse_cli_args with --version...")
-        with patch.object(sys, 'argv', ['main.py', '--version']):
+        with patch.object(sys, "argv", ["main.py", "--version"]):
             with pytest.raises(SystemExit):
                 parse_cli_args()
-        
+
         captured = capsys.readouterr()
         print(f"Version output: {captured.out}")
         print(f"APP_VERSION: {APP_VERSION}")
-        
+
         assert APP_VERSION in captured.out

--- a/tests/unit/test_main_lifespan.py
+++ b/tests/unit/test_main_lifespan.py
@@ -12,55 +12,51 @@ Tests cover:
 
 import asyncio
 import json
-import pytest
-import sys
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, Mock, patch, call
-from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 # =============================================================================
 # Test Class: Legacy Fallback (Migration)
 # =============================================================================
 
+
 class TestLifespanLegacyFallback:
     """
     Tests for legacy .env → credentials.json migration.
-    
+
     What it does: Verifies automatic migration from .env to credentials.json
     Purpose: Ensure backward compatibility with existing .env configurations
     """
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_legacy_mode_recreate_credentials(self, tmp_path, monkeypatch):
         """
         Test 92: ACCOUNT_SYSTEM=false всегда пересоздаёт credentials.json
-        
+
         What it does: Verifies that legacy mode recreates credentials.json on every startup
         Purpose: Ensure .env changes are always reflected in legacy mode
         """
         print("\n=== Test 92: Legacy mode recreates credentials.json ===")
-        
+
         # Arrange: Patch constants directly in main module (not os.environ)
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", False)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
-        monkeypatch.setattr("main.PROFILE_ARN", "arn:aws:codewhisperer:us-east-1:123456789:profile/test")
-        monkeypatch.setattr("main.REGION", "us-east-1")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         # Create old credentials.json
         old_creds = [{"type": "json", "path": "/old/path.json"}]
         creds_file.write_text(json.dumps(old_creds))
         print(f"Created old credentials.json: {old_creds}")
-        
+
         # Mock config paths
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         # Mock AccountManager to prevent actual initialization
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
@@ -72,51 +68,51 @@ class TestLifespanLegacyFallback:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
+
                 # Import and run lifespan
-                from main import lifespan, app
-                
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: credentials.json was recreated
         assert creds_file.exists()
         new_creds = json.loads(creds_file.read_text())
         print(f"New credentials.json: {new_creds}")
-        
+
         assert len(new_creds) == 1
         assert new_creds[0]["type"] == "refresh_token"
         assert new_creds[0]["refresh_token"] == "test_refresh_token"
         print("✓ credentials.json was recreated from .env in legacy mode")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_account_system_one_time_migration(self, tmp_path, monkeypatch):
         """
         Test 93: ACCOUNT_SYSTEM=true создаёт credentials.json только раз
-        
+
         What it does: Verifies one-time migration in account system mode
         Purpose: Ensure credentials.json is not overwritten after initial migration
         """
         print("\n=== Test 93: Account system one-time migration ===")
-        
+
         # Arrange: Patch constants directly
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         # First run: no credentials.json
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -127,83 +123,84 @@ class TestLifespanLegacyFallback:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 # First run
                 async with lifespan(app):
                     pass
-        
+
         assert creds_file.exists()
         first_content = creds_file.read_text()
         print(f"First run created: {first_content}")
-        
+
         # Modify credentials.json manually
         manual_creds = [{"type": "json", "path": "/manual/path.json"}]
         creds_file.write_text(json.dumps(manual_creds))
         print(f"Manually modified to: {manual_creds}")
-        
+
         # Second run: credentials.json exists
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: credentials.json was NOT overwritten
         second_content = json.loads(creds_file.read_text())
         print(f"Second run kept: {second_content}")
-        
+
         assert second_content == manual_creds
         print("✓ credentials.json was not overwritten on second run")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_migration_priority_sqlite(self, tmp_path, monkeypatch):
         """
         Test 94: Приоритет SQLite > JSON > refresh_token
-        
+
         What it does: Verifies credential source priority during migration
         Purpose: Ensure correct priority order matches KiroAuthManager
         """
         print("\n=== Test 94: Migration priority SQLite > JSON > refresh_token ===")
-        
+
         # Arrange: all three sources present
         # Create SQLite DB
         import sqlite3
+
         sqlite_db = tmp_path / "data.sqlite3"
         conn = sqlite3.connect(str(sqlite_db))
         cursor = conn.cursor()
         cursor.execute("CREATE TABLE auth_kv (key TEXT PRIMARY KEY, value TEXT)")
         cursor.execute(
             "INSERT INTO auth_kv VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps({"access_token": "sqlite_token"}))
+            ("codewhisperer:odic:token", json.dumps({"access_token": "sqlite_token"})),
         )
         conn.commit()
         conn.close()
-        
+
         # Create JSON file
         json_file = tmp_path / "kiro-auth.json"
         json_file.write_text(json.dumps({"accessToken": "json_token"}))
-        
+
         # Patch constants directly
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", str(sqlite_db))
         monkeypatch.setattr("main.KIRO_CREDS_FILE", str(json_file))
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -214,53 +211,53 @@ class TestLifespanLegacyFallback:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: SQLite was chosen (highest priority)
         creds = json.loads(creds_file.read_text())
         print(f"Created credentials: {creds}")
-        
+
         assert len(creds) == 1
         assert creds[0]["type"] == "sqlite"
         assert creds[0]["path"] == str(sqlite_db)
         print("✓ SQLite was chosen (highest priority)")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_migration_add_env_overrides(self, tmp_path, monkeypatch):
         """
         Test 95: Добавление profile_arn, region, api_region из .env
-        
+
         What it does: Verifies that env var overrides are added to migrated credentials
         Purpose: Ensure per-account parameters are preserved during migration
         """
         print("\n=== Test 95: Add env overrides during migration ===")
-        
+
         # Arrange: Patch constants and also patch os.getenv for _add_env_overrides
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         # Patch os.getenv for the helper function
         monkeypatch.setenv("PROFILE_ARN", "arn:aws:codewhisperer:eu-central-1:123456789:profile/test")
         monkeypatch.setenv("KIRO_REGION", "eu-west-1")
         monkeypatch.setenv("KIRO_API_REGION", "eu-central-1")
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -271,53 +268,53 @@ class TestLifespanLegacyFallback:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: overrides were added
         creds = json.loads(creds_file.read_text())
         print(f"Created credentials with overrides: {creds}")
-        
+
         assert creds[0]["profile_arn"] == "arn:aws:codewhisperer:eu-central-1:123456789:profile/test"
         assert creds[0]["region"] == "eu-west-1"
         assert creds[0]["api_region"] == "eu-central-1"
         print("✓ Env overrides were added to credentials.json")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_skip_migration_if_exists(self, tmp_path, monkeypatch):
         """
         Test 96: Пропуск миграции если credentials.json существует
-        
+
         What it does: Verifies migration is skipped when credentials.json already exists
         Purpose: Prevent overwriting user-managed credentials
         """
         print("\n=== Test 96: Skip migration if credentials.json exists ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_refresh_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         # Pre-create credentials.json
         existing_creds = [{"type": "json", "path": "/existing/path.json"}]
         creds_file.write_text(json.dumps(existing_creds))
         print(f"Pre-existing credentials.json: {existing_creds}")
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -328,21 +325,21 @@ class TestLifespanLegacyFallback:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: credentials.json was not modified
         final_creds = json.loads(creds_file.read_text())
         print(f"Final credentials.json: {final_creds}")
-        
+
         assert final_creds == existing_creds
         print("✓ Migration was skipped, existing credentials.json preserved")
 
@@ -351,58 +348,59 @@ class TestLifespanLegacyFallback:
 # Test Class: AccountManager Initialization
 # =============================================================================
 
+
 class TestLifespanAccountManagerInit:
     """
     Tests for AccountManager initialization and lifecycle.
-    
+
     What it does: Verifies AccountManager creation, account initialization, and background tasks
     Purpose: Ensure proper startup and shutdown of Account System
     """
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_create_account_manager(self, tmp_path, monkeypatch):
         """
         Test 97: Создание AccountManager с правильными путями
-        
+
         What it does: Verifies AccountManager is created with correct file paths
         Purpose: Ensure AccountManager receives proper configuration
         """
         print("\n=== Test 97: Create AccountManager with correct paths ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         # Track AccountManager creation
         manager_created_with = {}
-        
+
         class MockAccountManager:
             def __init__(self, credentials_file, state_file):
                 manager_created_with["credentials_file"] = credentials_file
                 manager_created_with["state_file"] = state_file
                 self._accounts = {"test": MagicMock()}
                 self._current_account_index = 0
-            
+
             async def load_credentials(self):
                 pass
-            
+
             async def load_state(self):
                 pass
-            
+
             async def _initialize_account(self, account_id):
                 return True
-            
+
             async def _save_state(self):
                 pass
-            
+
             async def save_state_periodically(self):
                 await asyncio.sleep(1000)
 
@@ -411,59 +409,59 @@ class TestLifespanAccountManagerInit:
 
             def drain_unsaved_rate_observations(self):
                 return []
-        
+
         with patch("main.AccountManager", MockAccountManager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert
         print(f"AccountManager created with: {manager_created_with}")
         assert manager_created_with["credentials_file"] == str(creds_file)
         assert manager_created_with["state_file"] == str(state_file)
         print("✓ AccountManager created with correct paths")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_load_credentials_and_state(self, tmp_path, monkeypatch):
         """
         Test 98: Вызов load_credentials() и load_state()
-        
+
         What it does: Verifies that load methods are called during startup
         Purpose: Ensure credentials and state are loaded before initialization
         """
         print("\n=== Test 98: Call load_credentials() and load_state() ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         load_calls = {"credentials": False, "state": False}
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
         mock_manager._accounts = {"test": MagicMock()}
         mock_manager._current_account_index = 0
-        
+
         async def track_load_credentials():
             load_calls["credentials"] = True
-        
+
         async def track_load_state():
             load_calls["state"] = True
-        
+
         mock_manager.load_credentials = track_load_credentials
         mock_manager.load_state = track_load_state
         mock_manager._initialize_account = AsyncMock(return_value=True)
@@ -471,45 +469,45 @@ class TestLifespanAccountManagerInit:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert
         print(f"Load calls: {load_calls}")
         assert load_calls["credentials"] is True
         assert load_calls["state"] is True
         print("✓ load_credentials() and load_state() were called")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_set_account_system_flag(self, tmp_path, monkeypatch):
         """
         Test 99: Установка app.state.account_system
-        
+
         What it does: Verifies account_system flag is set in app.state
         Purpose: Ensure routes can check if account system is enabled
         """
         print("\n=== Test 99: Set app.state.account_system flag ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -520,308 +518,298 @@ class TestLifespanAccountManagerInit:
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     # Check flag during lifespan
                     assert hasattr(app.state, "account_system")
                     assert app.state.account_system is True
                     print(f"✓ app.state.account_system = {app.state.account_system}")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_initialize_first_working_account(self, tmp_path, monkeypatch):
         """
         Test 100: Инициализация первого рабочего аккаунта
-        
+
         What it does: Verifies first working account is initialized at startup
         Purpose: Ensure at least one account is ready before accepting requests
         """
         print("\n=== Test 100: Initialize first working account ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         initialized_accounts = []
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        mock_manager._accounts = {
-            "account1": MagicMock(),
-            "account2": MagicMock()
-        }
+        mock_manager._accounts = {"account1": MagicMock(), "account2": MagicMock()}
         mock_manager._current_account_index = 0
-        
+
         async def track_initialize(account_id):
             initialized_accounts.append(account_id)
             return True  # Success on first account
-        
+
         mock_manager._initialize_account = track_initialize
         mock_manager._save_state = AsyncMock()
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: only first account was initialized
         print(f"Initialized accounts: {initialized_accounts}")
         assert len(initialized_accounts) == 1
         assert initialized_accounts[0] == "account1"
         print("✓ First working account was initialized")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_full_circle_initialization(self, tmp_path, monkeypatch):
         """
         Test 101: Попытка инициализации всех аккаунтов по кругу
-        
+
         What it does: Verifies full circle attempt if first accounts fail
         Purpose: Ensure all accounts are tried before giving up
         """
         print("\n=== Test 101: Full circle initialization attempt ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         initialized_attempts = []
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        mock_manager._accounts = {
-            "account1": MagicMock(),
-            "account2": MagicMock(),
-            "account3": MagicMock()
-        }
+        mock_manager._accounts = {"account1": MagicMock(), "account2": MagicMock(), "account3": MagicMock()}
         mock_manager._current_account_index = 0
-        
+
         async def track_initialize(account_id):
             initialized_attempts.append(account_id)
             # First two fail, third succeeds
             if account_id == "account3":
                 return True
             return False
-        
+
         mock_manager._initialize_account = track_initialize
         mock_manager._save_state = AsyncMock()
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: all three accounts were tried
         print(f"Initialization attempts: {initialized_attempts}")
         assert initialized_attempts == ["account1", "account2", "account3"]
         print("✓ Full circle initialization was attempted")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_exit_if_no_accounts(self, tmp_path, monkeypatch):
         """
         Test 102: RuntimeError если нет аккаунтов в credentials.json
-        
+
         What it does: Verifies application raises RuntimeError if no accounts configured
         Purpose: Prevent startup with empty configuration
         """
         print("\n=== Test 102: RuntimeError if no accounts configured ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
         mock_manager._accounts = {}  # Empty accounts dict
         mock_manager._current_account_index = 0
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 # Assert: RuntimeError is raised
                 with pytest.raises(RuntimeError, match="No accounts configured"):
                     async with lifespan(app):
                         pass
-                
+
                 print("✓ RuntimeError was raised for empty accounts")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_exit_if_all_failed(self, tmp_path, monkeypatch):
         """
         Test 103: RuntimeError если все аккаунты не инициализировались
-        
+
         What it does: Verifies application raises RuntimeError if all accounts fail to initialize
         Purpose: Prevent startup without any working accounts
         """
         print("\n=== Test 103: RuntimeError if all accounts failed ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        mock_manager._accounts = {
-            "account1": MagicMock(),
-            "account2": MagicMock()
-        }
+        mock_manager._accounts = {"account1": MagicMock(), "account2": MagicMock()}
         mock_manager._current_account_index = 0
         mock_manager._initialize_account = AsyncMock(return_value=False)  # All fail
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 # Assert: RuntimeError is raised
                 with pytest.raises(RuntimeError, match="Failed to initialize any account"):
                     async with lifespan(app):
                         pass
-                
+
                 print("✓ RuntimeError was raised when all accounts failed")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_save_initial_state(self, tmp_path, monkeypatch):
         """
         Test 104: Сохранение начального state.json
-        
+
         What it does: Verifies initial state is saved after first account initialization
         Purpose: Ensure state persistence starts immediately
         """
         print("\n=== Test 104: Save initial state ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         save_state_called = False
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
         mock_manager._accounts = {"test": MagicMock()}
         mock_manager._current_account_index = 0
         mock_manager._initialize_account = AsyncMock(return_value=True)
-        
+
         async def track_save_state():
             nonlocal save_state_called
             save_state_called = True
-        
+
         mock_manager._save_state = track_save_state
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert
         print(f"_save_state called: {save_state_called}")
         assert save_state_called is True
         print("✓ Initial state was saved")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_start_background_task(self, tmp_path, monkeypatch):
         """
         Test 105: Запуск save_state_periodically()
-        
+
         What it does: Verifies background task is started for periodic state saving
         Purpose: Ensure state is saved periodically during runtime
         """
         print("\n=== Test 105: Start background task ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         periodic_task_started = False
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -831,51 +819,51 @@ class TestLifespanAccountManagerInit:
         mock_manager._save_state = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         async def track_periodic_save():
             nonlocal periodic_task_started
             periodic_task_started = True
             await asyncio.sleep(1000)  # Long sleep to keep task alive
-        
+
         mock_manager.save_state_periodically = track_periodic_save
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     # Give task time to start
                     await asyncio.sleep(0.1)
                     assert periodic_task_started is True
                     print("✓ Background task was started")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_shutdown_cancel_task(self, tmp_path, monkeypatch):
         """
         Test 106: Отмена background task при shutdown
-        
+
         What it does: Verifies background task is cancelled during shutdown
         Purpose: Ensure clean shutdown without hanging tasks
         """
         print("\n=== Test 106: Cancel background task on shutdown ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         task_cancelled = False
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -883,7 +871,7 @@ class TestLifespanAccountManagerInit:
         mock_manager._current_account_index = 0
         mock_manager._initialize_account = AsyncMock(return_value=True)
         mock_manager._save_state = AsyncMock()
-        
+
         async def periodic_save_with_cancel_check():
             try:
                 await asyncio.sleep(1000)
@@ -891,76 +879,76 @@ class TestLifespanAccountManagerInit:
                 nonlocal task_cancelled
                 task_cancelled = True
                 raise
-        
+
         mock_manager.save_state_periodically = periodic_save_with_cancel_check
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     await asyncio.sleep(0.1)
-                
+
                 # After context exit, task should be cancelled
                 await asyncio.sleep(0.1)
-        
+
         # Assert
         print(f"Task cancelled: {task_cancelled}")
         assert task_cancelled is True
         print("✓ Background task was cancelled on shutdown")
-    
+
     @pytest.mark.asyncio
     async def test_lifespan_shutdown_final_save(self, tmp_path, monkeypatch):
         """
         Test 107: Финальное сохранение state.json при shutdown
-        
+
         What it does: Verifies final state save happens during shutdown
         Purpose: Ensure no state is lost on graceful shutdown
         """
         print("\n=== Test 107: Final save on shutdown ===")
-        
+
         # Arrange: Patch constants
         monkeypatch.setattr("main.ACCOUNT_SYSTEM", True)
         monkeypatch.setattr("main.REFRESH_TOKEN", "test_token")
         monkeypatch.setattr("main.KIRO_CREDS_FILE", None)
         monkeypatch.setattr("main.KIRO_CLI_DB_FILE", None)
-        
+
         creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
-        
+
         monkeypatch.setattr("main.ACCOUNTS_CONFIG_FILE", str(creds_file))
         monkeypatch.setattr("main.ACCOUNTS_STATE_FILE", str(state_file))
-        
+
         save_calls = []
-        
+
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
         mock_manager._accounts = {"test": MagicMock()}
         mock_manager._current_account_index = 0
         mock_manager._initialize_account = AsyncMock(return_value=True)
-        
+
         async def track_save_state():
             save_calls.append("save")
-        
+
         mock_manager._save_state = track_save_state
         mock_manager.save_state_periodically = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
-        
+
         with patch("main.AccountManager", return_value=mock_manager):
             with patch("main.httpx.AsyncClient") as mock_client_class:
                 mock_client = AsyncMock()
                 mock_client_class.return_value = mock_client
-                
-                from main import lifespan, app
-                
+
+                from main import app, lifespan
+
                 async with lifespan(app):
                     pass
-        
+
         # Assert: at least 2 saves (initial + final)
         print(f"Save calls: {len(save_calls)}")
         assert len(save_calls) >= 2

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -13,73 +13,72 @@ Tests cover:
 """
 
 import json
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime
 
 from kiro.mcp_tools import (
-    generate_random_id,
     call_kiro_mcp_api,
-    generate_search_summary,
     extract_query_from_messages,
-    handle_native_web_search,
     generate_anthropic_web_search_sse,
-    generate_openai_web_search_sse
+    generate_openai_web_search_sse,
+    generate_random_id,
+    generate_search_summary,
 )
-
 
 # ==================================================================================================
 # Tests for ID Generation
 # ==================================================================================================
 
+
 class TestIDGeneration:
     """Tests for random ID generation."""
-    
+
     def test_generate_random_id_length(self):
         """
         What it does: Verifies ID generation with exact length.
         Purpose: Ensure generate_random_id returns correct length.
         """
         print("Setup: Generating IDs of different lengths...")
-        
+
         print("Action: Generate ID of length 22...")
         id_22 = generate_random_id(22)
         print(f"Comparing length: Expected 22, Got {len(id_22)}")
         assert len(id_22) == 22
-        
+
         print("Action: Generate ID of length 8...")
         id_8 = generate_random_id(8)
         print(f"Comparing length: Expected 8, Got {len(id_8)}")
         assert len(id_8) == 8
-        
+
         print("Action: Generate ID of length 100...")
         id_100 = generate_random_id(100)
         print(f"Comparing length: Expected 100, Got {len(id_100)}")
         assert len(id_100) == 100
-    
+
     def test_generate_random_id_alphanumeric(self):
         """
         What it does: Verifies ID contains only alphanumeric characters.
         Purpose: Ensure no special characters in generated IDs.
         """
         print("Setup: Generating large ID to test character set...")
-        
+
         print("Action: Generate ID of length 1000...")
         random_id = generate_random_id(1000)
-        
+
         print(f"Checking if alphanumeric: {random_id[:50]}...")
         assert random_id.isalnum()
-    
+
     def test_generate_random_id_uniqueness(self):
         """
         What it does: Verifies IDs are unique (probabilistically).
         Purpose: Ensure randomness works correctly.
         """
         print("Setup: Generating multiple IDs...")
-        
+
         print("Action: Generate 100 IDs of length 22...")
         ids = [generate_random_id(22) for _ in range(100)]
-        
+
         print(f"Comparing uniqueness: Generated {len(ids)} IDs, unique: {len(set(ids))}")
         assert len(set(ids)) == len(ids)  # All should be unique
 
@@ -88,9 +87,10 @@ class TestIDGeneration:
 # Tests for MCP API Call
 # ==================================================================================================
 
+
 class TestCallKiroMCPAPI:
     """Tests for MCP API calls."""
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_success(self, mock_auth_manager):
         """
@@ -99,54 +99,58 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking successful MCP API response...")
         query = "Python tutorials"
-        
+
         # Mock MCP response (CRITICAL: result.content[0].text is JSON STRING)
         mock_response_data = {
             "id": "web_search_tooluse_abc123_1234567890_xyz",
             "jsonrpc": "2.0",
             "result": {
-                "content": [{
-                    "type": "text",
-                    "text": json.dumps({
-                        "results": [
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
                             {
-                                "title": "Python Tutorial",
-                                "url": "https://python.org",
-                                "snippet": "Learn Python programming",
-                                "publishedDate": 1700000000000
+                                "results": [
+                                    {
+                                        "title": "Python Tutorial",
+                                        "url": "https://python.org",
+                                        "snippet": "Learn Python programming",
+                                        "publishedDate": 1700000000000,
+                                    }
+                                ],
+                                "totalResults": 1,
+                                "query": "Python tutorials",
                             }
-                        ],
-                        "totalResults": 1,
-                        "query": "Python tutorials"
-                    })
-                }],
-                "isError": False
-            }
+                        ),
+                    }
+                ],
+                "isError": False,
+            },
         }
-        
+
         # Mock httpx.AsyncClient - CRITICAL: json() must be async
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_response_data)
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
+
         print(f"Comparing tool_use_id: Got '{tool_use_id}'")
         assert tool_use_id is not None
         assert tool_use_id.startswith("srvtoolu_")
-        
+
         print(f"Comparing results: Got {results}")
         assert results is not None
         assert results["totalResults"] == 1
         assert results["results"][0]["title"] == "Python Tutorial"
         assert results["results"][0]["url"] == "https://python.org"
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_error_response(self, mock_auth_manager):
         """
@@ -155,30 +159,30 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking MCP API error response...")
         query = "test"
-        
+
         # Mock error response
         mock_response_data = {
             "id": "web_search_tooluse_abc123_1234567890_xyz",
             "jsonrpc": "2.0",
-            "error": {"code": -32600, "message": "Invalid request"}
+            "error": {"code": -32600, "message": "Invalid request"},
         }
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json = Mock(return_value=mock_response_data)
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
+
         print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
         assert tool_use_id is None
         assert results is None
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_http_error(self, mock_auth_manager):
         """
@@ -187,22 +191,22 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking HTTP 500 error...")
         query = "test"
-        
+
         mock_response = Mock()
         mock_response.status_code = 500
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
+
         print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
         assert tool_use_id is None
         assert results is None
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_timeout(self, mock_auth_manager):
         """
@@ -211,21 +215,21 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking timeout exception...")
         query = "test"
-        
+
         import httpx
-        
+
         mock_post = AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
+
         print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
         assert tool_use_id is None
         assert results is None
-    
+
     @pytest.mark.asyncio
     async def test_mcp_api_json_decode_error(self, mock_auth_manager):
         """
@@ -234,19 +238,19 @@ class TestCallKiroMCPAPI:
         """
         print("Setup: Mocking malformed JSON response...")
         query = "test"
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json = Mock(side_effect=json.JSONDecodeError("Invalid JSON", "", 0))
-        
+
         mock_post = AsyncMock(return_value=mock_response)
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value.post = mock_post
-        
+
         print("Action: Calling call_kiro_mcp_api...")
         with patch("kiro.mcp_tools.httpx.AsyncClient", return_value=mock_client):
             tool_use_id, results = await call_kiro_mcp_api(query, mock_auth_manager)
-        
+
         print(f"Comparing result: Expected (None, None), Got ({tool_use_id}, {results})")
         assert tool_use_id is None
         assert results is None
@@ -256,9 +260,10 @@ class TestCallKiroMCPAPI:
 # Tests for Search Summary Generation
 # ==================================================================================================
 
+
 class TestGenerateSearchSummary:
     """Tests for search summary formatting."""
-    
+
     def test_generate_summary_with_results(self):
         """
         What it does: Verifies summary formatting with results.
@@ -272,38 +277,38 @@ class TestGenerateSearchSummary:
                     "title": "Python.org",
                     "url": "https://python.org",
                     "snippet": "Official Python website with tutorials",
-                    "publishedDate": 1700000000000
+                    "publishedDate": 1700000000000,
                 },
                 {
                     "title": "Python Tutorial",
                     "url": "https://docs.python.org",
                     "snippet": "Complete Python documentation",
-                    "publishedDate": None  # No date
-                }
+                    "publishedDate": None,  # No date
+                },
             ],
-            "totalResults": 2
+            "totalResults": 2,
         }
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
-        print(f"Checking XML tags...")
+
+        print("Checking XML tags...")
         assert "<web_search>" in summary
         assert "</web_search>" in summary
-        
-        print(f"Checking query in summary...")
+
+        print("Checking query in summary...")
         assert "Python" in summary
-        
-        print(f"Checking first result...")
+
+        print("Checking first result...")
         assert "Python.org" in summary
         assert "https://python.org" in summary
         assert "Official Python website with tutorials" in summary
-        
-        print(f"Checking second result...")
+
+        print("Checking second result...")
         assert "Python Tutorial" in summary
         assert "https://docs.python.org" in summary
         assert "Complete Python documentation" in summary
-    
+
     def test_generate_summary_no_results(self):
         """
         What it does: Verifies summary with empty results list.
@@ -312,21 +317,21 @@ class TestGenerateSearchSummary:
         print("Setup: Creating empty results...")
         query = "nonexistent"
         results = {"results": [], "totalResults": 0}
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
-        print(f"Checking XML tags...")
+
+        print("Checking XML tags...")
         assert "<web_search>" in summary
         assert "</web_search>" in summary
-        
-        print(f"Checking query in summary...")
+
+        print("Checking query in summary...")
         assert "nonexistent" in summary
-        
+
         print(f"Summary content: {repr(summary)}")
         # Empty results list produces empty content between tags (no "No results found")
         assert "Search results for" in summary
-    
+
     def test_generate_summary_malformed_results(self):
         """
         What it does: Verifies handling of malformed results.
@@ -335,13 +340,13 @@ class TestGenerateSearchSummary:
         print("Setup: Creating malformed results...")
         query = "test"
         results = {"invalid": "structure"}
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
-        print(f"Checking for 'No results found'...")
+
+        print("Checking for 'No results found'...")
         assert "No results found" in summary
-    
+
     def test_generate_summary_date_formatting(self):
         """
         What it does: Verifies date formatting from milliseconds timestamp.
@@ -351,22 +356,19 @@ class TestGenerateSearchSummary:
         query = "test"
         # 1700000000000 ms = 2023-11-14 22:13:20 UTC
         results = {
-            "results": [{
-                "title": "Test",
-                "url": "https://test.com",
-                "snippet": "Test snippet",
-                "publishedDate": 1700000000000
-            }],
-            "totalResults": 1
+            "results": [
+                {"title": "Test", "url": "https://test.com", "snippet": "Test snippet", "publishedDate": 1700000000000}
+            ],
+            "totalResults": 1,
         }
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
-        print(f"Checking date format...")
+
+        print("Checking date format...")
         # Should contain formatted date like "14 Nov 2023"
         assert "Nov 2023" in summary or "Ноя 2023" in summary  # Depends on locale
-    
+
     def test_generate_summary_full_snippet_no_truncation(self):
         """
         What it does: Verifies snippets are NOT truncated.
@@ -376,19 +378,14 @@ class TestGenerateSearchSummary:
         query = "test"
         long_snippet = "A" * 1000  # 1000 characters
         results = {
-            "results": [{
-                "title": "Test",
-                "url": "https://test.com",
-                "snippet": long_snippet,
-                "publishedDate": None
-            }],
-            "totalResults": 1
+            "results": [{"title": "Test", "url": "https://test.com", "snippet": long_snippet, "publishedDate": None}],
+            "totalResults": 1,
         }
-        
+
         print("Action: Generating summary...")
         summary = generate_search_summary(query, results)
-        
-        print(f"Checking snippet is NOT truncated...")
+
+        print("Checking snippet is NOT truncated...")
         assert long_snippet in summary
         assert len(long_snippet) == 1000  # Full length preserved
 
@@ -397,9 +394,10 @@ class TestGenerateSearchSummary:
 # Tests for Query Extraction
 # ==================================================================================================
 
+
 class TestExtractQueryFromMessages:
     """Tests for query extraction from messages."""
-    
+
     def test_extract_query_anthropic_string_content(self):
         """
         What it does: Extracts query from Anthropic string content.
@@ -407,14 +405,15 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating Anthropic message with string content...")
         from kiro.models_anthropic import AnthropicMessage
+
         messages = [AnthropicMessage(role="user", content="Search for Python tutorials")]
-        
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Search for Python tutorials', Got '{query}'")
         assert query == "Search for Python tutorials"
-    
+
     def test_extract_query_anthropic_list_content(self):
         """
         What it does: Extracts query from Anthropic list content.
@@ -422,17 +421,15 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating Anthropic message with list content...")
         from kiro.models_anthropic import AnthropicMessage, TextContentBlock
-        messages = [AnthropicMessage(
-            role="user",
-            content=[TextContentBlock(type="text", text="Python tutorials")]
-        )]
-        
+
+        messages = [AnthropicMessage(role="user", content=[TextContentBlock(type="text", text="Python tutorials")])]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Python tutorials', Got '{query}'")
         assert query == "Python tutorials"
-    
+
     def test_extract_query_with_prefix(self):
         """
         What it does: Removes 'Perform a web search for the query:' prefix.
@@ -440,17 +437,15 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating message with prefix...")
         from kiro.models_anthropic import AnthropicMessage
-        messages = [AnthropicMessage(
-            role="user",
-            content="Perform a web search for the query: Python"
-        )]
-        
+
+        messages = [AnthropicMessage(role="user", content="Perform a web search for the query: Python")]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Python', Got '{query}'")
         assert query == "Python"
-    
+
     def test_extract_query_empty_messages(self):
         """
         What it does: Handles empty messages list.
@@ -458,38 +453,43 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating empty messages list...")
         messages = []
-        
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected None, Got {query}")
         assert query is None
-    
+
     def test_extract_query_no_text_content(self):
         """
         What it does: Handles messages without text content.
         Purpose: Ensure None is returned for non-text messages.
         """
         print("Setup: Creating message with image content...")
-        from kiro.models_anthropic import AnthropicMessage, ImageContentBlock, Base64ImageSource
-        messages = [AnthropicMessage(
-            role="user",
-            content=[ImageContentBlock(
-                type="image",
-                source=Base64ImageSource(
-                    type="base64",
-                    media_type="image/png",
-                    data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-                )
-            )]
-        )]
-        
+        from kiro.models_anthropic import AnthropicMessage, Base64ImageSource, ImageContentBlock
+
+        messages = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    ImageContentBlock(
+                        type="image",
+                        source=Base64ImageSource(
+                            type="base64",
+                            media_type="image/png",
+                            data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                        ),
+                    )
+                ],
+            )
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected None or empty, Got '{query}'")
         assert query is None or query == ""
-    
+
     def test_extract_query_multiple_text_blocks(self):
         """
         What it does: Concatenates multiple text blocks.
@@ -497,17 +497,20 @@ class TestExtractQueryFromMessages:
         """
         print("Setup: Creating message with multiple text blocks...")
         from kiro.models_anthropic import AnthropicMessage, TextContentBlock
-        messages = [AnthropicMessage(
-            role="user",
-            content=[
-                TextContentBlock(type="text", text="Search for "),
-                TextContentBlock(type="text", text="Python tutorials")
-            ]
-        )]
-        
+
+        messages = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    TextContentBlock(type="text", text="Search for "),
+                    TextContentBlock(type="text", text="Python tutorials"),
+                ],
+            )
+        ]
+
         print("Action: Extracting query...")
         query = extract_query_from_messages(messages, "anthropic")
-        
+
         print(f"Comparing query: Expected 'Search for Python tutorials', Got '{query}'")
         assert query == "Search for Python tutorials"
 
@@ -516,9 +519,10 @@ class TestExtractQueryFromMessages:
 # Tests for SSE Emulation
 # ==================================================================================================
 
+
 class TestAnthropicSSEEmulation:
     """Tests for Anthropic SSE stream generation."""
-    
+
     @pytest.mark.asyncio
     async def test_generate_anthropic_sse_structure(self):
         """
@@ -529,27 +533,24 @@ class TestAnthropicSSEEmulation:
         model = "claude-sonnet-4"
         query = "Python"
         tool_use_id = "srvtoolu_test123"
-        results = {
-            "results": [{"title": "Test", "url": "https://test.com", "snippet": "Test"}],
-            "totalResults": 1
-        }
+        results = {"results": [{"title": "Test", "url": "https://test.com", "snippet": "Test"}], "totalResults": 1}
         input_tokens = 100
-        
+
         print("Action: Generating SSE stream...")
         events = []
         async for event in generate_anthropic_web_search_sse(model, query, tool_use_id, results, input_tokens):
             events.append(event)
-        
+
         print(f"Comparing event count: Got {len(events)} events")
         assert len(events) >= 11  # At least 11 events (may have more text_delta chunks)
-        
+
         print("Checking event types...")
         event_types = []
         for event in events:
             if "event:" in event:
                 event_type = event.split("event:")[1].split("\n")[0].strip()
                 event_types.append(event_type)
-        
+
         print(f"Event types: {event_types}")
         assert "message_start" in event_types
         assert "content_block_start" in event_types
@@ -561,7 +562,7 @@ class TestAnthropicSSEEmulation:
 
 class TestOpenAISSEEmulation:
     """Tests for OpenAI SSE stream generation."""
-    
+
     @pytest.mark.asyncio
     async def test_generate_openai_sse_structure(self):
         """
@@ -572,31 +573,28 @@ class TestOpenAISSEEmulation:
         model = "claude-sonnet-4"
         query = "Python"
         tool_use_id = "srvtoolu_test123"
-        results = {
-            "results": [{"title": "Test", "url": "https://test.com", "snippet": "Test"}],
-            "totalResults": 1
-        }
+        results = {"results": [{"title": "Test", "url": "https://test.com", "snippet": "Test"}], "totalResults": 1}
         input_tokens = 100
-        
+
         print("Action: Generating SSE stream...")
         chunks = []
         async for chunk in generate_openai_web_search_sse(model, query, tool_use_id, results, input_tokens):
             chunks.append(chunk)
-        
+
         print(f"Comparing chunk count: Got {len(chunks)} chunks")
         assert len(chunks) >= 3  # At least: role, content chunks, finish + [DONE]
-        
+
         print("Checking for [DONE] marker...")
         assert any("[DONE]" in chunk for chunk in chunks)
-        
+
         print("Checking for role delta (flexible matching)...")
         assert any('"role"' in chunk and '"assistant"' in chunk for chunk in chunks)
-        
+
         print("Checking for finish_reason (flexible matching)...")
         assert any('"finish_reason"' in chunk and '"stop"' in chunk for chunk in chunks)
-        
+
         print("Checking for data: prefix...")
         assert any(chunk.startswith("data:") for chunk in chunks)
-        
+
         print("Checking for usage information...")
         assert any('"usage"' in chunk for chunk in chunks)

--- a/tests/unit/test_model_alias_resolution.py
+++ b/tests/unit/test_model_alias_resolution.py
@@ -24,9 +24,7 @@ def _openai_model_id(model: str) -> str:
 
 
 def _anthropic_model_id(model: str) -> str:
-    request = AnthropicMessagesRequest(
-        model=model, max_tokens=32, messages=[{"role": "user", "content": "hi"}]
-    )
+    request = AnthropicMessagesRequest(model=model, max_tokens=32, messages=[{"role": "user", "content": "hi"}])
     payload = anthropic_to_kiro(request, "test", "profile")
     return payload["conversationState"]["currentMessage"]["userInputMessage"]["modelId"]
 

--- a/tests/unit/test_model_resolver.py
+++ b/tests/unit/test_model_resolver.py
@@ -11,22 +11,23 @@ Tests 5-layer model resolution architecture:
 4. Pass-through - unknown models are sent to Kiro
 """
 
-import pytest
 from dataclasses import FrozenInstanceError
 
-from kiro.model_resolver import (
-    normalize_model_name,
-    get_model_id_for_kiro,
-    extract_model_family,
-    ModelResolver,
-    ModelResolution,
-)
-from kiro.cache import ModelInfoCache
+import pytest
 
+from kiro.cache import ModelInfoCache
+from kiro.model_resolver import (
+    ModelResolution,
+    ModelResolver,
+    extract_model_family,
+    get_model_id_for_kiro,
+    normalize_model_name,
+)
 
 # =============================================================================
 # Fixtures
 # =============================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -80,19 +81,20 @@ def resolver_without_hidden(mock_model_cache):
 # TestNormalizeModelName - Tests for model name normalization
 # =============================================================================
 
+
 class TestNormalizeModelName:
     """
     Tests for normalize_model_name() function.
-    
+
     Checks conversion of client formats to Kiro format:
     - Dashes → dots for minor versions
     - Removal of date suffix (20251001)
     - Removal of 'latest' suffix
     - Legacy format (claude-3-7-sonnet)
     """
-    
+
     # === Standard format with minor version ===
-    
+
     def test_normalizes_haiku_dash_to_dot(self):
         """
         What it does: claude-haiku-4-5 → claude-haiku-4.5
@@ -100,10 +102,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4-5'...")
         result = normalize_model_name("claude-haiku-4-5")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_normalizes_sonnet_dash_to_dot(self):
         """
         What it does: claude-sonnet-4-5 → claude-sonnet-4.5
@@ -111,10 +113,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4-5'...")
         result = normalize_model_name("claude-sonnet-4-5")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_normalizes_opus_dash_to_dot(self):
         """
         What it does: claude-opus-4-5 → claude-opus-4.5
@@ -122,12 +124,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-opus-4-5'...")
         result = normalize_model_name("claude-opus-4-5")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     # === Removal of date suffix ===
-    
+
     def test_strips_date_suffix_haiku(self):
         """
         What it does: claude-haiku-4-5-20251001 → claude-haiku-4.5
@@ -135,10 +137,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4-5-20251001'...")
         result = normalize_model_name("claude-haiku-4-5-20251001")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_strips_date_suffix_sonnet(self):
         """
         What it does: claude-sonnet-4-5-20250929 → claude-sonnet-4.5
@@ -146,10 +148,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4-5-20250929'...")
         result = normalize_model_name("claude-sonnet-4-5-20250929")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_strips_date_suffix_opus(self):
         """
         What it does: claude-opus-4-5-20251101 → claude-opus-4.5
@@ -157,12 +159,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-opus-4-5-20251101'...")
         result = normalize_model_name("claude-opus-4-5-20251101")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     # === Removal of 'latest' suffix ===
-    
+
     def test_strips_latest_suffix(self):
         """
         What it does: claude-haiku-4-5-latest → claude-haiku-4.5
@@ -170,12 +172,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4-5-latest'...")
         result = normalize_model_name("claude-haiku-4-5-latest")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     # === Standard format without minor version ===
-    
+
     def test_keeps_model_without_minor(self):
         """
         What it does: claude-sonnet-4 → claude-sonnet-4
@@ -183,10 +185,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4'...")
         result = normalize_model_name("claude-sonnet-4")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4', Got '{result}'")
         assert result == "claude-sonnet-4"
-    
+
     def test_strips_date_from_model_without_minor(self):
         """
         What it does: claude-sonnet-4-20250514 → claude-sonnet-4
@@ -194,12 +196,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4-20250514'...")
         result = normalize_model_name("claude-sonnet-4-20250514")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4', Got '{result}'")
         assert result == "claude-sonnet-4"
-    
+
     # === Legacy format (claude-X-Y-family) ===
-    
+
     def test_normalizes_legacy_format(self):
         """
         What it does: claude-3-7-sonnet → claude-3.7-sonnet
@@ -207,10 +209,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-7-sonnet'...")
         result = normalize_model_name("claude-3-7-sonnet")
-        
+
         print(f"Comparing result: Expected 'claude-3.7-sonnet', Got '{result}'")
         assert result == "claude-3.7-sonnet"
-    
+
     def test_normalizes_legacy_format_with_date(self):
         """
         What it does: claude-3-7-sonnet-20250219 → claude-3.7-sonnet
@@ -218,10 +220,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-7-sonnet-20250219'...")
         result = normalize_model_name("claude-3-7-sonnet-20250219")
-        
+
         print(f"Comparing result: Expected 'claude-3.7-sonnet', Got '{result}'")
         assert result == "claude-3.7-sonnet"
-    
+
     def test_normalizes_legacy_haiku(self):
         """
         What it does: claude-3-5-haiku → claude-3.5-haiku
@@ -229,10 +231,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-5-haiku'...")
         result = normalize_model_name("claude-3-5-haiku")
-        
+
         print(f"Comparing result: Expected 'claude-3.5-haiku', Got '{result}'")
         assert result == "claude-3.5-haiku"
-    
+
     def test_normalizes_legacy_opus(self):
         """
         What it does: claude-3-0-opus → claude-3.0-opus
@@ -240,26 +242,26 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-3-0-opus'...")
         result = normalize_model_name("claude-3-0-opus")
-        
+
         print(f"Comparing result: Expected 'claude-3.0-opus', Got '{result}'")
         assert result == "claude-3.0-opus"
-    
+
     # === Inverted format with suffix (Pattern 5 - Cursor IDE) ===
-    
+
     def test_inverted_format_with_high_suffix(self):
         """
         What it does: claude-4.5-opus-high → claude-opus-4.5
         Goal: Check inverted format normalization with 'high' suffix (Cursor IDE).
-        
+
         Cursor IDE sends model names in inverted format with priority suffix.
         This is Pattern 5 from PR #49.
         """
         print("Action: Normalizing 'claude-4.5-opus-high'...")
         result = normalize_model_name("claude-4.5-opus-high")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     def test_inverted_format_with_low_suffix(self):
         """
         What it does: claude-4.5-sonnet-low → claude-sonnet-4.5
@@ -267,65 +269,65 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-4.5-sonnet-low'...")
         result = normalize_model_name("claude-4.5-sonnet-low")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_inverted_format_with_thinking_suffix(self):
         """
         What it does: claude-4.5-opus-high-thinking → claude-opus-4.5
         Goal: Check inverted format with compound suffix (high-thinking).
-        
+
         The pattern strips ALL suffixes after the family name.
         """
         print("Action: Normalizing 'claude-4.5-opus-high-thinking'...")
         result = normalize_model_name("claude-4.5-opus-high-thinking")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     def test_inverted_format_all_families(self):
         """
         What it does: Verifies inverted format works for all families.
         Goal: Check haiku, sonnet, opus all work with inverted format.
         """
         print("Action: Normalizing inverted format for all families...")
-        
+
         print("  Testing haiku...")
         result_haiku = normalize_model_name("claude-4.5-haiku-high")
         print(f"  Comparing: Expected 'claude-haiku-4.5', Got '{result_haiku}'")
         assert result_haiku == "claude-haiku-4.5"
-        
+
         print("  Testing sonnet...")
         result_sonnet = normalize_model_name("claude-4.5-sonnet-low")
         print(f"  Comparing: Expected 'claude-sonnet-4.5', Got '{result_sonnet}'")
         assert result_sonnet == "claude-sonnet-4.5"
-        
+
         print("  Testing opus...")
         result_opus = normalize_model_name("claude-4.5-opus-high")
         print(f"  Comparing: Expected 'claude-opus-4.5', Got '{result_opus}'")
         assert result_opus == "claude-opus-4.5"
-    
+
     def test_inverted_format_requires_suffix(self):
         """
         What it does: Verifies that suffix is required (doesn't match claude-3.7-sonnet).
         Goal: CRITICAL - ensure Pattern 5 doesn't break already-normalized formats.
-        
+
         This is the most important test for Pattern 5. The regex MUST require a suffix
         to avoid matching already-normalized formats like claude-3.7-sonnet.
         """
         print("Action: Normalizing 'claude-3.7-sonnet' (should NOT match Pattern 5)...")
         result = normalize_model_name("claude-3.7-sonnet")
-        
+
         print(f"Comparing result: Expected 'claude-3.7-sonnet' (unchanged), Got '{result}'")
         assert result == "claude-3.7-sonnet"
-        
+
         print("Action: Normalizing 'claude-4.5-sonnet' (should NOT match Pattern 5)...")
         result2 = normalize_model_name("claude-4.5-sonnet")
-        
+
         print(f"Comparing result: Expected 'claude-4.5-sonnet' (unchanged), Got '{result2}'")
         assert result2 == "claude-4.5-sonnet"
-    
+
     def test_inverted_format_case_insensitive(self):
         """
         What it does: CLAUDE-4.5-OPUS-HIGH → claude-opus-4.5
@@ -333,12 +335,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'CLAUDE-4.5-OPUS-HIGH'...")
         result = normalize_model_name("CLAUDE-4.5-OPUS-HIGH")
-        
+
         print(f"Comparing result: Expected 'claude-opus-4.5', Got '{result}'")
         assert result == "claude-opus-4.5"
-    
+
     # === Already normalized (passthrough) ===
-    
+
     def test_passthrough_already_normalized_haiku(self):
         """
         What it does: claude-haiku-4.5 → claude-haiku-4.5
@@ -346,10 +348,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-haiku-4.5'...")
         result = normalize_model_name("claude-haiku-4.5")
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_passthrough_already_normalized_sonnet(self):
         """
         What it does: claude-sonnet-4.5 → claude-sonnet-4.5
@@ -357,10 +359,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'claude-sonnet-4.5'...")
         result = normalize_model_name("claude-sonnet-4.5")
-        
+
         print(f"Comparing result: Expected 'claude-sonnet-4.5', Got '{result}'")
         assert result == "claude-sonnet-4.5"
-    
+
     def test_passthrough_auto(self):
         """
         What it does: auto → auto
@@ -368,12 +370,12 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'auto'...")
         result = normalize_model_name("auto")
-        
+
         print(f"Comparing result: Expected 'auto', Got '{result}'")
         assert result == "auto"
-    
+
     # === Edge cases ===
-    
+
     def test_handles_empty_string(self):
         """
         What it does: "" → ""
@@ -381,10 +383,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing empty string...")
         result = normalize_model_name("")
-        
+
         print(f"Comparing result: Expected '', Got '{result}'")
         assert result == ""
-    
+
     def test_handles_unknown_format(self):
         """
         What it does: gpt-4 → gpt-4 (passthrough)
@@ -392,10 +394,10 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'gpt-4'...")
         result = normalize_model_name("gpt-4")
-        
+
         print(f"Comparing result: Expected 'gpt-4', Got '{result}'")
         assert result == "gpt-4"
-    
+
     def test_handles_random_model_name(self):
         """
         What it does: some-random-model → some-random-model
@@ -403,7 +405,7 @@ class TestNormalizeModelName:
         """
         print("Action: Normalizing 'some-random-model'...")
         result = normalize_model_name("some-random-model")
-        
+
         print(f"Comparing result: Expected 'some-random-model', Got '{result}'")
         assert result == "some-random-model"
 
@@ -412,39 +414,43 @@ class TestNormalizeModelName:
 # TestNormalizeModelNameParametrized - Parametrized tests
 # =============================================================================
 
+
 class TestNormalizeModelNameParametrized:
     """Parametrized tests for complete coverage of scenarios."""
-    
-    @pytest.mark.parametrize("input_model,expected", [
-        # Standard format with minor version
-        ("claude-haiku-4-5", "claude-haiku-4.5"),
-        ("claude-haiku-4-5-20251001", "claude-haiku-4.5"),
-        ("claude-haiku-4-5-latest", "claude-haiku-4.5"),
-        ("claude-sonnet-4-5", "claude-sonnet-4.5"),
-        ("claude-sonnet-4-5-20250929", "claude-sonnet-4.5"),
-        ("claude-opus-4-5", "claude-opus-4.5"),
-        ("claude-opus-4-5-20251101", "claude-opus-4.5"),
-        # Without minor version
-        ("claude-sonnet-4", "claude-sonnet-4"),
-        ("claude-sonnet-4-20250514", "claude-sonnet-4"),
-        ("claude-haiku-4", "claude-haiku-4"),
-        ("claude-opus-4", "claude-opus-4"),
-        # Legacy format
-        ("claude-3-7-sonnet", "claude-3.7-sonnet"),
-        ("claude-3-7-sonnet-20250219", "claude-3.7-sonnet"),
-        ("claude-3-5-haiku", "claude-3.5-haiku"),
-        ("claude-3-0-opus", "claude-3.0-opus"),
-        # Already normalized
-        ("claude-haiku-4.5", "claude-haiku-4.5"),
-        ("claude-sonnet-4.5", "claude-sonnet-4.5"),
-        ("claude-opus-4.5", "claude-opus-4.5"),
-        ("claude-3.7-sonnet", "claude-3.7-sonnet"),
-        ("auto", "auto"),
-        # Passthrough for unknown
-        ("gpt-4", "gpt-4"),
-        ("gpt-4-turbo", "gpt-4-turbo"),
-        ("unknown-model", "unknown-model"),
-    ])
+
+    @pytest.mark.parametrize(
+        "input_model,expected",
+        [
+            # Standard format with minor version
+            ("claude-haiku-4-5", "claude-haiku-4.5"),
+            ("claude-haiku-4-5-20251001", "claude-haiku-4.5"),
+            ("claude-haiku-4-5-latest", "claude-haiku-4.5"),
+            ("claude-sonnet-4-5", "claude-sonnet-4.5"),
+            ("claude-sonnet-4-5-20250929", "claude-sonnet-4.5"),
+            ("claude-opus-4-5", "claude-opus-4.5"),
+            ("claude-opus-4-5-20251101", "claude-opus-4.5"),
+            # Without minor version
+            ("claude-sonnet-4", "claude-sonnet-4"),
+            ("claude-sonnet-4-20250514", "claude-sonnet-4"),
+            ("claude-haiku-4", "claude-haiku-4"),
+            ("claude-opus-4", "claude-opus-4"),
+            # Legacy format
+            ("claude-3-7-sonnet", "claude-3.7-sonnet"),
+            ("claude-3-7-sonnet-20250219", "claude-3.7-sonnet"),
+            ("claude-3-5-haiku", "claude-3.5-haiku"),
+            ("claude-3-0-opus", "claude-3.0-opus"),
+            # Already normalized
+            ("claude-haiku-4.5", "claude-haiku-4.5"),
+            ("claude-sonnet-4.5", "claude-sonnet-4.5"),
+            ("claude-opus-4.5", "claude-opus-4.5"),
+            ("claude-3.7-sonnet", "claude-3.7-sonnet"),
+            ("auto", "auto"),
+            # Passthrough for unknown
+            ("gpt-4", "gpt-4"),
+            ("gpt-4-turbo", "gpt-4-turbo"),
+            ("unknown-model", "unknown-model"),
+        ],
+    )
     def test_normalize_model_name_all_scenarios(self, input_model, expected):
         """
         What it does: Checks all normalization scenarios.
@@ -452,7 +458,7 @@ class TestNormalizeModelNameParametrized:
         """
         print(f"Action: Normalizing '{input_model}'...")
         result = normalize_model_name(input_model)
-        
+
         print(f"Comparing result: Expected '{expected}', Got '{result}'")
         assert result == expected
 
@@ -461,13 +467,14 @@ class TestNormalizeModelNameParametrized:
 # TestExtractModelFamily - Tests for model family extraction
 # =============================================================================
 
+
 class TestExtractModelFamily:
     """
     Tests for extract_model_family() function.
-    
+
     Checks extraction of model family (haiku, sonnet, opus) from name.
     """
-    
+
     def test_extracts_haiku_from_standard_format(self):
         """
         What it does: claude-haiku-4.5 → haiku
@@ -475,10 +482,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-haiku-4.5'...")
         result = extract_model_family("claude-haiku-4.5")
-        
+
         print(f"Comparing result: Expected 'haiku', Got '{result}'")
         assert result == "haiku"
-    
+
     def test_extracts_sonnet_from_standard_format(self):
         """
         What it does: claude-sonnet-4.5 → sonnet
@@ -486,10 +493,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-sonnet-4.5'...")
         result = extract_model_family("claude-sonnet-4.5")
-        
+
         print(f"Comparing result: Expected 'sonnet', Got '{result}'")
         assert result == "sonnet"
-    
+
     def test_extracts_opus_from_standard_format(self):
         """
         What it does: claude-opus-4.5 → opus
@@ -497,10 +504,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-opus-4.5'...")
         result = extract_model_family("claude-opus-4.5")
-        
+
         print(f"Comparing result: Expected 'opus', Got '{result}'")
         assert result == "opus"
-    
+
     def test_extracts_sonnet_from_legacy_format(self):
         """
         What it does: claude-3.7-sonnet → sonnet
@@ -508,10 +515,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-3.7-sonnet'...")
         result = extract_model_family("claude-3.7-sonnet")
-        
+
         print(f"Comparing result: Expected 'sonnet', Got '{result}'")
         assert result == "sonnet"
-    
+
     def test_extracts_haiku_from_unnormalized(self):
         """
         What it does: claude-haiku-4-5-20251001 → haiku
@@ -519,10 +526,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'claude-haiku-4-5-20251001'...")
         result = extract_model_family("claude-haiku-4-5-20251001")
-        
+
         print(f"Comparing result: Expected 'haiku', Got '{result}'")
         assert result == "haiku"
-    
+
     def test_returns_none_for_non_claude(self):
         """
         What it does: gpt-4 → None
@@ -530,10 +537,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'gpt-4'...")
         result = extract_model_family("gpt-4")
-        
+
         print(f"Comparing result: Expected None, Got {result}")
         assert result is None
-    
+
     def test_returns_none_for_auto(self):
         """
         What it does: auto → None
@@ -541,10 +548,10 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'auto'...")
         result = extract_model_family("auto")
-        
+
         print(f"Comparing result: Expected None, Got {result}")
         assert result is None
-    
+
     def test_case_insensitive(self):
         """
         What it does: CLAUDE-HAIKU-4.5 → haiku
@@ -552,7 +559,7 @@ class TestExtractModelFamily:
         """
         print("Action: Extracting family from 'CLAUDE-HAIKU-4.5'...")
         result = extract_model_family("CLAUDE-HAIKU-4.5")
-        
+
         print(f"Comparing result: Expected 'haiku', Got '{result}'")
         assert result == "haiku"
 
@@ -561,13 +568,14 @@ class TestExtractModelFamily:
 # TestGetModelIdForKiro - Tests for converter helper
 # =============================================================================
 
+
 class TestGetModelIdForKiro:
     """
     Tests for get_model_id_for_kiro() function.
-    
+
     Checks getting model ID for sending to Kiro API.
     """
-    
+
     def test_normalizes_without_hidden_models(self):
         """
         What it does: Normalizes model without hidden models.
@@ -575,10 +583,10 @@ class TestGetModelIdForKiro:
         """
         print("Action: get_model_id_for_kiro('claude-haiku-4-5-20251001', {})...")
         result = get_model_id_for_kiro("claude-haiku-4-5-20251001", {})
-        
+
         print(f"Comparing result: Expected 'claude-haiku-4.5', Got '{result}'")
         assert result == "claude-haiku-4.5"
-    
+
     def test_returns_internal_id_for_hidden_model(self):
         """
         What it does: Returns internal ID for hidden model (pass-through).
@@ -634,9 +642,10 @@ class TestGetModelIdForKiro:
 # TestModelResolver - Tests for ModelResolver class
 # =============================================================================
 
+
 class TestModelResolverInitialization:
     """Tests for ModelResolver initialization."""
-    
+
     def test_init_with_cache_and_hidden_models(self, mock_model_cache, hidden_models):
         """
         What it does: Creates ModelResolver with cache and hidden models.
@@ -644,11 +653,11 @@ class TestModelResolverInitialization:
         """
         print("Action: Creating ModelResolver...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=hidden_models)
-        
+
         print("Check: Attributes set correctly...")
         assert resolver.cache is mock_model_cache
         assert resolver.hidden_models == hidden_models
-    
+
     def test_init_with_empty_hidden_models(self, mock_model_cache):
         """
         What it does: Creates ModelResolver without hidden models.
@@ -656,10 +665,10 @@ class TestModelResolverInitialization:
         """
         print("Action: Creating ModelResolver without hidden models...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_models={})
-        
+
         print("Check: hidden_models is empty...")
         assert resolver.hidden_models == {}
-    
+
     def test_init_with_none_hidden_models(self, mock_model_cache):
         """
         What it does: Creates ModelResolver with hidden_models=None.
@@ -667,14 +676,14 @@ class TestModelResolverInitialization:
         """
         print("Action: Creating ModelResolver with hidden_models=None...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=None)
-        
+
         print("Check: hidden_models initialized as empty dict...")
         assert resolver.hidden_models == {}
 
 
 class TestModelResolverResolve:
     """Tests for resolve() method of ModelResolver class."""
-    
+
     def test_resolve_finds_model_in_cache(self, model_resolver):
         """
         What it does: Finds model in cache.
@@ -682,23 +691,23 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'claude-haiku-4-5'...")
         result = model_resolver.resolve("claude-haiku-4-5")
-        
+
         print(f"Check result: {result}")
         print(f"Comparing internal_id: Expected 'claude-haiku-4.5', Got '{result.internal_id}'")
         assert result.internal_id == "claude-haiku-4.5"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-        
+
         print(f"Comparing is_verified: Expected True, Got {result.is_verified}")
         assert result.is_verified is True
-        
+
         print(f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'")
         assert result.normalized == "claude-haiku-4.5"
-        
+
         print(f"Comparing original_request: Expected 'claude-haiku-4-5', Got '{result.original_request}'")
         assert result.original_request == "claude-haiku-4-5"
-    
+
     def test_resolve_finds_model_in_hidden(self, model_resolver):
         """
         What it does: Finds model in hidden models.
@@ -708,7 +717,9 @@ class TestModelResolverResolve:
         result = model_resolver.resolve("claude-3-7-sonnet")
 
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0' (pass-through), Got '{result.internal_id}'")
+        print(
+            f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0' (pass-through), Got '{result.internal_id}'"
+        )
         assert result.internal_id == "CLAUDE_3_7_SONNET_20250219_V1_0"
 
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
@@ -726,7 +737,9 @@ class TestModelResolverResolve:
         result = model_resolver.resolve("claude-haiku-4-6")
 
         print(f"Check result: {result}")
-        print(f"Comparing internal_id: Expected 'claude-haiku-4.6' (normalized, pass-through), Got '{result.internal_id}'")
+        print(
+            f"Comparing internal_id: Expected 'claude-haiku-4.6' (normalized, pass-through), Got '{result.internal_id}'"
+        )
         assert result.internal_id == "claude-haiku-4.6"
 
         print(f"Comparing source: Expected 'passthrough', Got '{result.source}'")
@@ -734,7 +747,7 @@ class TestModelResolverResolve:
 
         print(f"Comparing is_verified: Expected False, Got {result.is_verified}")
         assert result.is_verified is False
-    
+
     def test_resolve_normalizes_before_lookup(self, model_resolver):
         """
         What it does: Normalizes name before cache lookup.
@@ -742,35 +755,35 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'claude-haiku-4-5-20251001'...")
         result = model_resolver.resolve("claude-haiku-4-5-20251001")
-        
+
         print(f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'")
         assert result.normalized == "claude-haiku-4.5"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-    
+
     def test_resolve_never_raises(self, model_resolver):
         """
         What it does: Never raises exception.
         Goal: Check that resolve() always returns ModelResolution.
         """
         print("Action: Resolving strange input data...")
-        
+
         # Empty string
         result1 = model_resolver.resolve("")
         print(f"Empty string: {result1}")
         assert isinstance(result1, ModelResolution)
-        
+
         # Special characters
         result2 = model_resolver.resolve("!@#$%^&*()")
         print(f"Special characters: {result2}")
         assert isinstance(result2, ModelResolution)
-        
+
         # Very long name
         result3 = model_resolver.resolve("a" * 1000)
         print(f"Long name: source={result3.source}")
         assert isinstance(result3, ModelResolution)
-    
+
     def test_resolve_auto_model(self, model_resolver):
         """
         What it does: Resolves 'auto' model.
@@ -778,13 +791,13 @@ class TestModelResolverResolve:
         """
         print("Action: Resolving 'auto'...")
         result = model_resolver.resolve("auto")
-        
+
         print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
         assert result.internal_id == "auto"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-    
+
     def test_resolve_with_empty_cache(self, empty_model_cache, hidden_models):
         """
         What it does: Resolves model with empty cache.
@@ -792,23 +805,23 @@ class TestModelResolverResolve:
         """
         print("Setup: Creating resolver with empty cache...")
         resolver = ModelResolver(cache=empty_model_cache, hidden_models=hidden_models)
-        
+
         print("Action: Resolving 'claude-3.7-sonnet'...")
         result = resolver.resolve("claude-3.7-sonnet")
-        
+
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
         assert result.source == "hidden"
-        
+
         print("Action: Resolving 'claude-haiku-4.5' (not in cache)...")
         result2 = resolver.resolve("claude-haiku-4.5")
-        
+
         print(f"Comparing source: Expected 'passthrough', Got '{result2.source}'")
         assert result2.source == "passthrough"
 
 
 class TestModelResolverGetAvailableModels:
     """Tests for get_available_models() method."""
-    
+
     def test_get_available_models_combines_cache_and_hidden(self, model_resolver):
         """
         What it does: Returns models from cache and hidden.
@@ -816,20 +829,20 @@ class TestModelResolverGetAvailableModels:
         """
         print("Action: Getting list of available models...")
         models = model_resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
-        
+
         # Check cache models
         print("Check: Cache models present...")
         assert "claude-haiku-4.5" in models
         assert "claude-sonnet-4.5" in models
         assert "claude-opus-4.5" in models
         assert "auto" in models
-        
+
         # Check hidden models
         print("Check: Hidden models present...")
         assert "claude-3.7-sonnet" in models
-    
+
     def test_get_available_models_returns_sorted_list(self, model_resolver):
         """
         What it does: Returns sorted list.
@@ -837,12 +850,12 @@ class TestModelResolverGetAvailableModels:
         """
         print("Action: Getting list of available models...")
         models = model_resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print(f"Sorted: {sorted(models)}")
-        
+
         assert models == sorted(models)
-    
+
     def test_get_available_models_no_duplicates(self, mock_model_cache):
         """
         What it does: Does not return duplicates.
@@ -851,19 +864,19 @@ class TestModelResolverGetAvailableModels:
         # Add hidden model that already exists in cache
         hidden = {"claude-haiku-4.5": "SOME_INTERNAL_ID"}
         resolver = ModelResolver(cache=mock_model_cache, hidden_models=hidden)
-        
+
         print("Action: Getting list with potential duplicate...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
-        
+
         # Check uniqueness
         assert len(models) == len(set(models))
 
 
 class TestModelResolverGetModelsByFamily:
     """Tests for get_models_by_family() method."""
-    
+
     def test_get_models_by_family_haiku(self, model_resolver):
         """
         What it does: Returns only Haiku models.
@@ -871,13 +884,13 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting Haiku models...")
         models = model_resolver.get_models_by_family("haiku")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-haiku-4.5" in models
         assert "claude-sonnet-4.5" not in models
         assert "claude-opus-4.5" not in models
-    
+
     def test_get_models_by_family_sonnet(self, model_resolver):
         """
         What it does: Returns only Sonnet models.
@@ -885,14 +898,14 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting Sonnet models...")
         models = model_resolver.get_models_by_family("sonnet")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-sonnet-4.5" in models
         assert "claude-sonnet-4" in models
         assert "claude-3.7-sonnet" in models  # Hidden model
         assert "claude-haiku-4.5" not in models
-    
+
     def test_get_models_by_family_opus(self, model_resolver):
         """
         What it does: Returns only Opus models.
@@ -900,12 +913,12 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting Opus models...")
         models = model_resolver.get_models_by_family("opus")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-opus-4.5" in models
         assert "claude-sonnet-4.5" not in models
-    
+
     def test_get_models_by_family_case_insensitive(self, model_resolver):
         """
         What it does: Filtering is case insensitive.
@@ -913,15 +926,15 @@ class TestModelResolverGetModelsByFamily:
         """
         print("Action: Getting HAIKU models (uppercase)...")
         models = model_resolver.get_models_by_family("HAIKU")
-        
+
         print(f"Received models: {models}")
-        
+
         assert "claude-haiku-4.5" in models
 
 
 class TestModelResolverGetSuggestionsForModel:
     """Tests for get_suggestions_for_model() method."""
-    
+
     def test_get_suggestions_returns_same_family(self, model_resolver):
         """
         What it does: Returns models of same family.
@@ -929,14 +942,14 @@ class TestModelResolverGetSuggestionsForModel:
         """
         print("Action: Getting suggestions for 'claude-haiku-4-6'...")
         suggestions = model_resolver.get_suggestions_for_model("claude-haiku-4-6")
-        
+
         print(f"Received suggestions: {suggestions}")
-        
+
         # All suggestions should be Haiku
         for s in suggestions:
             print(f"Check: '{s}' contains 'haiku'...")
             assert "haiku" in s.lower()
-    
+
     def test_get_suggestions_no_cross_family(self, model_resolver):
         """
         What it does: NEVER suggests models from other family.
@@ -944,15 +957,15 @@ class TestModelResolverGetSuggestionsForModel:
         """
         print("Action: Getting suggestions for 'claude-opus-5'...")
         suggestions = model_resolver.get_suggestions_for_model("claude-opus-5")
-        
+
         print(f"Received suggestions: {suggestions}")
-        
+
         # Should NOT be Sonnet or Haiku
         for s in suggestions:
             print(f"Check: '{s}' does NOT contain 'sonnet' or 'haiku'...")
             assert "sonnet" not in s.lower()
             assert "haiku" not in s.lower()
-    
+
     def test_get_suggestions_returns_all_for_unknown_family(self, model_resolver):
         """
         What it does: Returns all models for unknown family.
@@ -960,9 +973,9 @@ class TestModelResolverGetSuggestionsForModel:
         """
         print("Action: Getting suggestions for 'gpt-4'...")
         suggestions = model_resolver.get_suggestions_for_model("gpt-4")
-        
+
         print(f"Received suggestions: {suggestions}")
-        
+
         # Should be all models
         all_models = model_resolver.get_available_models()
         assert set(suggestions) == set(all_models)
@@ -972,9 +985,10 @@ class TestModelResolverGetSuggestionsForModel:
 # TestModelResolution - Tests for ModelResolution dataclass
 # =============================================================================
 
+
 class TestModelResolution:
     """Tests for ModelResolution dataclass."""
-    
+
     def test_model_resolution_fields(self):
         """
         What it does: Checks all ModelResolution fields.
@@ -986,16 +1000,16 @@ class TestModelResolution:
             source="cache",
             original_request="claude-haiku-4-5",
             normalized="claude-haiku-4.5",
-            is_verified=True
+            is_verified=True,
         )
-        
+
         print(f"Check fields: {resolution}")
         assert resolution.internal_id == "claude-haiku-4.5"
         assert resolution.source == "cache"
         assert resolution.original_request == "claude-haiku-4-5"
         assert resolution.normalized == "claude-haiku-4.5"
         assert resolution.is_verified is True
-    
+
     def test_model_resolution_is_frozen(self):
         """
         What it does: Checks that ModelResolution is immutable.
@@ -1003,17 +1017,13 @@ class TestModelResolution:
         """
         print("Action: Creating ModelResolution...")
         resolution = ModelResolution(
-            internal_id="test",
-            source="cache",
-            original_request="test",
-            normalized="test",
-            is_verified=True
+            internal_id="test", source="cache", original_request="test", normalized="test", is_verified=True
         )
-        
+
         print("Check: Attempt to modify field should raise error...")
         with pytest.raises(FrozenInstanceError):
             resolution.internal_id = "changed"
-    
+
     def test_model_resolution_equality(self):
         """
         What it does: Checks comparison of two ModelResolution objects.
@@ -1021,23 +1031,15 @@ class TestModelResolution:
         """
         print("Action: Creating two identical ModelResolution objects...")
         resolution1 = ModelResolution(
-            internal_id="test",
-            source="cache",
-            original_request="test",
-            normalized="test",
-            is_verified=True
+            internal_id="test", source="cache", original_request="test", normalized="test", is_verified=True
         )
         resolution2 = ModelResolution(
-            internal_id="test",
-            source="cache",
-            original_request="test",
-            normalized="test",
-            is_verified=True
+            internal_id="test", source="cache", original_request="test", normalized="test", is_verified=True
         )
-        
+
         print(f"Comparing: {resolution1} == {resolution2}")
         assert resolution1 == resolution2
-    
+
     def test_model_resolution_inequality(self):
         """
         What it does: Checks inequality of different ModelResolution objects.
@@ -1045,20 +1047,12 @@ class TestModelResolution:
         """
         print("Action: Creating two different ModelResolution objects...")
         resolution1 = ModelResolution(
-            internal_id="test1",
-            source="cache",
-            original_request="test",
-            normalized="test",
-            is_verified=True
+            internal_id="test1", source="cache", original_request="test", normalized="test", is_verified=True
         )
         resolution2 = ModelResolution(
-            internal_id="test2",
-            source="hidden",
-            original_request="test",
-            normalized="test",
-            is_verified=True
+            internal_id="test2", source="hidden", original_request="test", normalized="test", is_verified=True
         )
-        
+
         print(f"Comparing: {resolution1} != {resolution2}")
         assert resolution1 != resolution2
 
@@ -1067,9 +1061,10 @@ class TestModelResolution:
 # TestModelInfoCacheNewMethods - Tests for new cache methods
 # =============================================================================
 
+
 class TestModelInfoCacheIsValidModel:
     """Tests for is_valid_model() method in ModelInfoCache."""
-    
+
     @pytest.mark.asyncio
     async def test_is_valid_model_returns_true_for_cached(self):
         """
@@ -1079,13 +1074,13 @@ class TestModelInfoCacheIsValidModel:
         print("Setup: Creating and populating cache...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "claude-sonnet-4.5"}])
-        
+
         print("Action: Checking is_valid_model('claude-sonnet-4.5')...")
         result = cache.is_valid_model("claude-sonnet-4.5")
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_is_valid_model_returns_false_for_unknown(self):
         """
@@ -1095,13 +1090,13 @@ class TestModelInfoCacheIsValidModel:
         print("Setup: Creating and populating cache...")
         cache = ModelInfoCache()
         await cache.update([{"modelId": "claude-sonnet-4.5"}])
-        
+
         print("Action: Checking is_valid_model('unknown-model')...")
         result = cache.is_valid_model("unknown-model")
-        
+
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
-    
+
     def test_is_valid_model_on_empty_cache(self):
         """
         What it does: Returns False for empty cache.
@@ -1109,17 +1104,17 @@ class TestModelInfoCacheIsValidModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Checking is_valid_model('any-model')...")
         result = cache.is_valid_model("any-model")
-        
+
         print(f"Comparing result: Expected False, Got {result}")
         assert result is False
 
 
 class TestModelInfoCacheAddHiddenModel:
     """Tests for add_hidden_model() method in ModelInfoCache."""
-    
+
     def test_add_hidden_model_adds_to_cache(self):
         """
         What it does: Adds hidden model to cache.
@@ -1127,13 +1122,13 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "CLAUDE_3_7_SONNET_20250219_V1_0")
-        
+
         print("Check: Model added to cache...")
         assert cache.is_valid_model("claude-3.7-sonnet") is True
-    
+
     def test_add_hidden_model_stores_internal_id(self):
         """
         What it does: Stores internal ID in _internal_id field.
@@ -1141,17 +1136,17 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "CLAUDE_3_7_SONNET_20250219_V1_0")
-        
+
         print("Check: _internal_id saved...")
         model_info = cache.get("claude-3.7-sonnet")
         print(f"model_info: {model_info}")
-        
+
         assert model_info["_internal_id"] == "CLAUDE_3_7_SONNET_20250219_V1_0"
         assert model_info["_is_hidden"] is True
-    
+
     def test_add_hidden_model_sets_model_id(self):
         """
         What it does: Sets modelId equal to display_name.
@@ -1159,16 +1154,16 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "INTERNAL_ID")
-        
+
         print("Check: modelId set...")
         model_info = cache.get("claude-3.7-sonnet")
-        
+
         assert model_info["modelId"] == "claude-3.7-sonnet"
         assert model_info["modelName"] == "claude-3.7-sonnet"
-    
+
     @pytest.mark.asyncio
     async def test_add_hidden_model_does_not_overwrite_existing(self):
         """
@@ -1177,21 +1172,19 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating cache with model...")
         cache = ModelInfoCache()
-        await cache.update([{
-            "modelId": "claude-3.7-sonnet",
-            "modelName": "Original Name",
-            "tokenLimits": {"maxInputTokens": 200000}
-        }])
-        
+        await cache.update(
+            [{"modelId": "claude-3.7-sonnet", "modelName": "Original Name", "tokenLimits": {"maxInputTokens": 200000}}]
+        )
+
         print("Action: Attempting to add hidden model with same ID...")
         cache.add_hidden_model("claude-3.7-sonnet", "NEW_INTERNAL_ID")
-        
+
         print("Check: Original data preserved...")
         model_info = cache.get("claude-3.7-sonnet")
-        
+
         assert model_info["modelName"] == "Original Name"
         assert "_internal_id" not in model_info  # Should not be added
-    
+
     def test_add_hidden_model_appears_in_get_all_model_ids(self):
         """
         What it does: Hidden model appears in list of all models.
@@ -1199,13 +1192,13 @@ class TestModelInfoCacheAddHiddenModel:
         """
         print("Setup: Creating empty cache...")
         cache = ModelInfoCache()
-        
+
         print("Action: Adding hidden model...")
         cache.add_hidden_model("claude-3.7-sonnet", "INTERNAL_ID")
-        
+
         print("Check: Model in list...")
         model_ids = cache.get_all_model_ids()
-        
+
         assert "claude-3.7-sonnet" in model_ids
 
 
@@ -1213,13 +1206,14 @@ class TestModelInfoCacheAddHiddenModel:
 # TestCriticalSafetyPrinciple - Critical security tests
 # =============================================================================
 
+
 class TestCriticalSafetyPrinciple:
     """
     Critical security tests: Family Isolation.
-    
+
     IMPORTANT: Resolver MUST NEVER cross model family boundaries!
     """
-    
+
     def test_opus_never_becomes_sonnet(self, model_resolver):
         """
         What it does: Opus request NEVER becomes Sonnet.
@@ -1227,16 +1221,16 @@ class TestCriticalSafetyPrinciple:
         """
         print("Action: Resolving non-existent Opus model...")
         result = model_resolver.resolve("claude-opus-5")
-        
+
         print(f"Result: {result}")
-        
+
         # Should be passthrough, NOT fallback to Sonnet
         print("Check: Does NOT contain 'sonnet'...")
         assert "sonnet" not in result.internal_id.lower()
-        
+
         print("Check: Does NOT contain 'haiku'...")
         assert "haiku" not in result.internal_id.lower()
-    
+
     def test_haiku_never_becomes_opus(self, model_resolver):
         """
         What it does: Haiku request NEVER becomes Opus.
@@ -1244,16 +1238,16 @@ class TestCriticalSafetyPrinciple:
         """
         print("Action: Resolving non-existent Haiku model...")
         result = model_resolver.resolve("claude-haiku-5")
-        
+
         print(f"Result: {result}")
-        
+
         # Should be passthrough, NOT fallback to Opus
         print("Check: Does NOT contain 'opus'...")
         assert "opus" not in result.internal_id.lower()
-        
+
         print("Check: Does NOT contain 'sonnet'...")
         assert "sonnet" not in result.internal_id.lower()
-    
+
     def test_sonnet_never_becomes_haiku(self, model_resolver):
         """
         What it does: Sonnet request NEVER becomes Haiku.
@@ -1261,46 +1255,46 @@ class TestCriticalSafetyPrinciple:
         """
         print("Action: Resolving non-existent Sonnet model...")
         result = model_resolver.resolve("claude-sonnet-5")
-        
+
         print(f"Result: {result}")
-        
+
         # Should be passthrough, NOT fallback to Haiku
         print("Check: Does NOT contain 'haiku'...")
         assert "haiku" not in result.internal_id.lower()
-        
+
         print("Check: Does NOT contain 'opus'...")
         assert "opus" not in result.internal_id.lower()
-    
+
     def test_suggestions_respect_family_boundaries(self, model_resolver):
         """
         What it does: Suggestions only from same family.
         Goal: Check that get_suggestions_for_model() respects boundaries.
         """
         families = ["haiku", "sonnet", "opus"]
-        
+
         for family in families:
             print(f"Check family: {family}...")
             suggestions = model_resolver.get_suggestions_for_model(f"claude-{family}-99")
-            
+
             for suggestion in suggestions:
                 print(f"  Suggestion: {suggestion}")
                 # Each suggestion must contain same family
-                assert family in suggestion.lower(), \
-                    f"Suggestion '{suggestion}' not from family '{family}'!"
+                assert family in suggestion.lower(), f"Suggestion '{suggestion}' not from family '{family}'!"
 
 
 # =============================================================================
 # TestModelAliasSystem - Tests for Layer 0 (Aliases)
 # =============================================================================
 
+
 class TestModelAliasSystemBasics:
     """
     Tests for model alias system (Layer 0).
-    
+
     Aliases allow custom names that map to real model IDs.
     Use case: Avoid conflicts with IDE-specific model names (e.g., Cursor's "auto").
     """
-    
+
     def test_alias_resolves_to_target_model(self, mock_model_cache):
         """
         What it does: Alias resolves to target model.
@@ -1309,19 +1303,19 @@ class TestModelAliasSystemBasics:
         print("Setup: Creating resolver with alias...")
         aliases = {"auto-kiro": "auto"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'auto-kiro'...")
         result = resolver.resolve("auto-kiro")
-        
+
         print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
         assert result.internal_id == "auto"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-        
+
         print(f"Comparing original_request: Expected 'auto-kiro', Got '{result.original_request}'")
         assert result.original_request == "auto-kiro"
-    
+
     def test_non_aliased_models_work_normally(self, mock_model_cache):
         """
         What it does: Non-aliased models work as before.
@@ -1330,16 +1324,16 @@ class TestModelAliasSystemBasics:
         print("Setup: Creating resolver with alias...")
         aliases = {"auto-kiro": "auto"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'claude-haiku-4.5' (not aliased)...")
         result = resolver.resolve("claude-haiku-4.5")
-        
+
         print(f"Comparing internal_id: Expected 'claude-haiku-4.5', Got '{result.internal_id}'")
         assert result.internal_id == "claude-haiku-4.5"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-    
+
     def test_alias_with_normalization_chain(self, mock_model_cache):
         """
         What it does: Alias → Normalization → Cache.
@@ -1348,47 +1342,43 @@ class TestModelAliasSystemBasics:
         print("Setup: Creating resolver with alias to unnormalized name...")
         aliases = {"my-haiku": "claude-haiku-4-5"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'my-haiku'...")
         result = resolver.resolve("my-haiku")
-        
+
         print(f"Comparing internal_id: Expected 'claude-haiku-4.5', Got '{result.internal_id}'")
         assert result.internal_id == "claude-haiku-4.5"
-        
+
         print(f"Comparing normalized: Expected 'claude-haiku-4.5', Got '{result.normalized}'")
         assert result.normalized == "claude-haiku-4.5"
-    
+
     def test_multiple_aliases(self, mock_model_cache):
         """
         What it does: Multiple aliases work correctly.
         Purpose: Ensure multiple aliases don't interfere.
         """
         print("Setup: Creating resolver with multiple aliases...")
-        aliases = {
-            "auto-kiro": "auto",
-            "my-opus": "claude-opus-4.5",
-            "fast": "claude-haiku-4.5"
-        }
+        aliases = {"auto-kiro": "auto", "my-opus": "claude-opus-4.5", "fast": "claude-haiku-4.5"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving all aliases...")
         result1 = resolver.resolve("auto-kiro")
         result2 = resolver.resolve("my-opus")
         result3 = resolver.resolve("fast")
-        
+
         print(f"Comparing: auto-kiro → {result1.internal_id}")
         assert result1.internal_id == "auto"
-        
+
         print(f"Comparing: my-opus → {result2.internal_id}")
         assert result2.internal_id == "claude-opus-4.5"
-        
+
         print(f"Comparing: fast → {result3.internal_id}")
         assert result3.internal_id == "claude-haiku-4.5"
 
 
 class TestModelAliasSystemEdgeCases:
     """Edge cases and boundary conditions for alias system."""
-    
+
     def test_alias_to_non_existent_model(self, mock_model_cache):
         """
         What it does: Alias pointing to non-existent model passes through as-is.
@@ -1423,12 +1413,14 @@ class TestModelAliasSystemEdgeCases:
         print("Action: Resolving 'legacy-sonnet'...")
         result = resolver.resolve("legacy-sonnet")
 
-        print(f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0' (pass-through), Got '{result.internal_id}'")
+        print(
+            f"Comparing internal_id: Expected 'CLAUDE_3_7_SONNET_20250219_V1_0' (pass-through), Got '{result.internal_id}'"
+        )
         assert result.internal_id == "CLAUDE_3_7_SONNET_20250219_V1_0"
 
         print(f"Comparing source: Expected 'hidden', Got '{result.source}'")
         assert result.source == "hidden"
-    
+
     def test_empty_aliases_dict(self, mock_model_cache):
         """
         What it does: Empty aliases dict works correctly.
@@ -1436,13 +1428,13 @@ class TestModelAliasSystemEdgeCases:
         """
         print("Setup: Creating resolver with empty aliases...")
         resolver = ModelResolver(cache=mock_model_cache, aliases={})
-        
+
         print("Action: Resolving 'auto'...")
         result = resolver.resolve("auto")
-        
+
         print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
         assert result.internal_id == "auto"
-    
+
     def test_none_aliases(self, mock_model_cache):
         """
         What it does: None aliases parameter works correctly.
@@ -1450,10 +1442,10 @@ class TestModelAliasSystemEdgeCases:
         """
         print("Setup: Creating resolver with aliases=None...")
         resolver = ModelResolver(cache=mock_model_cache, aliases=None)
-        
+
         print("Check: aliases initialized as empty dict...")
         assert resolver.aliases == {}
-    
+
     def test_alias_with_same_name_as_real_model(self, mock_model_cache):
         """
         What it does: Alias with same name as real model.
@@ -1463,15 +1455,15 @@ class TestModelAliasSystemEdgeCases:
         # Alias "auto" to point to "claude-sonnet-4.5"
         aliases = {"auto": "claude-sonnet-4.5"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Resolving 'auto'...")
         result = resolver.resolve("auto")
-        
+
         print(f"Comparing internal_id: Expected 'claude-sonnet-4.5', Got '{result.internal_id}'")
         assert result.internal_id == "claude-sonnet-4.5"
-        
+
         print("CRITICAL: Alias takes precedence over cache!")
-    
+
     def test_alias_case_sensitivity(self, mock_model_cache):
         """
         What it does: Aliases are case-sensitive.
@@ -1492,7 +1484,7 @@ class TestModelAliasSystemEdgeCases:
 
 class TestHiddenFromListFunctionality:
     """Tests for HIDDEN_FROM_LIST feature."""
-    
+
     def test_hidden_model_not_in_available_list(self, mock_model_cache):
         """
         What it does: Hidden model doesn't appear in get_available_models().
@@ -1501,18 +1493,18 @@ class TestHiddenFromListFunctionality:
         print("Setup: Creating resolver with hidden_from_list...")
         hidden_from_list = ["auto"]
         resolver = ModelResolver(cache=mock_model_cache, hidden_from_list=hidden_from_list)
-        
+
         print("Action: Getting available models...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print("Check: 'auto' NOT in list...")
         assert "auto" not in models
-        
+
         print("Check: Other models still present...")
         assert "claude-haiku-4.5" in models
         assert "claude-sonnet-4.5" in models
-    
+
     def test_hidden_model_still_works_when_requested(self, mock_model_cache):
         """
         What it does: Hidden model still works when requested directly.
@@ -1521,18 +1513,18 @@ class TestHiddenFromListFunctionality:
         print("Setup: Creating resolver with hidden_from_list...")
         hidden_from_list = ["auto"]
         resolver = ModelResolver(cache=mock_model_cache, hidden_from_list=hidden_from_list)
-        
+
         print("Action: Resolving 'auto' directly...")
         result = resolver.resolve("auto")
-        
+
         print(f"Comparing internal_id: Expected 'auto', Got '{result.internal_id}'")
         assert result.internal_id == "auto"
-        
+
         print(f"Comparing source: Expected 'cache', Got '{result.source}'")
         assert result.source == "cache"
-        
+
         print("CRITICAL: Hidden model still works!")
-    
+
     def test_alias_appears_when_original_hidden(self, mock_model_cache):
         """
         What it does: Alias appears in list when original is hidden.
@@ -1542,19 +1534,19 @@ class TestHiddenFromListFunctionality:
         aliases = {"auto-kiro": "auto"}
         hidden_from_list = ["auto"]
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases, hidden_from_list=hidden_from_list)
-        
+
         print("Action: Getting available models...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print("Check: 'auto-kiro' (alias) IS in list...")
         assert "auto-kiro" in models
-        
+
         print("Check: 'auto' (original) NOT in list...")
         assert "auto" not in models
-        
+
         print("SUCCESS: Alias visible, original hidden!")
-    
+
     def test_multiple_hidden_models(self, mock_model_cache):
         """
         What it does: Multiple models can be hidden.
@@ -1563,18 +1555,18 @@ class TestHiddenFromListFunctionality:
         print("Setup: Creating resolver with multiple hidden models...")
         hidden_from_list = ["auto", "claude-sonnet-4"]
         resolver = ModelResolver(cache=mock_model_cache, hidden_from_list=hidden_from_list)
-        
+
         print("Action: Getting available models...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print("Check: Both hidden models NOT in list...")
         assert "auto" not in models
         assert "claude-sonnet-4" not in models
-        
+
         print("Check: Other models still present...")
         assert "claude-haiku-4.5" in models
-    
+
     def test_empty_hidden_from_list(self, mock_model_cache):
         """
         What it does: Empty hidden_from_list works correctly.
@@ -1582,15 +1574,15 @@ class TestHiddenFromListFunctionality:
         """
         print("Setup: Creating resolver with empty hidden_from_list...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_from_list=[])
-        
+
         print("Action: Getting available models...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print("Check: All models present...")
         assert "auto" in models
         assert "claude-haiku-4.5" in models
-    
+
     def test_none_hidden_from_list(self, mock_model_cache):
         """
         What it does: None hidden_from_list parameter works correctly.
@@ -1598,14 +1590,14 @@ class TestHiddenFromListFunctionality:
         """
         print("Setup: Creating resolver with hidden_from_list=None...")
         resolver = ModelResolver(cache=mock_model_cache, hidden_from_list=None)
-        
+
         print("Check: hidden_from_list initialized as empty set...")
         assert resolver.hidden_from_list == set()
 
 
 class TestAliasSystemIntegration:
     """Integration tests for alias system with existing layers."""
-    
+
     def test_cursor_auto_conflict_solution(self, mock_model_cache):
         """
         What it does: Solves Cursor IDE "auto" conflict.
@@ -1615,31 +1607,31 @@ class TestAliasSystemIntegration:
         aliases = {"auto-kiro": "auto"}
         hidden_from_list = ["auto"]
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases, hidden_from_list=hidden_from_list)
-        
+
         print("Action: Getting available models (what Cursor sees)...")
         models = resolver.get_available_models()
-        
+
         print(f"Models visible to Cursor: {models}")
         print("Check: 'auto' NOT visible (no conflict)...")
         assert "auto" not in models
-        
+
         print("Check: 'auto-kiro' IS visible...")
         assert "auto-kiro" in models
-        
+
         print("Action: User requests 'auto-kiro' in Cursor...")
         result = resolver.resolve("auto-kiro")
-        
+
         print(f"Comparing: 'auto-kiro' resolves to '{result.internal_id}'")
         assert result.internal_id == "auto"
-        
+
         print("Action: Old code with 'auto' still works...")
         result2 = resolver.resolve("auto")
-        
+
         print(f"Comparing: 'auto' still resolves to '{result2.internal_id}'")
         assert result2.internal_id == "auto"
-        
+
         print("SUCCESS: Cursor conflict solved! ✅")
-    
+
     def test_no_duplicates_in_available_models(self, mock_model_cache):
         """
         What it does: No duplicates when alias points to existing model.
@@ -1648,18 +1640,18 @@ class TestAliasSystemIntegration:
         print("Setup: Creating resolver with alias to existing model...")
         aliases = {"my-haiku": "claude-haiku-4.5"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Getting available models...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
         print("Check: No duplicates...")
         assert len(models) == len(set(models))
-        
+
         print("Check: Both alias and original present...")
         assert "my-haiku" in models
         assert "claude-haiku-4.5" in models
-    
+
     def test_alias_with_hidden_models_and_hidden_from_list(self, mock_model_cache):
         """
         What it does: Complex scenario with all features.
@@ -1669,38 +1661,35 @@ class TestAliasSystemIntegration:
         hidden_models = {"claude-3.7-sonnet": "CLAUDE_3_7_SONNET_20250219_V1_0"}
         aliases = {"auto-kiro": "auto", "legacy": "claude-3.7-sonnet"}
         hidden_from_list = ["auto"]
-        
+
         resolver = ModelResolver(
-            cache=mock_model_cache,
-            hidden_models=hidden_models,
-            aliases=aliases,
-            hidden_from_list=hidden_from_list
+            cache=mock_model_cache, hidden_models=hidden_models, aliases=aliases, hidden_from_list=hidden_from_list
         )
-        
+
         print("Action: Getting available models...")
         models = resolver.get_available_models()
-        
+
         print(f"Received models: {models}")
-        
+
         print("Check: Alias 'auto-kiro' present...")
         assert "auto-kiro" in models
-        
+
         print("Check: Original 'auto' hidden...")
         assert "auto" not in models
-        
+
         print("Check: Hidden model 'claude-3.7-sonnet' present...")
         assert "claude-3.7-sonnet" in models
-        
+
         print("Check: Alias to hidden model 'legacy' present...")
         assert "legacy" in models
-        
+
         print("Check: Cache models present...")
         assert "claude-haiku-4.5" in models
 
 
 class TestAliasSystemSecurity:
     """Security tests - ensure aliases don't break safety principles."""
-    
+
     def test_alias_cannot_bypass_family_isolation(self, mock_model_cache):
         """
         What it does: Alias doesn't break family isolation.
@@ -1720,7 +1709,7 @@ class TestAliasSystemSecurity:
 
         print("Check: Unknown models pass through as-is (gateway, not gatekeeper)...")
         assert result.internal_id == "claude-opus-5"
-    
+
     def test_alias_suggestions_respect_target_family(self, mock_model_cache):
         """
         What it does: Suggestions for aliased model respect target family.
@@ -1729,12 +1718,12 @@ class TestAliasSystemSecurity:
         print("Setup: Creating resolver with alias...")
         aliases = {"fast": "claude-haiku-4.5"}
         resolver = ModelResolver(cache=mock_model_cache, aliases=aliases)
-        
+
         print("Action: Getting suggestions for 'fast'...")
         # Note: get_suggestions_for_model() extracts family from the NAME
         # So it won't find "haiku" in "fast", will return all models
         suggestions = resolver.get_suggestions_for_model("fast")
-        
+
         print(f"Received suggestions: {suggestions}")
         # This is expected behavior - alias name doesn't contain family
         assert len(suggestions) > 0

--- a/tests/unit/test_models_anthropic.py
+++ b/tests/unit/test_models_anthropic.py
@@ -16,49 +16,47 @@ import pytest
 from pydantic import ValidationError
 
 from kiro.models_anthropic import (
-    # Content blocks
-    TextContentBlock,
-    ThinkingContentBlock,
-    ToolUseContentBlock,
-    ToolResultContentBlock,
-    ToolReferenceContentBlock,
-    # Image models
-    Base64ImageSource,
-    URLImageSource,
-    ImageContentBlock,
-    ContentBlock,
-    # Message models
-    AnthropicMessage,
-    # Tool models
-    AnthropicTool,
-    ToolChoiceAuto,
-    ToolChoiceAny,
-    ToolChoiceTool,
-    ToolChoice,
-    # Request models
-    SystemContentBlock,
-    AnthropicMessagesRequest,
-    # Response models
-    AnthropicUsage,
-    AnthropicMessagesResponse,
-    # Streaming models
-    MessageStartEvent,
-    ContentBlockStartEvent,
-    TextDelta,
-    ThinkingDelta,
-    InputJsonDelta,
-    ContentBlockDeltaEvent,
-    ContentBlockStopEvent,
-    MessageDeltaUsage,
-    MessageDeltaEvent,
-    MessageStopEvent,
-    PingEvent,
-    ErrorEvent,
     # Error models
     AnthropicErrorDetail,
     AnthropicErrorResponse,
+    # Message models
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    # Tool models
+    AnthropicTool,
+    # Response models
+    AnthropicUsage,
+    # Image models
+    Base64ImageSource,
+    ContentBlock,
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    ErrorEvent,
+    ImageContentBlock,
+    InputJsonDelta,
+    MessageDeltaEvent,
+    MessageDeltaUsage,
+    # Streaming models
+    MessageStartEvent,
+    MessageStopEvent,
+    PingEvent,
+    # Request models
+    SystemContentBlock,
+    # Content blocks
+    TextContentBlock,
+    TextDelta,
+    ThinkingContentBlock,
+    ThinkingDelta,
+    ToolChoiceAny,
+    ToolChoiceAuto,
+    ToolChoiceTool,
+    ToolReferenceContentBlock,
+    ToolResultContentBlock,
+    ToolUseContentBlock,
+    URLImageSource,
 )
-
 
 # Base64 1x1 pixel JPEG for testing
 TEST_IMAGE_BASE64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q=="
@@ -68,73 +66,67 @@ TEST_IMAGE_BASE64 = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAs
 # Tests for Base64ImageSource
 # ==================================================================================================
 
+
 class TestBase64ImageSource:
     """Tests for Base64ImageSource Pydantic model."""
-    
+
     def test_valid_base64_source(self):
         """
         What it does: Verifies creation of valid Base64ImageSource.
         Purpose: Ensure model accepts valid base64 image data.
         """
         print("Setup: Creating Base64ImageSource with valid data...")
-        source = Base64ImageSource(
-            type="base64",
-            media_type="image/jpeg",
-            data=TEST_IMAGE_BASE64
-        )
-        
+        source = Base64ImageSource(type="base64", media_type="image/jpeg", data=TEST_IMAGE_BASE64)
+
         print(f"Result: {source}")
         print(f"Comparing type: Expected 'base64', Got '{source.type}'")
         assert source.type == "base64"
-        
+
         print(f"Comparing media_type: Expected 'image/jpeg', Got '{source.media_type}'")
         assert source.media_type == "image/jpeg"
-        
+
         print(f"Comparing data: Expected {TEST_IMAGE_BASE64[:20]}..., Got {source.data[:20]}...")
         assert source.data == TEST_IMAGE_BASE64
-    
+
     def test_type_defaults_to_base64(self):
         """
         What it does: Verifies that type defaults to "base64".
         Purpose: Ensure default value is set correctly.
         """
         print("Setup: Creating Base64ImageSource without explicit type...")
-        source = Base64ImageSource(
-            media_type="image/png",
-            data=TEST_IMAGE_BASE64
-        )
-        
+        source = Base64ImageSource(media_type="image/png", data=TEST_IMAGE_BASE64)
+
         print(f"Comparing type: Expected 'base64', Got '{source.type}'")
         assert source.type == "base64"
-    
+
     def test_requires_media_type(self):
         """
         What it does: Verifies that media_type is required.
         Purpose: Ensure validation fails without media_type.
         """
         print("Setup: Attempting to create Base64ImageSource without media_type...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             Base64ImageSource(data=TEST_IMAGE_BASE64)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "media_type" in str(exc_info.value)
-    
+
     def test_requires_data(self):
         """
         What it does: Verifies that data is required.
         Purpose: Ensure validation fails without data.
         """
         print("Setup: Attempting to create Base64ImageSource without data...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             Base64ImageSource(media_type="image/jpeg")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "data" in str(exc_info.value)
-    
+
     def test_accepts_various_media_types(self):
         """
         What it does: Verifies acceptance of various image media types.
@@ -142,12 +134,12 @@ class TestBase64ImageSource:
         """
         print("Setup: Testing various media types...")
         media_types = ["image/jpeg", "image/png", "image/gif", "image/webp"]
-        
+
         for media_type in media_types:
             print(f"Testing media_type: {media_type}")
             source = Base64ImageSource(media_type=media_type, data=TEST_IMAGE_BASE64)
             assert source.media_type == media_type
-        
+
         print("All media types accepted successfully")
 
 
@@ -155,27 +147,25 @@ class TestBase64ImageSource:
 # Tests for URLImageSource
 # ==================================================================================================
 
+
 class TestURLImageSource:
     """Tests for URLImageSource Pydantic model."""
-    
+
     def test_valid_url_source(self):
         """
         What it does: Verifies creation of valid URLImageSource.
         Purpose: Ensure model accepts valid URL.
         """
         print("Setup: Creating URLImageSource with valid URL...")
-        source = URLImageSource(
-            type="url",
-            url="https://example.com/image.jpg"
-        )
-        
+        source = URLImageSource(type="url", url="https://example.com/image.jpg")
+
         print(f"Result: {source}")
         print(f"Comparing type: Expected 'url', Got '{source.type}'")
         assert source.type == "url"
-        
+
         print(f"Comparing url: Expected 'https://example.com/image.jpg', Got '{source.url}'")
         assert source.url == "https://example.com/image.jpg"
-    
+
     def test_type_defaults_to_url(self):
         """
         What it does: Verifies that type defaults to "url".
@@ -183,21 +173,21 @@ class TestURLImageSource:
         """
         print("Setup: Creating URLImageSource without explicit type...")
         source = URLImageSource(url="https://example.com/image.png")
-        
+
         print(f"Comparing type: Expected 'url', Got '{source.type}'")
         assert source.type == "url"
-    
+
     def test_requires_url(self):
         """
         What it does: Verifies that url is required.
         Purpose: Ensure validation fails without url.
         """
         print("Setup: Attempting to create URLImageSource without url...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             URLImageSource()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "url" in str(exc_info.value)
 
@@ -206,9 +196,10 @@ class TestURLImageSource:
 # Tests for ImageContentBlock
 # ==================================================================================================
 
+
 class TestImageContentBlock:
     """Tests for ImageContentBlock Pydantic model."""
-    
+
     def test_with_base64_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with base64 source.
@@ -216,40 +207,33 @@ class TestImageContentBlock:
         """
         print("Setup: Creating ImageContentBlock with base64 source...")
         block = ImageContentBlock(
-            type="image",
-            source=Base64ImageSource(
-                media_type="image/jpeg",
-                data=TEST_IMAGE_BASE64
-            )
+            type="image", source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64)
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
-        
+
         print(f"Comparing source.type: Expected 'base64', Got '{block.source.type}'")
         assert block.source.type == "base64"
         assert block.source.media_type == "image/jpeg"
-    
+
     def test_with_url_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with URL source.
         Purpose: Ensure model accepts URLImageSource.
         """
         print("Setup: Creating ImageContentBlock with URL source...")
-        block = ImageContentBlock(
-            type="image",
-            source=URLImageSource(url="https://example.com/image.jpg")
-        )
-        
+        block = ImageContentBlock(type="image", source=URLImageSource(url="https://example.com/image.jpg"))
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
-        
+
         print(f"Comparing source.type: Expected 'url', Got '{block.source.type}'")
         assert block.source.type == "url"
         assert block.source.url == "https://example.com/image.jpg"
-    
+
     def test_with_dict_base64_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with dict source.
@@ -257,62 +241,49 @@ class TestImageContentBlock:
         """
         print("Setup: Creating ImageContentBlock with dict source...")
         block = ImageContentBlock(
-            type="image",
-            source={
-                "type": "base64",
-                "media_type": "image/png",
-                "data": TEST_IMAGE_BASE64
-            }
+            type="image", source={"type": "base64", "media_type": "image/png", "data": TEST_IMAGE_BASE64}
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing source.type: Expected 'base64', Got '{block.source.type}'")
         assert block.source.type == "base64"
         assert block.source.media_type == "image/png"
-    
+
     def test_with_dict_url_source(self):
         """
         What it does: Verifies creation of ImageContentBlock with dict URL source.
         Purpose: Ensure model accepts dict that matches URLImageSource schema.
         """
         print("Setup: Creating ImageContentBlock with dict URL source...")
-        block = ImageContentBlock(
-            type="image",
-            source={
-                "type": "url",
-                "url": "https://example.com/test.gif"
-            }
-        )
-        
+        block = ImageContentBlock(type="image", source={"type": "url", "url": "https://example.com/test.gif"})
+
         print(f"Result: {block}")
         print(f"Comparing source.type: Expected 'url', Got '{block.source.type}'")
         assert block.source.type == "url"
         assert block.source.url == "https://example.com/test.gif"
-    
+
     def test_type_literal_is_image(self):
         """
         What it does: Verifies that type must be "image".
         Purpose: Ensure type literal validation works.
         """
         print("Setup: Creating ImageContentBlock with correct type...")
-        block = ImageContentBlock(
-            source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64)
-        )
-        
+        block = ImageContentBlock(source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64))
+
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
-    
+
     def test_requires_source(self):
         """
         What it does: Verifies that source is required.
         Purpose: Ensure validation fails without source.
         """
         print("Setup: Attempting to create ImageContentBlock without source...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ImageContentBlock(type="image")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "source" in str(exc_info.value)
 
@@ -321,9 +292,10 @@ class TestImageContentBlock:
 # Tests for ContentBlock Union
 # ==================================================================================================
 
+
 class TestContentBlockUnion:
     """Tests for ContentBlock union type accepting ImageContentBlock."""
-    
+
     def test_accepts_text_content_block(self):
         """
         What it does: Verifies ContentBlock accepts TextContentBlock.
@@ -331,17 +303,17 @@ class TestContentBlockUnion:
         """
         print("Setup: Creating TextContentBlock...")
         block: ContentBlock = TextContentBlock(text="Hello, world!")
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
         assert block.text == "Hello, world!"
-    
+
     def test_accepts_image_content_block(self):
         """
         What it does: Verifies ContentBlock accepts ImageContentBlock.
         Purpose: Ensure union includes image blocks (Issue #30 fix).
-        
+
         This is the key test that verifies the fix for Issue #30.
         Before the fix, ContentBlock union did not include ImageContentBlock,
         causing 422 Validation Error when image content was sent.
@@ -350,39 +322,32 @@ class TestContentBlockUnion:
         block: ContentBlock = ImageContentBlock(
             source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64)
         )
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'image', Got '{block.type}'")
         assert block.type == "image"
         assert block.source.type == "base64"
-    
+
     def test_accepts_tool_use_content_block(self):
         """
         What it does: Verifies ContentBlock accepts ToolUseContentBlock.
         Purpose: Ensure union includes tool_use blocks.
         """
         print("Setup: Creating ToolUseContentBlock...")
-        block: ContentBlock = ToolUseContentBlock(
-            id="call_123",
-            name="get_weather",
-            input={"location": "Moscow"}
-        )
-        
+        block: ContentBlock = ToolUseContentBlock(id="call_123", name="get_weather", input={"location": "Moscow"})
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_use', Got '{block.type}'")
         assert block.type == "tool_use"
-    
+
     def test_accepts_tool_result_content_block(self):
         """
         What it does: Verifies ContentBlock accepts ToolResultContentBlock.
         Purpose: Ensure union includes tool_result blocks.
         """
         print("Setup: Creating ToolResultContentBlock...")
-        block: ContentBlock = ToolResultContentBlock(
-            tool_use_id="call_123",
-            content="Weather: Sunny, 25°C"
-        )
-        
+        block: ContentBlock = ToolResultContentBlock(tool_use_id="call_123", content="Weather: Sunny, 25°C")
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
@@ -392,19 +357,20 @@ class TestContentBlockUnion:
 # Tests for AnthropicMessage with Image Content (Issue #30 fix verification)
 # ==================================================================================================
 
+
 class TestAnthropicMessageWithImages:
     """
     Tests for AnthropicMessage with image content.
-    
+
     These tests verify the fix for Issue #30 - 422 Validation Error
     when sending image content blocks in messages.
     """
-    
+
     def test_message_with_image_content_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts image content blocks.
         Purpose: This is the PRIMARY test for Issue #30 fix.
-        
+
         Before the fix, this would raise a ValidationError because
         ContentBlock union did not include ImageContentBlock.
         """
@@ -413,33 +379,28 @@ class TestAnthropicMessageWithImages:
             role="user",
             content=[
                 TextContentBlock(text="What's in this image?"),
-                ImageContentBlock(
-                    source=Base64ImageSource(
-                        media_type="image/jpeg",
-                        data=TEST_IMAGE_BASE64
-                    )
-                )
-            ]
+                ImageContentBlock(source=Base64ImageSource(media_type="image/jpeg", data=TEST_IMAGE_BASE64)),
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'user', Got '{message.role}'")
         assert message.role == "user"
-        
+
         print(f"Comparing content length: Expected 2, Got {len(message.content)}")
         assert len(message.content) == 2
-        
+
         print(f"Comparing content[0].type: Expected 'text', Got '{message.content[0].type}'")
         assert message.content[0].type == "text"
-        
+
         print(f"Comparing content[1].type: Expected 'image', Got '{message.content[1].type}'")
         assert message.content[1].type == "image"
-    
+
     def test_message_with_dict_image_content_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts dict image content.
         Purpose: Ensure raw dict format (as received from API) validates correctly.
-        
+
         This is how the actual API request comes in - as raw dicts, not Pydantic models.
         """
         print("Setup: Creating AnthropicMessage with dict image content...")
@@ -447,25 +408,18 @@ class TestAnthropicMessageWithImages:
             role="user",
             content=[
                 {"type": "text", "text": "Describe this image"},
-                {
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": "image/png",
-                        "data": TEST_IMAGE_BASE64
-                    }
-                }
-            ]
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": TEST_IMAGE_BASE64}},
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing content length: Expected 2, Got {len(message.content)}")
         assert len(message.content) == 2
-        
+
         print(f"Comparing content[1].type: Expected 'image', Got '{message.content[1].type}'")
         assert message.content[1].type == "image"
         assert message.content[1].source.type == "base64"
-    
+
     def test_message_with_multiple_images_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts multiple images.
@@ -476,28 +430,19 @@ class TestAnthropicMessageWithImages:
             role="user",
             content=[
                 {"type": "text", "text": "Compare these images"},
-                {
-                    "type": "image",
-                    "source": {"type": "base64", "media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}
-                },
-                {
-                    "type": "image",
-                    "source": {"type": "base64", "media_type": "image/png", "data": TEST_IMAGE_BASE64}
-                },
-                {
-                    "type": "image",
-                    "source": {"type": "base64", "media_type": "image/webp", "data": TEST_IMAGE_BASE64}
-                }
-            ]
+                {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": TEST_IMAGE_BASE64}},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/webp", "data": TEST_IMAGE_BASE64}},
+            ],
         )
-        
+
         print(f"Result content length: {len(message.content)}")
         assert len(message.content) == 4
-        
+
         image_blocks = [b for b in message.content if b.type == "image"]
         print(f"Image blocks count: {len(image_blocks)}")
         assert len(image_blocks) == 3
-    
+
     def test_message_with_url_image_validates(self):
         """
         What it does: Verifies AnthropicMessage accepts URL image source.
@@ -508,16 +453,10 @@ class TestAnthropicMessageWithImages:
             role="user",
             content=[
                 {"type": "text", "text": "What's in this image?"},
-                {
-                    "type": "image",
-                    "source": {
-                        "type": "url",
-                        "url": "https://example.com/image.jpg"
-                    }
-                }
-            ]
+                {"type": "image", "source": {"type": "url", "url": "https://example.com/image.jpg"}},
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing content[1].source.type: Expected 'url', Got '{message.content[1].source.type}'")
         assert message.content[1].source.type == "url"
@@ -528,14 +467,15 @@ class TestAnthropicMessageWithImages:
 # Tests for AnthropicMessagesRequest with Image Content
 # ==================================================================================================
 
+
 class TestAnthropicMessagesRequestWithImages:
     """Tests for full AnthropicMessagesRequest with image content."""
-    
+
     def test_request_with_image_message_validates(self):
         """
         What it does: Verifies full request with image content validates.
         Purpose: End-to-end validation test for Issue #30 fix.
-        
+
         This simulates the actual request that was failing with 422 error.
         """
         print("Setup: Creating full AnthropicMessagesRequest with image...")
@@ -549,29 +489,25 @@ class TestAnthropicMessagesRequestWithImages:
                         {"type": "text", "text": "What's in this image?"},
                         {
                             "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": "image/jpeg",
-                                "data": TEST_IMAGE_BASE64
-                            }
-                        }
-                    ]
+                            "source": {"type": "base64", "media_type": "image/jpeg", "data": TEST_IMAGE_BASE64},
+                        },
+                    ],
                 )
-            ]
+            ],
         )
-        
+
         print(f"Result: {request}")
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{request.model}'")
         assert request.model == "claude-sonnet-4-5"
-        
+
         print(f"Comparing messages count: Expected 1, Got {len(request.messages)}")
         assert len(request.messages) == 1
-        
+
         print(f"Comparing content count: Expected 2, Got {len(request.messages[0].content)}")
         assert len(request.messages[0].content) == 2
-        
+
         print("Request with image content validated successfully!")
-    
+
     def test_request_with_conversation_including_images(self):
         """
         What it does: Verifies multi-turn conversation with images validates.
@@ -588,37 +524,27 @@ class TestAnthropicMessagesRequestWithImages:
                         {"type": "text", "text": "What's in this image?"},
                         {
                             "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": "image/jpeg",
-                                "data": TEST_IMAGE_BASE64
-                            }
-                        }
-                    ]
+                            "source": {"type": "base64", "media_type": "image/jpeg", "data": TEST_IMAGE_BASE64},
+                        },
+                    ],
                 ),
-                AnthropicMessage(
-                    role="assistant",
-                    content="I can see a small test image."
-                ),
-                AnthropicMessage(
-                    role="user",
-                    content="Can you describe it in more detail?"
-                )
-            ]
+                AnthropicMessage(role="assistant", content="I can see a small test image."),
+                AnthropicMessage(role="user", content="Can you describe it in more detail?"),
+            ],
         )
-        
+
         print(f"Result messages count: {len(request.messages)}")
         assert len(request.messages) == 3
-        
+
         # First message has image
         assert request.messages[0].content[1].type == "image"
-        
+
         # Second message is string (assistant)
         assert request.messages[1].content == "I can see a small test image."
-        
+
         # Third message is string (user follow-up)
         assert request.messages[2].content == "Can you describe it in more detail?"
-        
+
         print("Multi-turn conversation with images validated successfully!")
 
 
@@ -626,9 +552,10 @@ class TestAnthropicMessagesRequestWithImages:
 # Tests for TextContentBlock
 # ==================================================================================================
 
+
 class TestTextContentBlock:
     """Tests for TextContentBlock Pydantic model."""
-    
+
     def test_valid_text_block(self):
         """
         What it does: Verifies creation of valid TextContentBlock.
@@ -636,14 +563,14 @@ class TestTextContentBlock:
         """
         print("Setup: Creating TextContentBlock with valid text...")
         block = TextContentBlock(text="Hello, world!")
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
-        
+
         print(f"Comparing text: Expected 'Hello, world!', Got '{block.text}'")
         assert block.text == "Hello, world!"
-    
+
     def test_type_defaults_to_text(self):
         """
         What it does: Verifies that type defaults to "text".
@@ -651,24 +578,24 @@ class TestTextContentBlock:
         """
         print("Setup: Creating TextContentBlock without explicit type...")
         block = TextContentBlock(text="Test")
-        
+
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
-    
+
     def test_requires_text(self):
         """
         What it does: Verifies that text is required.
         Purpose: Ensure validation fails without text.
         """
         print("Setup: Attempting to create TextContentBlock without text...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             TextContentBlock()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "text" in str(exc_info.value)
-    
+
     def test_accepts_empty_string(self):
         """
         What it does: Verifies that empty string is accepted.
@@ -676,10 +603,10 @@ class TestTextContentBlock:
         """
         print("Setup: Creating TextContentBlock with empty string...")
         block = TextContentBlock(text="")
-        
+
         print(f"Comparing text: Expected '', Got '{block.text}'")
         assert block.text == ""
-    
+
     def test_accepts_multiline_text(self):
         """
         What it does: Verifies that multiline text is accepted.
@@ -688,7 +615,7 @@ class TestTextContentBlock:
         print("Setup: Creating TextContentBlock with multiline text...")
         multiline = "Line 1\nLine 2\nLine 3"
         block = TextContentBlock(text=multiline)
-        
+
         print(f"Comparing text: Expected multiline, Got '{block.text}'")
         assert block.text == multiline
         assert "\n" in block.text
@@ -698,30 +625,28 @@ class TestTextContentBlock:
 # Tests for ThinkingContentBlock
 # ==================================================================================================
 
+
 class TestThinkingContentBlock:
     """Tests for ThinkingContentBlock Pydantic model."""
-    
+
     def test_valid_thinking_block(self):
         """
         What it does: Verifies creation of valid ThinkingContentBlock.
         Purpose: Ensure model accepts valid thinking content.
         """
         print("Setup: Creating ThinkingContentBlock with valid thinking...")
-        block = ThinkingContentBlock(
-            thinking="Let me analyze this step by step...",
-            signature="abc123"
-        )
-        
+        block = ThinkingContentBlock(thinking="Let me analyze this step by step...", signature="abc123")
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'thinking', Got '{block.type}'")
         assert block.type == "thinking"
-        
+
         print(f"Comparing thinking: Got '{block.thinking[:30]}...'")
         assert block.thinking == "Let me analyze this step by step..."
-        
+
         print(f"Comparing signature: Expected 'abc123', Got '{block.signature}'")
         assert block.signature == "abc123"
-    
+
     def test_type_defaults_to_thinking(self):
         """
         What it does: Verifies that type defaults to "thinking".
@@ -729,10 +654,10 @@ class TestThinkingContentBlock:
         """
         print("Setup: Creating ThinkingContentBlock without explicit type...")
         block = ThinkingContentBlock(thinking="Test thinking")
-        
+
         print(f"Comparing type: Expected 'thinking', Got '{block.type}'")
         assert block.type == "thinking"
-    
+
     def test_signature_defaults_to_empty(self):
         """
         What it does: Verifies that signature defaults to empty string.
@@ -740,21 +665,21 @@ class TestThinkingContentBlock:
         """
         print("Setup: Creating ThinkingContentBlock without signature...")
         block = ThinkingContentBlock(thinking="Test")
-        
+
         print(f"Comparing signature: Expected '', Got '{block.signature}'")
         assert block.signature == ""
-    
+
     def test_requires_thinking(self):
         """
         What it does: Verifies that thinking is required.
         Purpose: Ensure validation fails without thinking.
         """
         print("Setup: Attempting to create ThinkingContentBlock without thinking...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ThinkingContentBlock()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "thinking" in str(exc_info.value)
 
@@ -763,34 +688,31 @@ class TestThinkingContentBlock:
 # Tests for ToolUseContentBlock
 # ==================================================================================================
 
+
 class TestToolUseContentBlock:
     """Tests for ToolUseContentBlock Pydantic model."""
-    
+
     def test_valid_tool_use_block(self):
         """
         What it does: Verifies creation of valid ToolUseContentBlock.
         Purpose: Ensure model accepts valid tool use data.
         """
         print("Setup: Creating ToolUseContentBlock with valid data...")
-        block = ToolUseContentBlock(
-            id="call_123",
-            name="get_weather",
-            input={"location": "Moscow", "units": "celsius"}
-        )
-        
+        block = ToolUseContentBlock(id="call_123", name="get_weather", input={"location": "Moscow", "units": "celsius"})
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_use', Got '{block.type}'")
         assert block.type == "tool_use"
-        
+
         print(f"Comparing id: Expected 'call_123', Got '{block.id}'")
         assert block.id == "call_123"
-        
+
         print(f"Comparing name: Expected 'get_weather', Got '{block.name}'")
         assert block.name == "get_weather"
-        
+
         print(f"Comparing input: Got {block.input}")
         assert block.input == {"location": "Moscow", "units": "celsius"}
-    
+
     def test_type_defaults_to_tool_use(self):
         """
         What it does: Verifies that type defaults to "tool_use".
@@ -798,52 +720,52 @@ class TestToolUseContentBlock:
         """
         print("Setup: Creating ToolUseContentBlock without explicit type...")
         block = ToolUseContentBlock(id="call_1", name="test", input={})
-        
+
         print(f"Comparing type: Expected 'tool_use', Got '{block.type}'")
         assert block.type == "tool_use"
-    
+
     def test_requires_id(self):
         """
         What it does: Verifies that id is required.
         Purpose: Ensure validation fails without id.
         """
         print("Setup: Attempting to create ToolUseContentBlock without id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolUseContentBlock(name="test", input={})
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "id" in str(exc_info.value)
-    
+
     def test_requires_name(self):
         """
         What it does: Verifies that name is required.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create ToolUseContentBlock without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolUseContentBlock(id="call_1", input={})
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
-    
+
     def test_requires_input(self):
         """
         What it does: Verifies that input is required.
         Purpose: Ensure validation fails without input.
         """
         print("Setup: Attempting to create ToolUseContentBlock without input...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolUseContentBlock(id="call_1", name="test")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input" in str(exc_info.value)
-    
+
     def test_accepts_empty_input(self):
         """
         What it does: Verifies that empty input dict is accepted.
@@ -851,23 +773,19 @@ class TestToolUseContentBlock:
         """
         print("Setup: Creating ToolUseContentBlock with empty input...")
         block = ToolUseContentBlock(id="call_1", name="no_params_tool", input={})
-        
+
         print(f"Comparing input: Expected {{}}, Got {block.input}")
         assert block.input == {}
-    
+
     def test_accepts_complex_input(self):
         """
         What it does: Verifies that complex nested input is accepted.
         Purpose: Ensure nested structures work.
         """
         print("Setup: Creating ToolUseContentBlock with complex input...")
-        complex_input = {
-            "query": "test",
-            "options": {"limit": 10, "offset": 0},
-            "filters": ["active", "recent"]
-        }
+        complex_input = {"query": "test", "options": {"limit": 10, "offset": 0}, "filters": ["active", "recent"]}
         block = ToolUseContentBlock(id="call_1", name="search", input=complex_input)
-        
+
         print(f"Comparing input: Got {block.input}")
         assert block.input == complex_input
 
@@ -876,30 +794,28 @@ class TestToolUseContentBlock:
 # Tests for ToolResultContentBlock
 # ==================================================================================================
 
+
 class TestToolResultContentBlock:
     """Tests for ToolResultContentBlock Pydantic model."""
-    
+
     def test_valid_tool_result_block(self):
         """
         What it does: Verifies creation of valid ToolResultContentBlock.
         Purpose: Ensure model accepts valid tool result data.
         """
         print("Setup: Creating ToolResultContentBlock with valid data...")
-        block = ToolResultContentBlock(
-            tool_use_id="call_123",
-            content="Weather in Moscow: Sunny, 25°C"
-        )
-        
+        block = ToolResultContentBlock(tool_use_id="call_123", content="Weather in Moscow: Sunny, 25°C")
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
-        
+
         print(f"Comparing tool_use_id: Expected 'call_123', Got '{block.tool_use_id}'")
         assert block.tool_use_id == "call_123"
-        
+
         print(f"Comparing content: Got '{block.content}'")
         assert block.content == "Weather in Moscow: Sunny, 25°C"
-    
+
     def test_type_defaults_to_tool_result(self):
         """
         What it does: Verifies that type defaults to "tool_result".
@@ -907,24 +823,24 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock without explicit type...")
         block = ToolResultContentBlock(tool_use_id="call_1")
-        
+
         print(f"Comparing type: Expected 'tool_result', Got '{block.type}'")
         assert block.type == "tool_result"
-    
+
     def test_requires_tool_use_id(self):
         """
         What it does: Verifies that tool_use_id is required.
         Purpose: Ensure validation fails without tool_use_id.
         """
         print("Setup: Attempting to create ToolResultContentBlock without tool_use_id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolResultContentBlock(content="Result")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "tool_use_id" in str(exc_info.value)
-    
+
     def test_content_is_optional(self):
         """
         What it does: Verifies that content is optional.
@@ -932,10 +848,10 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock without content...")
         block = ToolResultContentBlock(tool_use_id="call_1")
-        
+
         print(f"Comparing content: Expected None, Got {block.content}")
         assert block.content is None
-    
+
     def test_accepts_list_content(self):
         """
         What it does: Verifies that list content is accepted.
@@ -943,29 +859,24 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock with list content...")
         block = ToolResultContentBlock(
-            tool_use_id="call_1",
-            content=[TextContentBlock(text="Part 1"), TextContentBlock(text="Part 2")]
+            tool_use_id="call_1", content=[TextContentBlock(text="Part 1"), TextContentBlock(text="Part 2")]
         )
-        
+
         print(f"Comparing content type: Expected list, Got {type(block.content)}")
         assert isinstance(block.content, list)
         assert len(block.content) == 2
-    
+
     def test_is_error_field(self):
         """
         What it does: Verifies that is_error field works.
         Purpose: Ensure error results can be marked.
         """
         print("Setup: Creating ToolResultContentBlock with is_error=True...")
-        block = ToolResultContentBlock(
-            tool_use_id="call_1",
-            content="Error: File not found",
-            is_error=True
-        )
-        
+        block = ToolResultContentBlock(tool_use_id="call_1", content="Error: File not found", is_error=True)
+
         print(f"Comparing is_error: Expected True, Got {block.is_error}")
         assert block.is_error is True
-    
+
     def test_is_error_defaults_to_none(self):
         """
         What it does: Verifies that is_error defaults to None.
@@ -973,7 +884,7 @@ class TestToolResultContentBlock:
         """
         print("Setup: Creating ToolResultContentBlock without is_error...")
         block = ToolResultContentBlock(tool_use_id="call_1", content="Success")
-        
+
         print(f"Comparing is_error: Expected None, Got {block.is_error}")
         assert block.is_error is None
 
@@ -987,8 +898,8 @@ class TestToolResultContentBlock:
             tool_use_id="call_1",
             content=[
                 TextContentBlock(text="Loaded tool"),
-                ToolReferenceContentBlock(tool_name="mcp__slack__read_channel")
-            ]
+                ToolReferenceContentBlock(tool_name="mcp__slack__read_channel"),
+            ],
         )
 
         print(f"Comparing content length: Expected 2, Got {len(block.content)}")
@@ -1000,6 +911,7 @@ class TestToolResultContentBlock:
 # ==================================================================================================
 # Tests for ToolReferenceContentBlock
 # ==================================================================================================
+
 
 class TestToolReferenceContentBlock:
     """Tests for ToolReferenceContentBlock Pydantic model."""
@@ -1058,9 +970,10 @@ class TestToolReferenceContentBlock:
 # Tests for AnthropicTool
 # ==================================================================================================
 
+
 class TestAnthropicTool:
     """Tests for AnthropicTool Pydantic model."""
-    
+
     def test_valid_tool(self):
         """
         What it does: Verifies creation of valid AnthropicTool.
@@ -1072,51 +985,49 @@ class TestAnthropicTool:
             description="Get weather for a location",
             input_schema={
                 "type": "object",
-                "properties": {
-                    "location": {"type": "string", "description": "City name"}
-                },
-                "required": ["location"]
-            }
+                "properties": {"location": {"type": "string", "description": "City name"}},
+                "required": ["location"],
+            },
         )
-        
+
         print(f"Result: {tool}")
         print(f"Comparing name: Expected 'get_weather', Got '{tool.name}'")
         assert tool.name == "get_weather"
-        
+
         print(f"Comparing description: Got '{tool.description}'")
         assert tool.description == "Get weather for a location"
-        
+
         print(f"Comparing input_schema: Got {tool.input_schema}")
         assert "properties" in tool.input_schema
-    
+
     def test_requires_name(self):
         """
         What it does: Verifies that name is required.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create AnthropicTool without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicTool(input_schema={})
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
-    
+
     def test_requires_input_schema(self):
         """
         What it does: Verifies that input_schema is required.
         Purpose: Ensure validation fails without input_schema.
         """
         print("Setup: Attempting to create AnthropicTool without input_schema...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicTool(name="test")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input_schema" in str(exc_info.value)
-    
+
     def test_description_is_optional(self):
         """
         What it does: Verifies that description is optional.
@@ -1124,37 +1035,33 @@ class TestAnthropicTool:
         """
         print("Setup: Creating AnthropicTool without description...")
         tool = AnthropicTool(name="simple_tool", input_schema={})
-        
+
         print(f"Comparing description: Expected None, Got {tool.description}")
         assert tool.description is None
-    
+
     def test_server_side_tool_without_input_schema_valid(self):
         """
         What it does: Server-side tool (with type field) should NOT require input_schema.
         Purpose: Ensure Anthropic server-side tools work without input_schema.
         """
         print("Setup: Creating server-side tool with type field...")
-        tool_data = {
-            "type": "web_search_20250305",
-            "name": "web_search",
-            "max_uses": 5
-        }
-        
+        tool_data = {"type": "web_search_20250305", "name": "web_search", "max_uses": 5}
+
         print("Action: Creating AnthropicTool...")
         tool = AnthropicTool(**tool_data)
-        
+
         print(f"Comparing type: Expected 'web_search_20250305', Got '{tool.type}'")
         assert tool.type == "web_search_20250305"
-        
+
         print(f"Comparing name: Expected 'web_search', Got '{tool.name}'")
         assert tool.name == "web_search"
-        
+
         print(f"Comparing input_schema: Expected None, Got {tool.input_schema}")
         assert tool.input_schema is None
-        
+
         print(f"Comparing max_uses: Expected 5, Got {tool.max_uses}")
         assert tool.max_uses == 5
-    
+
     def test_user_defined_tool_without_input_schema_invalid(self):
         """
         What it does: User-defined tool (no type field) MUST have input_schema.
@@ -1163,17 +1070,17 @@ class TestAnthropicTool:
         print("Setup: Attempting to create user-defined tool without input_schema...")
         tool_data = {
             "name": "my_tool",
-            "description": "My tool"
+            "description": "My tool",
             # Missing input_schema and no type field
         }
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicTool(**tool_data)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input_schema is required" in str(exc_info.value)
-    
+
     def test_server_side_tool_all_parameters(self):
         """
         What it does: Server-side tool with all optional parameters.
@@ -1187,22 +1094,22 @@ class TestAnthropicTool:
             "max_uses": 10,
             "allowed_domains": ["example.com", "test.com"],
             "blocked_domains": ["spam.com"],
-            "user_location": {"city": "Moscow", "country": "RU"}
+            "user_location": {"city": "Moscow", "country": "RU"},
         }
-        
+
         print("Action: Creating AnthropicTool...")
         tool = AnthropicTool(**tool_data)
-        
+
         print(f"Comparing allowed_domains: Got {tool.allowed_domains}")
         assert tool.allowed_domains == ["example.com", "test.com"]
-        
+
         print(f"Comparing blocked_domains: Got {tool.blocked_domains}")
         assert tool.blocked_domains == ["spam.com"]
-        
+
         print(f"Comparing user_location: Got {tool.user_location}")
         assert tool.user_location["city"] == "Moscow"
         assert tool.user_location["country"] == "RU"
-    
+
     def test_server_side_tool_with_input_schema_valid(self):
         """
         What it does: Server-side tool CAN have input_schema (optional).
@@ -1212,20 +1119,15 @@ class TestAnthropicTool:
         tool_data = {
             "type": "web_search_20250305",
             "name": "web_search",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "query": {"type": "string"}
-                }
-            }
+            "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
         }
-        
+
         print("Action: Creating AnthropicTool...")
         tool = AnthropicTool(**tool_data)
-        
+
         print(f"Comparing type: Got '{tool.type}'")
         assert tool.type == "web_search_20250305"
-        
+
         print(f"Comparing input_schema: Got {tool.input_schema}")
         assert tool.input_schema is not None
         assert "properties" in tool.input_schema
@@ -1235,9 +1137,10 @@ class TestAnthropicTool:
 # Tests for ToolChoice models
 # ==================================================================================================
 
+
 class TestToolChoiceModels:
     """Tests for ToolChoice Pydantic models."""
-    
+
     def test_tool_choice_auto(self):
         """
         What it does: Verifies creation of ToolChoiceAuto.
@@ -1245,11 +1148,11 @@ class TestToolChoiceModels:
         """
         print("Setup: Creating ToolChoiceAuto...")
         choice = ToolChoiceAuto()
-        
+
         print(f"Result: {choice}")
         print(f"Comparing type: Expected 'auto', Got '{choice.type}'")
         assert choice.type == "auto"
-    
+
     def test_tool_choice_any(self):
         """
         What it does: Verifies creation of ToolChoiceAny.
@@ -1257,11 +1160,11 @@ class TestToolChoiceModels:
         """
         print("Setup: Creating ToolChoiceAny...")
         choice = ToolChoiceAny()
-        
+
         print(f"Result: {choice}")
         print(f"Comparing type: Expected 'any', Got '{choice.type}'")
         assert choice.type == "any"
-    
+
     def test_tool_choice_tool(self):
         """
         What it does: Verifies creation of ToolChoiceTool.
@@ -1269,25 +1172,25 @@ class TestToolChoiceModels:
         """
         print("Setup: Creating ToolChoiceTool...")
         choice = ToolChoiceTool(name="get_weather")
-        
+
         print(f"Result: {choice}")
         print(f"Comparing type: Expected 'tool', Got '{choice.type}'")
         assert choice.type == "tool"
-        
+
         print(f"Comparing name: Expected 'get_weather', Got '{choice.name}'")
         assert choice.name == "get_weather"
-    
+
     def test_tool_choice_tool_requires_name(self):
         """
         What it does: Verifies that ToolChoiceTool requires name.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create ToolChoiceTool without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolChoiceTool()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
 
@@ -1296,9 +1199,10 @@ class TestToolChoiceModels:
 # Tests for SystemContentBlock
 # ==================================================================================================
 
+
 class TestSystemContentBlock:
     """Tests for SystemContentBlock Pydantic model."""
-    
+
     def test_valid_system_block(self):
         """
         What it does: Verifies creation of valid SystemContentBlock.
@@ -1306,29 +1210,26 @@ class TestSystemContentBlock:
         """
         print("Setup: Creating SystemContentBlock with valid data...")
         block = SystemContentBlock(text="You are a helpful assistant.")
-        
+
         print(f"Result: {block}")
         print(f"Comparing type: Expected 'text', Got '{block.type}'")
         assert block.type == "text"
-        
+
         print(f"Comparing text: Got '{block.text}'")
         assert block.text == "You are a helpful assistant."
-    
+
     def test_with_cache_control(self):
         """
         What it does: Verifies SystemContentBlock with cache_control.
         Purpose: Ensure prompt caching format works.
         """
         print("Setup: Creating SystemContentBlock with cache_control...")
-        block = SystemContentBlock(
-            text="You are helpful.",
-            cache_control={"type": "ephemeral"}
-        )
-        
+        block = SystemContentBlock(text="You are helpful.", cache_control={"type": "ephemeral"})
+
         print(f"Result: {block}")
         print(f"Comparing cache_control: Got {block.cache_control}")
         assert block.cache_control == {"type": "ephemeral"}
-    
+
     def test_cache_control_is_optional(self):
         """
         What it does: Verifies that cache_control is optional.
@@ -1336,21 +1237,21 @@ class TestSystemContentBlock:
         """
         print("Setup: Creating SystemContentBlock without cache_control...")
         block = SystemContentBlock(text="Test")
-        
+
         print(f"Comparing cache_control: Expected None, Got {block.cache_control}")
         assert block.cache_control is None
-    
+
     def test_requires_text(self):
         """
         What it does: Verifies that text is required.
         Purpose: Ensure validation fails without text.
         """
         print("Setup: Attempting to create SystemContentBlock without text...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             SystemContentBlock()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "text" in str(exc_info.value)
 
@@ -1359,9 +1260,10 @@ class TestSystemContentBlock:
 # Tests for AnthropicUsage
 # ==================================================================================================
 
+
 class TestAnthropicUsage:
     """Tests for AnthropicUsage Pydantic model."""
-    
+
     def test_valid_usage(self):
         """
         What it does: Verifies creation of valid AnthropicUsage.
@@ -1369,39 +1271,39 @@ class TestAnthropicUsage:
         """
         print("Setup: Creating AnthropicUsage with valid data...")
         usage = AnthropicUsage(input_tokens=100, output_tokens=50)
-        
+
         print(f"Result: {usage}")
         print(f"Comparing input_tokens: Expected 100, Got {usage.input_tokens}")
         assert usage.input_tokens == 100
-        
+
         print(f"Comparing output_tokens: Expected 50, Got {usage.output_tokens}")
         assert usage.output_tokens == 50
-    
+
     def test_requires_input_tokens(self):
         """
         What it does: Verifies that input_tokens is required.
         Purpose: Ensure validation fails without input_tokens.
         """
         print("Setup: Attempting to create AnthropicUsage without input_tokens...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicUsage(output_tokens=50)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "input_tokens" in str(exc_info.value)
-    
+
     def test_requires_output_tokens(self):
         """
         What it does: Verifies that output_tokens is required.
         Purpose: Ensure validation fails without output_tokens.
         """
         print("Setup: Attempting to create AnthropicUsage without output_tokens...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             AnthropicUsage(input_tokens=100)
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "output_tokens" in str(exc_info.value)
 
@@ -1410,9 +1312,10 @@ class TestAnthropicUsage:
 # Tests for AnthropicMessagesResponse
 # ==================================================================================================
 
+
 class TestAnthropicMessagesResponse:
     """Tests for AnthropicMessagesResponse Pydantic model."""
-    
+
     def test_valid_response(self):
         """
         What it does: Verifies creation of valid AnthropicMessagesResponse.
@@ -1423,22 +1326,22 @@ class TestAnthropicMessagesResponse:
             id="msg_123",
             model="claude-sonnet-4-5",
             content=[TextContentBlock(text="Hello!")],
-            usage=AnthropicUsage(input_tokens=10, output_tokens=5)
+            usage=AnthropicUsage(input_tokens=10, output_tokens=5),
         )
-        
+
         print(f"Result: {response}")
         print(f"Comparing id: Expected 'msg_123', Got '{response.id}'")
         assert response.id == "msg_123"
-        
+
         print(f"Comparing type: Expected 'message', Got '{response.type}'")
         assert response.type == "message"
-        
+
         print(f"Comparing role: Expected 'assistant', Got '{response.role}'")
         assert response.role == "assistant"
-        
+
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{response.model}'")
         assert response.model == "claude-sonnet-4-5"
-    
+
     def test_stop_reason_values(self):
         """
         What it does: Verifies that stop_reason accepts valid values.
@@ -1446,7 +1349,7 @@ class TestAnthropicMessagesResponse:
         """
         print("Setup: Testing various stop_reason values...")
         stop_reasons = ["end_turn", "max_tokens", "stop_sequence", "tool_use"]
-        
+
         for reason in stop_reasons:
             print(f"Testing stop_reason: {reason}")
             response = AnthropicMessagesResponse(
@@ -1454,12 +1357,12 @@ class TestAnthropicMessagesResponse:
                 model="claude-sonnet-4-5",
                 content=[TextContentBlock(text="Test")],
                 usage=AnthropicUsage(input_tokens=1, output_tokens=1),
-                stop_reason=reason
+                stop_reason=reason,
             )
             assert response.stop_reason == reason
-        
+
         print("All stop_reason values accepted successfully")
-    
+
     def test_stop_reason_is_optional(self):
         """
         What it does: Verifies that stop_reason is optional.
@@ -1470,9 +1373,9 @@ class TestAnthropicMessagesResponse:
             id="msg_1",
             model="claude-sonnet-4-5",
             content=[TextContentBlock(text="Test")],
-            usage=AnthropicUsage(input_tokens=1, output_tokens=1)
+            usage=AnthropicUsage(input_tokens=1, output_tokens=1),
         )
-        
+
         print(f"Comparing stop_reason: Expected None, Got {response.stop_reason}")
         assert response.stop_reason is None
 
@@ -1481,40 +1384,36 @@ class TestAnthropicMessagesResponse:
 # Tests for Streaming Event Models
 # ==================================================================================================
 
+
 class TestStreamingEvents:
     """Tests for streaming event Pydantic models."""
-    
+
     def test_message_start_event(self):
         """
         What it does: Verifies creation of MessageStartEvent.
         Purpose: Ensure message_start event works.
         """
         print("Setup: Creating MessageStartEvent...")
-        event = MessageStartEvent(
-            message={"id": "msg_1", "type": "message", "role": "assistant"}
-        )
-        
+        event = MessageStartEvent(message={"id": "msg_1", "type": "message", "role": "assistant"})
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'message_start', Got '{event.type}'")
         assert event.type == "message_start"
         assert event.message["id"] == "msg_1"
-    
+
     def test_content_block_start_event(self):
         """
         What it does: Verifies creation of ContentBlockStartEvent.
         Purpose: Ensure content_block_start event works.
         """
         print("Setup: Creating ContentBlockStartEvent...")
-        event = ContentBlockStartEvent(
-            index=0,
-            content_block={"type": "text", "text": ""}
-        )
-        
+        event = ContentBlockStartEvent(index=0, content_block={"type": "text", "text": ""})
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'content_block_start', Got '{event.type}'")
         assert event.type == "content_block_start"
         assert event.index == 0
-    
+
     def test_text_delta(self):
         """
         What it does: Verifies creation of TextDelta.
@@ -1522,12 +1421,12 @@ class TestStreamingEvents:
         """
         print("Setup: Creating TextDelta...")
         delta = TextDelta(text="Hello")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing type: Expected 'text_delta', Got '{delta.type}'")
         assert delta.type == "text_delta"
         assert delta.text == "Hello"
-    
+
     def test_thinking_delta(self):
         """
         What it does: Verifies creation of ThinkingDelta.
@@ -1535,12 +1434,12 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ThinkingDelta...")
         delta = ThinkingDelta(thinking="Let me think...")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing type: Expected 'thinking_delta', Got '{delta.type}'")
         assert delta.type == "thinking_delta"
         assert delta.thinking == "Let me think..."
-    
+
     def test_input_json_delta(self):
         """
         What it does: Verifies creation of InputJsonDelta.
@@ -1548,28 +1447,25 @@ class TestStreamingEvents:
         """
         print("Setup: Creating InputJsonDelta...")
         delta = InputJsonDelta(partial_json='{"loc')
-        
+
         print(f"Result: {delta}")
         print(f"Comparing type: Expected 'input_json_delta', Got '{delta.type}'")
         assert delta.type == "input_json_delta"
         assert delta.partial_json == '{"loc'
-    
+
     def test_content_block_delta_event(self):
         """
         What it does: Verifies creation of ContentBlockDeltaEvent.
         Purpose: Ensure content_block_delta event works.
         """
         print("Setup: Creating ContentBlockDeltaEvent...")
-        event = ContentBlockDeltaEvent(
-            index=0,
-            delta=TextDelta(text="Hello")
-        )
-        
+        event = ContentBlockDeltaEvent(index=0, delta=TextDelta(text="Hello"))
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'content_block_delta', Got '{event.type}'")
         assert event.type == "content_block_delta"
         assert event.index == 0
-    
+
     def test_content_block_stop_event(self):
         """
         What it does: Verifies creation of ContentBlockStopEvent.
@@ -1577,28 +1473,25 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ContentBlockStopEvent...")
         event = ContentBlockStopEvent(index=0)
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'content_block_stop', Got '{event.type}'")
         assert event.type == "content_block_stop"
         assert event.index == 0
-    
+
     def test_message_delta_event(self):
         """
         What it does: Verifies creation of MessageDeltaEvent.
         Purpose: Ensure message_delta event works.
         """
         print("Setup: Creating MessageDeltaEvent...")
-        event = MessageDeltaEvent(
-            delta={"stop_reason": "end_turn"},
-            usage=MessageDeltaUsage(output_tokens=10)
-        )
-        
+        event = MessageDeltaEvent(delta={"stop_reason": "end_turn"}, usage=MessageDeltaUsage(output_tokens=10))
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'message_delta', Got '{event.type}'")
         assert event.type == "message_delta"
         assert event.delta["stop_reason"] == "end_turn"
-    
+
     def test_message_stop_event(self):
         """
         What it does: Verifies creation of MessageStopEvent.
@@ -1606,11 +1499,11 @@ class TestStreamingEvents:
         """
         print("Setup: Creating MessageStopEvent...")
         event = MessageStopEvent()
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'message_stop', Got '{event.type}'")
         assert event.type == "message_stop"
-    
+
     def test_ping_event(self):
         """
         What it does: Verifies creation of PingEvent.
@@ -1618,11 +1511,11 @@ class TestStreamingEvents:
         """
         print("Setup: Creating PingEvent...")
         event = PingEvent()
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'ping', Got '{event.type}'")
         assert event.type == "ping"
-    
+
     def test_error_event(self):
         """
         What it does: Verifies creation of ErrorEvent.
@@ -1630,7 +1523,7 @@ class TestStreamingEvents:
         """
         print("Setup: Creating ErrorEvent...")
         event = ErrorEvent(error={"type": "invalid_request", "message": "Bad request"})
-        
+
         print(f"Result: {event}")
         print(f"Comparing type: Expected 'error', Got '{event.type}'")
         assert event.type == "error"
@@ -1641,27 +1534,25 @@ class TestStreamingEvents:
 # Tests for Error Models
 # ==================================================================================================
 
+
 class TestErrorModels:
     """Tests for error Pydantic models."""
-    
+
     def test_anthropic_error_detail(self):
         """
         What it does: Verifies creation of AnthropicErrorDetail.
         Purpose: Ensure error detail model works.
         """
         print("Setup: Creating AnthropicErrorDetail...")
-        detail = AnthropicErrorDetail(
-            type="invalid_request_error",
-            message="Invalid API key"
-        )
-        
+        detail = AnthropicErrorDetail(type="invalid_request_error", message="Invalid API key")
+
         print(f"Result: {detail}")
         print(f"Comparing type: Expected 'invalid_request_error', Got '{detail.type}'")
         assert detail.type == "invalid_request_error"
-        
+
         print(f"Comparing message: Got '{detail.message}'")
         assert detail.message == "Invalid API key"
-    
+
     def test_anthropic_error_response(self):
         """
         What it does: Verifies creation of AnthropicErrorResponse.
@@ -1669,16 +1560,13 @@ class TestErrorModels:
         """
         print("Setup: Creating AnthropicErrorResponse...")
         response = AnthropicErrorResponse(
-            error=AnthropicErrorDetail(
-                type="authentication_error",
-                message="Invalid API key provided"
-            )
+            error=AnthropicErrorDetail(type="authentication_error", message="Invalid API key provided")
         )
-        
+
         print(f"Result: {response}")
         print(f"Comparing type: Expected 'error', Got '{response.type}'")
         assert response.type == "error"
-        
+
         print(f"Comparing error.type: Got '{response.error.type}'")
         assert response.error.type == "authentication_error"
 
@@ -1687,9 +1575,10 @@ class TestErrorModels:
 # Tests for Client Thinking Budget Support (Issue #111)
 # ==================================================================================================
 
+
 class TestThinkingParameter:
     """Tests for thinking parameter in AnthropicMessagesRequest."""
-    
+
     def test_thinking_optional(self):
         """
         What it does: Verifies thinking parameter can be None (not specified)
@@ -1697,14 +1586,12 @@ class TestThinkingParameter:
         """
         print("Creating AnthropicMessagesRequest without thinking...")
         request = AnthropicMessagesRequest(
-            model="claude-sonnet-4.5",
-            messages=[AnthropicMessage(role="user", content="test")],
-            max_tokens=1024
+            model="claude-sonnet-4.5", messages=[AnthropicMessage(role="user", content="test")], max_tokens=1024
         )
-        
+
         print(f"Comparing: expected=None, got={request.thinking}")
         assert request.thinking is None
-    
+
     def test_thinking_with_budget_tokens(self):
         """
         What it does: Verifies thinking={"type": "enabled", "budget_tokens": 8000} is accepted
@@ -1715,14 +1602,14 @@ class TestThinkingParameter:
             model="claude-sonnet-4.5",
             messages=[AnthropicMessage(role="user", content="test")],
             max_tokens=1024,
-            thinking={"type": "enabled", "budget_tokens": 8000}
+            thinking={"type": "enabled", "budget_tokens": 8000},
         )
-        
+
         print(f"Comparing thinking: got={request.thinking}")
         assert request.thinking is not None
         assert request.thinking["type"] == "enabled"
         assert request.thinking["budget_tokens"] == 8000
-    
+
     def test_thinking_without_budget_tokens(self):
         """
         What it does: Verifies thinking={"type": "enabled"} without budget_tokens is accepted
@@ -1733,14 +1620,14 @@ class TestThinkingParameter:
             model="claude-sonnet-4.5",
             messages=[AnthropicMessage(role="user", content="test")],
             max_tokens=1024,
-            thinking={"type": "enabled"}
+            thinking={"type": "enabled"},
         )
-        
+
         print(f"Comparing thinking: got={request.thinking}")
         assert request.thinking is not None
         assert request.thinking["type"] == "enabled"
         assert "budget_tokens" not in request.thinking
-    
+
     def test_thinking_disabled(self):
         """
         What it does: Verifies thinking={"type": "disabled"} is accepted
@@ -1751,9 +1638,9 @@ class TestThinkingParameter:
             model="claude-sonnet-4.5",
             messages=[AnthropicMessage(role="user", content="test")],
             max_tokens=1024,
-            thinking={"type": "disabled"}
+            thinking={"type": "disabled"},
         )
-        
+
         print(f"Comparing thinking: got={request.thinking}")
         assert request.thinking is not None
         assert request.thinking["type"] == "disabled"

--- a/tests/unit/test_models_openai.py
+++ b/tests/unit/test_models_openai.py
@@ -16,72 +16,69 @@ import pytest
 from pydantic import ValidationError
 
 from kiro.models_openai import (
-    # Model listing
-    OpenAIModel,
-    ModelList,
-    # Chat messages
-    ChatMessage,
-    # Tools
-    ToolFunction,
-    Tool,
-    # Requests
-    ChatCompletionRequest,
     # Responses
     ChatCompletionChoice,
-    ChatCompletionUsage,
-    ChatCompletionResponse,
+    ChatCompletionChunk,
+    ChatCompletionChunkChoice,
     # Streaming
     ChatCompletionChunkDelta,
-    ChatCompletionChunkChoice,
-    ChatCompletionChunk,
+    # Requests
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+    # Chat messages
+    ChatMessage,
+    ModelList,
+    # Model listing
+    OpenAIModel,
+    Tool,
+    # Tools
+    ToolFunction,
 )
-
 
 # ==================================================================================================
 # Tests for OpenAIModel
 # ==================================================================================================
 
+
 class TestOpenAIModel:
     """Tests for OpenAIModel Pydantic model."""
-    
+
     def test_valid_model(self):
         """
         What it does: Verifies creation of valid OpenAIModel.
         Purpose: Ensure model accepts valid data.
         """
         print("Setup: Creating OpenAIModel with valid data...")
-        model = OpenAIModel(
-            id="claude-sonnet-4-5",
-            description="Claude Sonnet 4.5 model"
-        )
-        
+        model = OpenAIModel(id="claude-sonnet-4-5", description="Claude Sonnet 4.5 model")
+
         print(f"Result: {model}")
         print(f"Comparing id: Expected 'claude-sonnet-4-5', Got '{model.id}'")
         assert model.id == "claude-sonnet-4-5"
-        
+
         print(f"Comparing object: Expected 'model', Got '{model.object}'")
         assert model.object == "model"
-        
+
         print(f"Comparing owned_by: Expected 'anthropic', Got '{model.owned_by}'")
         assert model.owned_by == "anthropic"
-        
+
         print(f"Comparing description: Got '{model.description}'")
         assert model.description == "Claude Sonnet 4.5 model"
-    
+
     def test_requires_id(self):
         """
         What it does: Verifies that id is required.
         Purpose: Ensure validation fails without id.
         """
         print("Setup: Attempting to create OpenAIModel without id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             OpenAIModel()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "id" in str(exc_info.value)
-    
+
     def test_object_defaults_to_model(self):
         """
         What it does: Verifies that object defaults to "model".
@@ -89,10 +86,10 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without explicit object...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing object: Expected 'model', Got '{model.object}'")
         assert model.object == "model"
-    
+
     def test_owned_by_defaults_to_anthropic(self):
         """
         What it does: Verifies that owned_by defaults to "anthropic".
@@ -100,10 +97,10 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without explicit owned_by...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing owned_by: Expected 'anthropic', Got '{model.owned_by}'")
         assert model.owned_by == "anthropic"
-    
+
     def test_created_is_auto_generated(self):
         """
         What it does: Verifies that created timestamp is auto-generated.
@@ -111,11 +108,11 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without explicit created...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing created: Got {model.created}")
         assert model.created > 0
         assert isinstance(model.created, int)
-    
+
     def test_description_is_optional(self):
         """
         What it does: Verifies that description is optional.
@@ -123,7 +120,7 @@ class TestOpenAIModel:
         """
         print("Setup: Creating OpenAIModel without description...")
         model = OpenAIModel(id="test-model")
-        
+
         print(f"Comparing description: Expected None, Got {model.description}")
         assert model.description is None
 
@@ -132,29 +129,25 @@ class TestOpenAIModel:
 # Tests for ModelList
 # ==================================================================================================
 
+
 class TestModelList:
     """Tests for ModelList Pydantic model."""
-    
+
     def test_valid_model_list(self):
         """
         What it does: Verifies creation of valid ModelList.
         Purpose: Ensure model list accepts valid data.
         """
         print("Setup: Creating ModelList with valid data...")
-        model_list = ModelList(
-            data=[
-                OpenAIModel(id="claude-sonnet-4-5"),
-                OpenAIModel(id="claude-opus-4")
-            ]
-        )
-        
+        model_list = ModelList(data=[OpenAIModel(id="claude-sonnet-4-5"), OpenAIModel(id="claude-opus-4")])
+
         print(f"Result: {model_list}")
         print(f"Comparing object: Expected 'list', Got '{model_list.object}'")
         assert model_list.object == "list"
-        
+
         print(f"Comparing data length: Expected 2, Got {len(model_list.data)}")
         assert len(model_list.data) == 2
-    
+
     def test_object_defaults_to_list(self):
         """
         What it does: Verifies that object defaults to "list".
@@ -162,24 +155,24 @@ class TestModelList:
         """
         print("Setup: Creating ModelList without explicit object...")
         model_list = ModelList(data=[])
-        
+
         print(f"Comparing object: Expected 'list', Got '{model_list.object}'")
         assert model_list.object == "list"
-    
+
     def test_requires_data(self):
         """
         What it does: Verifies that data is required.
         Purpose: Ensure validation fails without data.
         """
         print("Setup: Attempting to create ModelList without data...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ModelList()
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "data" in str(exc_info.value)
-    
+
     def test_accepts_empty_list(self):
         """
         What it does: Verifies that empty list is accepted.
@@ -187,7 +180,7 @@ class TestModelList:
         """
         print("Setup: Creating ModelList with empty data...")
         model_list = ModelList(data=[])
-        
+
         print(f"Comparing data: Expected [], Got {model_list.data}")
         assert model_list.data == []
 
@@ -196,9 +189,10 @@ class TestModelList:
 # Tests for ChatMessage
 # ==================================================================================================
 
+
 class TestChatMessage:
     """Tests for ChatMessage Pydantic model."""
-    
+
     def test_valid_user_message(self):
         """
         What it does: Verifies creation of valid user message.
@@ -206,14 +200,14 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with user role...")
         message = ChatMessage(role="user", content="Hello!")
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'user', Got '{message.role}'")
         assert message.role == "user"
-        
+
         print(f"Comparing content: Expected 'Hello!', Got '{message.content}'")
         assert message.content == "Hello!"
-    
+
     def test_valid_assistant_message(self):
         """
         What it does: Verifies creation of valid assistant message.
@@ -221,11 +215,11 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with assistant role...")
         message = ChatMessage(role="assistant", content="Hi there!")
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'assistant', Got '{message.role}'")
         assert message.role == "assistant"
-    
+
     def test_valid_system_message(self):
         """
         What it does: Verifies creation of valid system message.
@@ -233,44 +227,40 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with system role...")
         message = ChatMessage(role="system", content="You are helpful.")
-        
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'system', Got '{message.role}'")
         assert message.role == "system"
-    
+
     def test_valid_tool_message(self):
         """
         What it does: Verifies creation of valid tool message.
         Purpose: Ensure model accepts valid tool message.
         """
         print("Setup: Creating ChatMessage with tool role...")
-        message = ChatMessage(
-            role="tool",
-            content="Tool result",
-            tool_call_id="call_123"
-        )
-        
+        message = ChatMessage(role="tool", content="Tool result", tool_call_id="call_123")
+
         print(f"Result: {message}")
         print(f"Comparing role: Expected 'tool', Got '{message.role}'")
         assert message.role == "tool"
-        
+
         print(f"Comparing tool_call_id: Expected 'call_123', Got '{message.tool_call_id}'")
         assert message.tool_call_id == "call_123"
-    
+
     def test_requires_role(self):
         """
         What it does: Verifies that role is required.
         Purpose: Ensure validation fails without role.
         """
         print("Setup: Attempting to create ChatMessage without role...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatMessage(content="Hello")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "role" in str(exc_info.value)
-    
+
     def test_content_is_optional(self):
         """
         What it does: Verifies that content is optional.
@@ -278,10 +268,10 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage without content...")
         message = ChatMessage(role="assistant")
-        
+
         print(f"Comparing content: Expected None, Got {message.content}")
         assert message.content is None
-    
+
     def test_accepts_list_content(self):
         """
         What it does: Verifies that list content is accepted.
@@ -292,15 +282,15 @@ class TestChatMessage:
             role="user",
             content=[
                 {"type": "text", "text": "What's in this image?"},
-                {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
-            ]
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}},
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing content type: Expected list, Got {type(message.content)}")
         assert isinstance(message.content, list)
         assert len(message.content) == 2
-    
+
     def test_accepts_tool_calls(self):
         """
         What it does: Verifies that tool_calls is accepted.
@@ -310,18 +300,20 @@ class TestChatMessage:
         message = ChatMessage(
             role="assistant",
             content="I'll call a tool",
-            tool_calls=[{
-                "id": "call_123",
-                "type": "function",
-                "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'}
-            }]
+            tool_calls=[
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'},
+                }
+            ],
         )
-        
+
         print(f"Result: {message}")
         print(f"Comparing tool_calls: Got {message.tool_calls}")
         assert message.tool_calls is not None
         assert len(message.tool_calls) == 1
-    
+
     def test_name_is_optional(self):
         """
         What it does: Verifies that name is optional.
@@ -329,10 +321,10 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage without name...")
         message = ChatMessage(role="user", content="Hello")
-        
+
         print(f"Comparing name: Expected None, Got {message.name}")
         assert message.name is None
-    
+
     def test_accepts_name(self):
         """
         What it does: Verifies that name is accepted.
@@ -340,10 +332,10 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with name...")
         message = ChatMessage(role="user", content="Hello", name="John")
-        
+
         print(f"Comparing name: Expected 'John', Got '{message.name}'")
         assert message.name == "John"
-    
+
     def test_extra_fields_allowed(self):
         """
         What it does: Verifies that extra fields are allowed.
@@ -351,7 +343,7 @@ class TestChatMessage:
         """
         print("Setup: Creating ChatMessage with extra field...")
         message = ChatMessage(role="user", content="Hello", custom_field="value")
-        
+
         print(f"Comparing custom_field: Got '{message.custom_field}'")
         assert message.custom_field == "value"
 
@@ -360,9 +352,10 @@ class TestChatMessage:
 # Tests for ToolFunction
 # ==================================================================================================
 
+
 class TestToolFunction:
     """Tests for ToolFunction Pydantic model."""
-    
+
     def test_valid_tool_function(self):
         """
         What it does: Verifies creation of valid ToolFunction.
@@ -372,36 +365,33 @@ class TestToolFunction:
         func = ToolFunction(
             name="get_weather",
             description="Get weather for a location",
-            parameters={
-                "type": "object",
-                "properties": {"location": {"type": "string"}}
-            }
+            parameters={"type": "object", "properties": {"location": {"type": "string"}}},
         )
-        
+
         print(f"Result: {func}")
         print(f"Comparing name: Expected 'get_weather', Got '{func.name}'")
         assert func.name == "get_weather"
-        
+
         print(f"Comparing description: Got '{func.description}'")
         assert func.description == "Get weather for a location"
-        
+
         print(f"Comparing parameters: Got {func.parameters}")
         assert "properties" in func.parameters
-    
+
     def test_requires_name(self):
         """
         What it does: Verifies that name is required.
         Purpose: Ensure validation fails without name.
         """
         print("Setup: Attempting to create ToolFunction without name...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ToolFunction(description="Test")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "name" in str(exc_info.value)
-    
+
     def test_description_is_optional(self):
         """
         What it does: Verifies that description is optional.
@@ -409,10 +399,10 @@ class TestToolFunction:
         """
         print("Setup: Creating ToolFunction without description...")
         func = ToolFunction(name="test_func")
-        
+
         print(f"Comparing description: Expected None, Got {func.description}")
         assert func.description is None
-    
+
     def test_parameters_is_optional(self):
         """
         What it does: Verifies that parameters is optional.
@@ -420,7 +410,7 @@ class TestToolFunction:
         """
         print("Setup: Creating ToolFunction without parameters...")
         func = ToolFunction(name="no_params_func")
-        
+
         print(f"Comparing parameters: Expected None, Got {func.parameters}")
         assert func.parameters is None
 
@@ -429,9 +419,10 @@ class TestToolFunction:
 # Tests for Tool
 # ==================================================================================================
 
+
 class TestTool:
     """Tests for Tool Pydantic model."""
-    
+
     def test_valid_tool(self):
         """
         What it does: Verifies creation of valid Tool.
@@ -439,21 +430,16 @@ class TestTool:
         """
         print("Setup: Creating Tool with valid data...")
         tool = Tool(
-            type="function",
-            function=ToolFunction(
-                name="get_weather",
-                description="Get weather",
-                parameters={}
-            )
+            type="function", function=ToolFunction(name="get_weather", description="Get weather", parameters={})
         )
-        
+
         print(f"Result: {tool}")
         print(f"Comparing type: Expected 'function', Got '{tool.type}'")
         assert tool.type == "function"
-        
+
         print(f"Comparing function.name: Expected 'get_weather', Got '{tool.function.name}'")
         assert tool.function.name == "get_weather"
-    
+
     def test_type_defaults_to_function(self):
         """
         What it does: Verifies that type defaults to "function".
@@ -461,10 +447,10 @@ class TestTool:
         """
         print("Setup: Creating Tool without explicit type...")
         tool = Tool(function=ToolFunction(name="test"))
-        
+
         print(f"Comparing type: Expected 'function', Got '{tool.type}'")
         assert tool.type == "function"
-    
+
     def test_function_is_optional_for_flat_format(self):
         """
         What it does: Verifies that function is optional (for flat format compatibility).
@@ -475,34 +461,31 @@ class TestTool:
             type="function",
             name="test_tool",
             description="A test tool",
-            input_schema={"type": "object", "properties": {}}
+            input_schema={"type": "object", "properties": {}},
         )
-        
+
         print(f"Result: {tool}")
         print(f"Comparing name: Expected 'test_tool', Got '{tool.name}'")
         assert tool.name == "test_tool"
-        
+
         print(f"Comparing function: Expected None, Got {tool.function}")
         assert tool.function is None
-        
+
         print(f"Comparing description: Expected 'A test tool', Got '{tool.description}'")
         assert tool.description == "A test tool"
-    
+
     def test_standard_format_still_works(self):
         """
         What it does: Verifies that standard OpenAI format still works.
         Purpose: Ensure backward compatibility with standard format.
         """
         print("Setup: Creating Tool with standard OpenAI format (function field)...")
-        tool = Tool(
-            type="function",
-            function=ToolFunction(name="standard_tool", description="Standard")
-        )
-        
+        tool = Tool(type="function", function=ToolFunction(name="standard_tool", description="Standard"))
+
         print(f"Result: {tool}")
         print(f"Comparing function.name: Expected 'standard_tool', Got '{tool.function.name}'")
         assert tool.function.name == "standard_tool"
-        
+
         print(f"Comparing name: Expected None, Got {tool.name}")
         assert tool.name is None
 
@@ -511,100 +494,91 @@ class TestTool:
 # Tests for ChatCompletionRequest
 # ==================================================================================================
 
+
 class TestChatCompletionRequest:
     """Tests for ChatCompletionRequest Pydantic model."""
-    
+
     def test_valid_request(self):
         """
         What it does: Verifies creation of valid ChatCompletionRequest.
         Purpose: Ensure model accepts valid request.
         """
         print("Setup: Creating ChatCompletionRequest with valid data...")
-        request = ChatCompletionRequest(
-            model="claude-sonnet-4-5",
-            messages=[ChatMessage(role="user", content="Hello")]
-        )
-        
+        request = ChatCompletionRequest(model="claude-sonnet-4-5", messages=[ChatMessage(role="user", content="Hello")])
+
         print(f"Result: {request}")
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{request.model}'")
         assert request.model == "claude-sonnet-4-5"
-        
+
         print(f"Comparing messages length: Expected 1, Got {len(request.messages)}")
         assert len(request.messages) == 1
-        
+
         print(f"Comparing stream: Expected False, Got {request.stream}")
         assert request.stream is False
-    
+
     def test_requires_model(self):
         """
         What it does: Verifies that model is required.
         Purpose: Ensure validation fails without model.
         """
         print("Setup: Attempting to create ChatCompletionRequest without model...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionRequest(messages=[ChatMessage(role="user", content="Hi")])
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "model" in str(exc_info.value)
-    
+
     def test_requires_messages(self):
         """
         What it does: Verifies that messages is required.
         Purpose: Ensure validation fails without messages.
         """
         print("Setup: Attempting to create ChatCompletionRequest without messages...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionRequest(model="claude-sonnet-4-5")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "messages" in str(exc_info.value)
-    
+
     def test_requires_at_least_one_message(self):
         """
         What it does: Verifies that at least one message is required.
         Purpose: Ensure validation fails with empty messages.
         """
         print("Setup: Attempting to create ChatCompletionRequest with empty messages...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionRequest(model="claude-sonnet-4-5", messages=[])
-        
+
         print(f"ValidationError raised: {exc_info.value}")
-    
+
     def test_stream_defaults_to_false(self):
         """
         What it does: Verifies that stream defaults to False.
         Purpose: Ensure default value is set correctly.
         """
         print("Setup: Creating ChatCompletionRequest without explicit stream...")
-        request = ChatCompletionRequest(
-            model="test",
-            messages=[ChatMessage(role="user", content="Hi")]
-        )
-        
+        request = ChatCompletionRequest(model="test", messages=[ChatMessage(role="user", content="Hi")])
+
         print(f"Comparing stream: Expected False, Got {request.stream}")
         assert request.stream is False
-    
+
     def test_accepts_stream_true(self):
         """
         What it does: Verifies that stream=True is accepted.
         Purpose: Ensure streaming requests work.
         """
         print("Setup: Creating ChatCompletionRequest with stream=True...")
-        request = ChatCompletionRequest(
-            model="test",
-            messages=[ChatMessage(role="user", content="Hi")],
-            stream=True
-        )
-        
+        request = ChatCompletionRequest(model="test", messages=[ChatMessage(role="user", content="Hi")], stream=True)
+
         print(f"Comparing stream: Expected True, Got {request.stream}")
         assert request.stream is True
-    
+
     def test_accepts_tools(self):
         """
         What it does: Verifies that tools are accepted.
@@ -614,13 +588,13 @@ class TestChatCompletionRequest:
         request = ChatCompletionRequest(
             model="test",
             messages=[ChatMessage(role="user", content="Hi")],
-            tools=[Tool(function=ToolFunction(name="test_tool"))]
+            tools=[Tool(function=ToolFunction(name="test_tool"))],
         )
-        
+
         print(f"Comparing tools: Got {request.tools}")
         assert request.tools is not None
         assert len(request.tools) == 1
-    
+
     def test_accepts_generation_parameters(self):
         """
         What it does: Verifies that generation parameters are accepted.
@@ -628,19 +602,15 @@ class TestChatCompletionRequest:
         """
         print("Setup: Creating ChatCompletionRequest with generation params...")
         request = ChatCompletionRequest(
-            model="test",
-            messages=[ChatMessage(role="user", content="Hi")],
-            temperature=0.7,
-            top_p=0.9,
-            max_tokens=1000
+            model="test", messages=[ChatMessage(role="user", content="Hi")], temperature=0.7, top_p=0.9, max_tokens=1000
         )
-        
+
         print(f"Comparing temperature: Expected 0.7, Got {request.temperature}")
         assert request.temperature == 0.7
-        
+
         print(f"Comparing top_p: Expected 0.9, Got {request.top_p}")
         assert request.top_p == 0.9
-        
+
         print(f"Comparing max_tokens: Expected 1000, Got {request.max_tokens}")
         assert request.max_tokens == 1000
 
@@ -649,31 +619,28 @@ class TestChatCompletionRequest:
 # Tests for ChatCompletionUsage
 # ==================================================================================================
 
+
 class TestChatCompletionUsage:
     """Tests for ChatCompletionUsage Pydantic model."""
-    
+
     def test_valid_usage(self):
         """
         What it does: Verifies creation of valid ChatCompletionUsage.
         Purpose: Ensure model accepts valid usage data.
         """
         print("Setup: Creating ChatCompletionUsage with valid data...")
-        usage = ChatCompletionUsage(
-            prompt_tokens=100,
-            completion_tokens=50,
-            total_tokens=150
-        )
-        
+        usage = ChatCompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+
         print(f"Result: {usage}")
         print(f"Comparing prompt_tokens: Expected 100, Got {usage.prompt_tokens}")
         assert usage.prompt_tokens == 100
-        
+
         print(f"Comparing completion_tokens: Expected 50, Got {usage.completion_tokens}")
         assert usage.completion_tokens == 50
-        
+
         print(f"Comparing total_tokens: Expected 150, Got {usage.total_tokens}")
         assert usage.total_tokens == 150
-    
+
     def test_defaults_to_zero(self):
         """
         What it does: Verifies that all fields default to 0.
@@ -681,16 +648,16 @@ class TestChatCompletionUsage:
         """
         print("Setup: Creating ChatCompletionUsage without explicit values...")
         usage = ChatCompletionUsage()
-        
+
         print(f"Comparing prompt_tokens: Expected 0, Got {usage.prompt_tokens}")
         assert usage.prompt_tokens == 0
-        
+
         print(f"Comparing completion_tokens: Expected 0, Got {usage.completion_tokens}")
         assert usage.completion_tokens == 0
-        
+
         print(f"Comparing total_tokens: Expected 0, Got {usage.total_tokens}")
         assert usage.total_tokens == 0
-    
+
     def test_credits_used_is_optional(self):
         """
         What it does: Verifies that credits_used is optional.
@@ -698,7 +665,7 @@ class TestChatCompletionUsage:
         """
         print("Setup: Creating ChatCompletionUsage without credits_used...")
         usage = ChatCompletionUsage()
-        
+
         print(f"Comparing credits_used: Expected None, Got {usage.credits_used}")
         assert usage.credits_used is None
 
@@ -707,31 +674,28 @@ class TestChatCompletionUsage:
 # Tests for ChatCompletionChoice
 # ==================================================================================================
 
+
 class TestChatCompletionChoice:
     """Tests for ChatCompletionChoice Pydantic model."""
-    
+
     def test_valid_choice(self):
         """
         What it does: Verifies creation of valid ChatCompletionChoice.
         Purpose: Ensure model accepts valid choice data.
         """
         print("Setup: Creating ChatCompletionChoice with valid data...")
-        choice = ChatCompletionChoice(
-            index=0,
-            message={"role": "assistant", "content": "Hello!"},
-            finish_reason="stop"
-        )
-        
+        choice = ChatCompletionChoice(index=0, message={"role": "assistant", "content": "Hello!"}, finish_reason="stop")
+
         print(f"Result: {choice}")
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-        
+
         print(f"Comparing message: Got {choice.message}")
         assert choice.message["role"] == "assistant"
-        
+
         print(f"Comparing finish_reason: Expected 'stop', Got '{choice.finish_reason}'")
         assert choice.finish_reason == "stop"
-    
+
     def test_index_defaults_to_zero(self):
         """
         What it does: Verifies that index defaults to 0.
@@ -739,24 +703,24 @@ class TestChatCompletionChoice:
         """
         print("Setup: Creating ChatCompletionChoice without explicit index...")
         choice = ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
-        
+
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-    
+
     def test_requires_message(self):
         """
         What it does: Verifies that message is required.
         Purpose: Ensure validation fails without message.
         """
         print("Setup: Attempting to create ChatCompletionChoice without message...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionChoice(index=0, finish_reason="stop")
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "message" in str(exc_info.value)
-    
+
     def test_finish_reason_is_optional(self):
         """
         What it does: Verifies that finish_reason is optional.
@@ -764,7 +728,7 @@ class TestChatCompletionChoice:
         """
         print("Setup: Creating ChatCompletionChoice without finish_reason...")
         choice = ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})
-        
+
         print(f"Comparing finish_reason: Expected None, Got {choice.finish_reason}")
         assert choice.finish_reason is None
 
@@ -773,9 +737,10 @@ class TestChatCompletionChoice:
 # Tests for ChatCompletionResponse
 # ==================================================================================================
 
+
 class TestChatCompletionResponse:
     """Tests for ChatCompletionResponse Pydantic model."""
-    
+
     def test_valid_response(self):
         """
         What it does: Verifies creation of valid ChatCompletionResponse.
@@ -785,26 +750,23 @@ class TestChatCompletionResponse:
         response = ChatCompletionResponse(
             id="chatcmpl-123",
             model="claude-sonnet-4-5",
-            choices=[ChatCompletionChoice(
-                message={"role": "assistant", "content": "Hello!"},
-                finish_reason="stop"
-            )],
-            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+            choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hello!"}, finish_reason="stop")],
+            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
         )
-        
+
         print(f"Result: {response}")
         print(f"Comparing id: Expected 'chatcmpl-123', Got '{response.id}'")
         assert response.id == "chatcmpl-123"
-        
+
         print(f"Comparing object: Expected 'chat.completion', Got '{response.object}'")
         assert response.object == "chat.completion"
-        
+
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{response.model}'")
         assert response.model == "claude-sonnet-4-5"
-        
+
         print(f"Comparing choices length: Expected 1, Got {len(response.choices)}")
         assert len(response.choices) == 1
-    
+
     def test_object_defaults_to_chat_completion(self):
         """
         What it does: Verifies that object defaults to "chat.completion".
@@ -815,12 +777,12 @@ class TestChatCompletionResponse:
             id="test",
             model="test",
             choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})],
-            usage=ChatCompletionUsage()
+            usage=ChatCompletionUsage(),
         )
-        
+
         print(f"Comparing object: Expected 'chat.completion', Got '{response.object}'")
         assert response.object == "chat.completion"
-    
+
     def test_created_is_auto_generated(self):
         """
         What it does: Verifies that created timestamp is auto-generated.
@@ -831,28 +793,28 @@ class TestChatCompletionResponse:
             id="test",
             model="test",
             choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})],
-            usage=ChatCompletionUsage()
+            usage=ChatCompletionUsage(),
         )
-        
+
         print(f"Comparing created: Got {response.created}")
         assert response.created > 0
         assert isinstance(response.created, int)
-    
+
     def test_requires_id(self):
         """
         What it does: Verifies that id is required.
         Purpose: Ensure validation fails without id.
         """
         print("Setup: Attempting to create ChatCompletionResponse without id...")
-        
+
         print("Action: Creating model (should raise ValidationError)...")
         with pytest.raises(ValidationError) as exc_info:
             ChatCompletionResponse(
                 model="test",
                 choices=[ChatCompletionChoice(message={"role": "assistant", "content": "Hi"})],
-                usage=ChatCompletionUsage()
+                usage=ChatCompletionUsage(),
             )
-        
+
         print(f"ValidationError raised: {exc_info.value}")
         assert "id" in str(exc_info.value)
 
@@ -861,9 +823,10 @@ class TestChatCompletionResponse:
 # Tests for Streaming Models
 # ==================================================================================================
 
+
 class TestChatCompletionChunkDelta:
     """Tests for ChatCompletionChunkDelta Pydantic model."""
-    
+
     def test_valid_delta_with_content(self):
         """
         What it does: Verifies creation of valid delta with content.
@@ -871,11 +834,11 @@ class TestChatCompletionChunkDelta:
         """
         print("Setup: Creating ChatCompletionChunkDelta with content...")
         delta = ChatCompletionChunkDelta(content="Hello")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing content: Expected 'Hello', Got '{delta.content}'")
         assert delta.content == "Hello"
-    
+
     def test_valid_delta_with_role(self):
         """
         What it does: Verifies creation of valid delta with role.
@@ -883,11 +846,11 @@ class TestChatCompletionChunkDelta:
         """
         print("Setup: Creating ChatCompletionChunkDelta with role...")
         delta = ChatCompletionChunkDelta(role="assistant")
-        
+
         print(f"Result: {delta}")
         print(f"Comparing role: Expected 'assistant', Got '{delta.role}'")
         assert delta.role == "assistant"
-    
+
     def test_all_fields_optional(self):
         """
         What it does: Verifies that all fields are optional.
@@ -895,26 +858,24 @@ class TestChatCompletionChunkDelta:
         """
         print("Setup: Creating empty ChatCompletionChunkDelta...")
         delta = ChatCompletionChunkDelta()
-        
+
         print(f"Comparing role: Expected None, Got {delta.role}")
         assert delta.role is None
-        
+
         print(f"Comparing content: Expected None, Got {delta.content}")
         assert delta.content is None
-        
+
         print(f"Comparing tool_calls: Expected None, Got {delta.tool_calls}")
         assert delta.tool_calls is None
-    
+
     def test_accepts_tool_calls(self):
         """
         What it does: Verifies that tool_calls is accepted.
         Purpose: Ensure streaming tool calls work.
         """
         print("Setup: Creating ChatCompletionChunkDelta with tool_calls...")
-        delta = ChatCompletionChunkDelta(
-            tool_calls=[{"index": 0, "id": "call_1", "function": {"name": "test"}}]
-        )
-        
+        delta = ChatCompletionChunkDelta(tool_calls=[{"index": 0, "id": "call_1", "function": {"name": "test"}}])
+
         print(f"Comparing tool_calls: Got {delta.tool_calls}")
         assert delta.tool_calls is not None
         assert len(delta.tool_calls) == 1
@@ -922,25 +883,22 @@ class TestChatCompletionChunkDelta:
 
 class TestChatCompletionChunkChoice:
     """Tests for ChatCompletionChunkChoice Pydantic model."""
-    
+
     def test_valid_chunk_choice(self):
         """
         What it does: Verifies creation of valid chunk choice.
         Purpose: Ensure model accepts valid chunk choice.
         """
         print("Setup: Creating ChatCompletionChunkChoice with valid data...")
-        choice = ChatCompletionChunkChoice(
-            index=0,
-            delta=ChatCompletionChunkDelta(content="Hello")
-        )
-        
+        choice = ChatCompletionChunkChoice(index=0, delta=ChatCompletionChunkDelta(content="Hello"))
+
         print(f"Result: {choice}")
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-        
+
         print(f"Comparing delta.content: Expected 'Hello', Got '{choice.delta.content}'")
         assert choice.delta.content == "Hello"
-    
+
     def test_index_defaults_to_zero(self):
         """
         What it does: Verifies that index defaults to 0.
@@ -948,10 +906,10 @@ class TestChatCompletionChunkChoice:
         """
         print("Setup: Creating ChatCompletionChunkChoice without explicit index...")
         choice = ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())
-        
+
         print(f"Comparing index: Expected 0, Got {choice.index}")
         assert choice.index == 0
-    
+
     def test_finish_reason_is_optional(self):
         """
         What it does: Verifies that finish_reason is optional.
@@ -959,28 +917,25 @@ class TestChatCompletionChunkChoice:
         """
         print("Setup: Creating ChatCompletionChunkChoice without finish_reason...")
         choice = ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(content="Hi"))
-        
+
         print(f"Comparing finish_reason: Expected None, Got {choice.finish_reason}")
         assert choice.finish_reason is None
-    
+
     def test_accepts_finish_reason(self):
         """
         What it does: Verifies that finish_reason is accepted.
         Purpose: Ensure final chunk works.
         """
         print("Setup: Creating ChatCompletionChunkChoice with finish_reason...")
-        choice = ChatCompletionChunkChoice(
-            delta=ChatCompletionChunkDelta(),
-            finish_reason="stop"
-        )
-        
+        choice = ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(), finish_reason="stop")
+
         print(f"Comparing finish_reason: Expected 'stop', Got '{choice.finish_reason}'")
         assert choice.finish_reason == "stop"
 
 
 class TestChatCompletionChunk:
     """Tests for ChatCompletionChunk Pydantic model."""
-    
+
     def test_valid_chunk(self):
         """
         What it does: Verifies creation of valid chunk.
@@ -990,21 +945,19 @@ class TestChatCompletionChunk:
         chunk = ChatCompletionChunk(
             id="chatcmpl-123",
             model="claude-sonnet-4-5",
-            choices=[ChatCompletionChunkChoice(
-                delta=ChatCompletionChunkDelta(content="Hello")
-            )]
+            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(content="Hello"))],
         )
-        
+
         print(f"Result: {chunk}")
         print(f"Comparing id: Expected 'chatcmpl-123', Got '{chunk.id}'")
         assert chunk.id == "chatcmpl-123"
-        
+
         print(f"Comparing object: Expected 'chat.completion.chunk', Got '{chunk.object}'")
         assert chunk.object == "chat.completion.chunk"
-        
+
         print(f"Comparing model: Expected 'claude-sonnet-4-5', Got '{chunk.model}'")
         assert chunk.model == "claude-sonnet-4-5"
-    
+
     def test_object_defaults_to_chunk(self):
         """
         What it does: Verifies that object defaults to "chat.completion.chunk".
@@ -1012,14 +965,12 @@ class TestChatCompletionChunk:
         """
         print("Setup: Creating ChatCompletionChunk without explicit object...")
         chunk = ChatCompletionChunk(
-            id="test",
-            model="test",
-            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())]
+            id="test", model="test", choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())]
         )
-        
+
         print(f"Comparing object: Expected 'chat.completion.chunk', Got '{chunk.object}'")
         assert chunk.object == "chat.completion.chunk"
-    
+
     def test_usage_is_optional(self):
         """
         What it does: Verifies that usage is optional.
@@ -1027,14 +978,12 @@ class TestChatCompletionChunk:
         """
         print("Setup: Creating ChatCompletionChunk without usage...")
         chunk = ChatCompletionChunk(
-            id="test",
-            model="test",
-            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())]
+            id="test", model="test", choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta())]
         )
-        
+
         print(f"Comparing usage: Expected None, Got {chunk.usage}")
         assert chunk.usage is None
-    
+
     def test_accepts_usage(self):
         """
         What it does: Verifies that usage is accepted.
@@ -1044,13 +993,10 @@ class TestChatCompletionChunk:
         chunk = ChatCompletionChunk(
             id="test",
             model="test",
-            choices=[ChatCompletionChunkChoice(
-                delta=ChatCompletionChunkDelta(),
-                finish_reason="stop"
-            )],
-            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+            choices=[ChatCompletionChunkChoice(delta=ChatCompletionChunkDelta(), finish_reason="stop")],
+            usage=ChatCompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
         )
-        
+
         print(f"Comparing usage: Got {chunk.usage}")
         assert chunk.usage is not None
         assert chunk.usage.total_tokens == 15
@@ -1060,54 +1006,51 @@ class TestChatCompletionChunk:
 # Tests for Client Thinking Budget Support (Issue #111)
 # ==================================================================================================
 
+
 class TestReasoningEffort:
     """Tests for reasoning_effort parameter in ChatCompletionRequest."""
-    
+
     def test_reasoning_effort_valid_values(self):
         """
         What it does: Verifies all 6 reasoning_effort values are accepted
         Purpose: Ensure Pydantic validates all official OpenAI reasoning_effort levels
         """
         print("Testing all valid reasoning_effort values...")
-        
+
         for effort in ["none", "minimal", "low", "medium", "high", "xhigh"]:
             print(f"  Testing reasoning_effort='{effort}'...")
             request = ChatCompletionRequest(
-                model="claude-sonnet-4.5",
-                messages=[ChatMessage(role="user", content="test")],
-                reasoning_effort=effort
+                model="claude-sonnet-4.5", messages=[ChatMessage(role="user", content="test")], reasoning_effort=effort
             )
-            
+
             print(f"  Comparing: expected='{effort}', got='{request.reasoning_effort}'")
             assert request.reasoning_effort == effort
-    
+
     def test_reasoning_effort_optional(self):
         """
         What it does: Verifies reasoning_effort can be None (not specified)
         Purpose: Ensure reasoning_effort is optional parameter
         """
         print("Creating ChatCompletionRequest without reasoning_effort...")
-        request = ChatCompletionRequest(
-            model="claude-sonnet-4.5",
-            messages=[ChatMessage(role="user", content="test")]
-        )
-        
+        request = ChatCompletionRequest(model="claude-sonnet-4.5", messages=[ChatMessage(role="user", content="test")])
+
         print(f"Comparing: expected=None, got={request.reasoning_effort}")
         assert request.reasoning_effort is None
-    
+
     def test_reasoning_effort_invalid_value_rejected(self):
         """
         What it does: Verifies invalid reasoning_effort value is rejected by Pydantic
         Purpose: Ensure type safety for reasoning_effort parameter
         """
         print("Attempting to create ChatCompletionRequest with invalid reasoning_effort...")
-        
+
         from pydantic import ValidationError
+
         try:
-            request = ChatCompletionRequest(
+            ChatCompletionRequest(
                 model="claude-sonnet-4.5",
                 messages=[ChatMessage(role="user", content="test")],
-                reasoning_effort="ultra"  # Invalid value
+                reasoning_effort="ultra",  # Invalid value
             )
             print("ERROR: Should have raised ValidationError!")
             assert False, "Expected ValidationError for invalid reasoning_effort"

--- a/tests/unit/test_native_reasoning.py
+++ b/tests/unit/test_native_reasoning.py
@@ -55,10 +55,7 @@ async def test_native_signature_survives_stream_translation():
                 }
             ]
 
-    events = [
-        event
-        async for event in _process_chunk(SignatureParser(), b"signature-frame")
-    ]
+    events = [event async for event in _process_chunk(SignatureParser(), b"signature-frame")]
 
     assert len(events) == 1
     assert events[0].type == "thinking_signature"

--- a/tests/unit/test_network_errors.py
+++ b/tests/unit/test_network_errors.py
@@ -6,7 +6,6 @@ Tests classify_network_error(), format_error_for_user(), and get_short_error_mes
 """
 
 import socket
-import pytest
 
 import httpx
 
@@ -15,13 +14,13 @@ from kiro.network_errors import (
     NetworkErrorInfo,
     classify_network_error,
     format_error_for_user,
-    get_short_error_message
+    get_short_error_message,
 )
 
 
 class TestClassifyNetworkErrorDNS:
     """Tests for DNS resolution error classification."""
-    
+
     def test_dns_error_with_socket_gaierror_windows(self):
         """
         What it does: Verifies DNS errors are classified correctly on Windows.
@@ -31,10 +30,10 @@ class TestClassifyNetworkErrorDNS:
         dns_error = socket.gaierror(11001, "getaddrinfo failed")
         connect_error = httpx.ConnectError("All connection attempts failed")
         connect_error.__cause__ = dns_error
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is DNS_RESOLUTION...")
         print(f"Comparing category: Expected {ErrorCategory.DNS_RESOLUTION}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.DNS_RESOLUTION
@@ -43,7 +42,7 @@ class TestClassifyNetworkErrorDNS:
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 502
         assert "11001" in error_info.technical_details
-    
+
     def test_dns_error_with_socket_gaierror_unix(self):
         """
         What it does: Verifies DNS errors are classified correctly on Unix.
@@ -53,15 +52,15 @@ class TestClassifyNetworkErrorDNS:
         dns_error = socket.gaierror(-2, "Name or service not known")
         connect_error = httpx.ConnectError("Connection failed")
         connect_error.__cause__ = dns_error
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is DNS_RESOLUTION...")
         assert error_info.category == ErrorCategory.DNS_RESOLUTION
         assert "DNS" in error_info.user_message
         assert "-2" in error_info.technical_details
-    
+
     def test_dns_error_includes_troubleshooting_steps(self):
         """
         What it does: Verifies DNS errors include actionable troubleshooting steps.
@@ -71,10 +70,10 @@ class TestClassifyNetworkErrorDNS:
         dns_error = socket.gaierror(11001, "getaddrinfo failed")
         connect_error = httpx.ConnectError("Connection failed")
         connect_error.__cause__ = dns_error
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Troubleshooting steps present...")
         steps = error_info.troubleshooting_steps
         assert len(steps) >= 3
@@ -82,7 +81,7 @@ class TestClassifyNetworkErrorDNS:
         assert any("8.8.8.8" in step or "1.1.1.1" in step for step in steps)
         assert any("VPN" in step for step in steps)
         assert any("firewall" in step.lower() or "antivirus" in step.lower() for step in steps)
-    
+
     def test_dns_error_technical_details_include_errno(self):
         """
         What it does: Verifies technical details include errno for debugging.
@@ -92,10 +91,10 @@ class TestClassifyNetworkErrorDNS:
         dns_error = socket.gaierror(11001, "getaddrinfo failed")
         connect_error = httpx.ConnectError("Failed")
         connect_error.__cause__ = dns_error
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Technical details include errno...")
         assert "errno" in error_info.technical_details.lower()
         assert "11001" in error_info.technical_details
@@ -103,7 +102,7 @@ class TestClassifyNetworkErrorDNS:
 
 class TestClassifyNetworkErrorConnection:
     """Tests for connection error classification."""
-    
+
     def test_connection_refused_error(self):
         """
         What it does: Verifies connection refused errors are classified correctly.
@@ -111,10 +110,10 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with 'Connection refused'...")
         connect_error = httpx.ConnectError("Connection refused")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is CONNECTION_REFUSED...")
         print(f"Comparing category: Expected {ErrorCategory.CONNECTION_REFUSED}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.CONNECTION_REFUSED
@@ -122,7 +121,7 @@ class TestClassifyNetworkErrorConnection:
         assert "not accepting connections" in error_info.user_message
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 502
-    
+
     def test_connection_refused_with_econnrefused(self):
         """
         What it does: Verifies ECONNREFUSED is detected as CONNECTION_REFUSED.
@@ -130,13 +129,13 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with ECONNREFUSED...")
         connect_error = httpx.ConnectError("[Errno 111] ECONNREFUSED")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is CONNECTION_REFUSED...")
         assert error_info.category == ErrorCategory.CONNECTION_REFUSED
-    
+
     def test_connection_reset_error(self):
         """
         What it does: Verifies connection reset errors are classified correctly.
@@ -144,17 +143,17 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with 'Connection reset'...")
         connect_error = httpx.ConnectError("Connection reset by peer")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is CONNECTION_RESET...")
         print(f"Comparing category: Expected {ErrorCategory.CONNECTION_RESET}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.CONNECTION_RESET
         assert "Connection reset" in error_info.user_message
         assert "closed the connection" in error_info.user_message
         assert error_info.is_retryable is True
-    
+
     def test_connection_reset_with_econnreset(self):
         """
         What it does: Verifies ECONNRESET is detected as CONNECTION_RESET.
@@ -162,13 +161,13 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with ECONNRESET...")
         connect_error = httpx.ConnectError("[Errno 104] ECONNRESET")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is CONNECTION_RESET...")
         assert error_info.category == ErrorCategory.CONNECTION_RESET
-    
+
     def test_network_unreachable_error(self):
         """
         What it does: Verifies network unreachable errors are classified correctly.
@@ -176,16 +175,16 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with 'Network is unreachable'...")
         connect_error = httpx.ConnectError("Network is unreachable")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is NETWORK_UNREACHABLE...")
         print(f"Comparing category: Expected {ErrorCategory.NETWORK_UNREACHABLE}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.NETWORK_UNREACHABLE
         assert "Network unreachable" in error_info.user_message
         assert error_info.is_retryable is True
-    
+
     def test_network_unreachable_with_no_route_to_host(self):
         """
         What it does: Verifies "No route to host" is detected as NETWORK_UNREACHABLE.
@@ -193,13 +192,13 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with 'No route to host'...")
         connect_error = httpx.ConnectError("No route to host")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is NETWORK_UNREACHABLE...")
         assert error_info.category == ErrorCategory.NETWORK_UNREACHABLE
-    
+
     def test_network_unreachable_with_enetunreach(self):
         """
         What it does: Verifies ENETUNREACH is detected as NETWORK_UNREACHABLE.
@@ -207,13 +206,13 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating ConnectError with ENETUNREACH...")
         connect_error = httpx.ConnectError("[Errno 101] ENETUNREACH")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is NETWORK_UNREACHABLE...")
         assert error_info.category == ErrorCategory.NETWORK_UNREACHABLE
-    
+
     def test_generic_connect_error_classified_as_unknown(self):
         """
         What it does: Verifies generic connection errors fall back to UNKNOWN.
@@ -221,10 +220,10 @@ class TestClassifyNetworkErrorConnection:
         """
         print("Setup: Creating generic ConnectError...")
         connect_error = httpx.ConnectError("All connection attempts failed")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is UNKNOWN...")
         print(f"Comparing category: Expected {ErrorCategory.UNKNOWN}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.UNKNOWN
@@ -235,7 +234,7 @@ class TestClassifyNetworkErrorConnection:
 
 class TestClassifyNetworkErrorTimeout:
     """Tests for timeout error classification."""
-    
+
     def test_connect_timeout_error(self):
         """
         What it does: Verifies ConnectTimeout is classified correctly.
@@ -243,10 +242,10 @@ class TestClassifyNetworkErrorTimeout:
         """
         print("Setup: Creating ConnectTimeout...")
         timeout_error = httpx.ConnectTimeout("Connection timeout")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(timeout_error)
-        
+
         print("Verification: Category is TIMEOUT_CONNECT...")
         print(f"Comparing category: Expected {ErrorCategory.TIMEOUT_CONNECT}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.TIMEOUT_CONNECT
@@ -254,7 +253,7 @@ class TestClassifyNetworkErrorTimeout:
         assert "did not respond" in error_info.user_message
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 504
-    
+
     def test_connect_timeout_includes_troubleshooting(self):
         """
         What it does: Verifies connect timeout includes troubleshooting steps.
@@ -262,16 +261,16 @@ class TestClassifyNetworkErrorTimeout:
         """
         print("Setup: Creating ConnectTimeout...")
         timeout_error = httpx.ConnectTimeout("Timeout")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(timeout_error)
-        
+
         print("Verification: Troubleshooting steps present...")
         steps = error_info.troubleshooting_steps
         assert len(steps) >= 2
         assert any("internet connection" in step.lower() for step in steps)
         assert any("server" in step.lower() or "overloaded" in step.lower() for step in steps)
-    
+
     def test_read_timeout_error(self):
         """
         What it does: Verifies ReadTimeout is classified correctly.
@@ -279,10 +278,10 @@ class TestClassifyNetworkErrorTimeout:
         """
         print("Setup: Creating ReadTimeout...")
         timeout_error = httpx.ReadTimeout("Read timeout")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(timeout_error)
-        
+
         print("Verification: Category is TIMEOUT_READ...")
         print(f"Comparing category: Expected {ErrorCategory.TIMEOUT_READ}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.TIMEOUT_READ
@@ -290,7 +289,7 @@ class TestClassifyNetworkErrorTimeout:
         assert "stopped responding" in error_info.user_message
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 504
-    
+
     def test_read_timeout_includes_troubleshooting(self):
         """
         What it does: Verifies read timeout includes troubleshooting steps.
@@ -298,15 +297,15 @@ class TestClassifyNetworkErrorTimeout:
         """
         print("Setup: Creating ReadTimeout...")
         timeout_error = httpx.ReadTimeout("Timeout")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(timeout_error)
-        
+
         print("Verification: Troubleshooting steps present...")
         steps = error_info.troubleshooting_steps
         assert len(steps) >= 2
         assert any("server" in step.lower() or "processing" in step.lower() for step in steps)
-    
+
     def test_generic_timeout_error(self):
         """
         What it does: Verifies generic TimeoutException is classified as TIMEOUT_READ.
@@ -314,10 +313,10 @@ class TestClassifyNetworkErrorTimeout:
         """
         print("Setup: Creating generic TimeoutException...")
         timeout_error = httpx.TimeoutException("Timeout")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(timeout_error)
-        
+
         print("Verification: Category is TIMEOUT_READ...")
         print(f"Comparing category: Expected {ErrorCategory.TIMEOUT_READ}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.TIMEOUT_READ
@@ -327,7 +326,7 @@ class TestClassifyNetworkErrorTimeout:
 
 class TestClassifyNetworkErrorSSL:
     """Tests for SSL/TLS error classification."""
-    
+
     def test_ssl_error_detection(self):
         """
         What it does: Verifies SSL errors are classified correctly.
@@ -335,10 +334,10 @@ class TestClassifyNetworkErrorSSL:
         """
         print("Setup: Creating ConnectError with SSL in message...")
         connect_error = httpx.ConnectError("SSL handshake failed")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is SSL_ERROR...")
         print(f"Comparing category: Expected {ErrorCategory.SSL_ERROR}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.SSL_ERROR
@@ -346,7 +345,7 @@ class TestClassifyNetworkErrorSSL:
         assert "secure connection" in error_info.user_message
         assert error_info.is_retryable is False
         assert error_info.suggested_http_code == 502
-    
+
     def test_tls_error_detection(self):
         """
         What it does: Verifies TLS errors are detected as SSL_ERROR.
@@ -354,13 +353,13 @@ class TestClassifyNetworkErrorSSL:
         """
         print("Setup: Creating ConnectError with TLS in message...")
         connect_error = httpx.ConnectError("TLS connection failed")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is SSL_ERROR...")
         assert error_info.category == ErrorCategory.SSL_ERROR
-    
+
     def test_certificate_error_detection(self):
         """
         What it does: Verifies certificate errors are detected as SSL_ERROR.
@@ -368,13 +367,13 @@ class TestClassifyNetworkErrorSSL:
         """
         print("Setup: Creating ConnectError with certificate in message...")
         connect_error = httpx.ConnectError("Certificate verification failed")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Category is SSL_ERROR...")
         assert error_info.category == ErrorCategory.SSL_ERROR
-    
+
     def test_ssl_error_includes_troubleshooting(self):
         """
         What it does: Verifies SSL errors include troubleshooting steps.
@@ -382,10 +381,10 @@ class TestClassifyNetworkErrorSSL:
         """
         print("Setup: Creating SSL error...")
         connect_error = httpx.ConnectError("SSL error")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(connect_error)
-        
+
         print("Verification: Troubleshooting steps present...")
         steps = error_info.troubleshooting_steps
         assert len(steps) >= 2
@@ -395,7 +394,7 @@ class TestClassifyNetworkErrorSSL:
 
 class TestClassifyNetworkErrorProxy:
     """Tests for proxy error classification."""
-    
+
     def test_proxy_error_detection(self):
         """
         What it does: Verifies proxy errors are classified correctly.
@@ -403,10 +402,10 @@ class TestClassifyNetworkErrorProxy:
         """
         print("Setup: Creating ProxyError...")
         proxy_error = httpx.ProxyError("Proxy connection failed")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(proxy_error)
-        
+
         print("Verification: Category is PROXY_ERROR...")
         print(f"Comparing category: Expected {ErrorCategory.PROXY_ERROR}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.PROXY_ERROR
@@ -414,7 +413,7 @@ class TestClassifyNetworkErrorProxy:
         assert "cannot connect through" in error_info.user_message
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 502
-    
+
     def test_proxy_error_includes_troubleshooting(self):
         """
         What it does: Verifies proxy errors include troubleshooting steps.
@@ -422,10 +421,10 @@ class TestClassifyNetworkErrorProxy:
         """
         print("Setup: Creating ProxyError...")
         proxy_error = httpx.ProxyError("Proxy failed")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(proxy_error)
-        
+
         print("Verification: Troubleshooting steps present...")
         steps = error_info.troubleshooting_steps
         assert len(steps) >= 2
@@ -435,7 +434,7 @@ class TestClassifyNetworkErrorProxy:
 
 class TestClassifyNetworkErrorRedirects:
     """Tests for redirect error classification."""
-    
+
     def test_too_many_redirects_error(self):
         """
         What it does: Verifies TooManyRedirects is classified correctly.
@@ -443,10 +442,10 @@ class TestClassifyNetworkErrorRedirects:
         """
         print("Setup: Creating TooManyRedirects...")
         redirect_error = httpx.TooManyRedirects("Too many redirects")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(redirect_error)
-        
+
         print("Verification: Category is TOO_MANY_REDIRECTS...")
         print(f"Comparing category: Expected {ErrorCategory.TOO_MANY_REDIRECTS}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.TOO_MANY_REDIRECTS
@@ -458,7 +457,7 @@ class TestClassifyNetworkErrorRedirects:
 
 class TestClassifyNetworkErrorGeneric:
     """Tests for generic error classification."""
-    
+
     def test_generic_request_error_classified_as_unknown(self):
         """
         What it does: Verifies generic RequestError falls back to UNKNOWN.
@@ -466,17 +465,17 @@ class TestClassifyNetworkErrorGeneric:
         """
         print("Setup: Creating generic RequestError...")
         request_error = httpx.RequestError("Unknown network error")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(request_error)
-        
+
         print("Verification: Category is UNKNOWN...")
         print(f"Comparing category: Expected {ErrorCategory.UNKNOWN}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.UNKNOWN
         assert "unexpected error" in error_info.user_message.lower()
         assert error_info.is_retryable is True
         assert error_info.suggested_http_code == 502
-    
+
     def test_non_httpx_error_classified_as_unknown(self):
         """
         What it does: Verifies non-httpx errors fall back to UNKNOWN.
@@ -484,10 +483,10 @@ class TestClassifyNetworkErrorGeneric:
         """
         print("Setup: Creating generic Exception...")
         generic_error = Exception("Something went wrong")
-        
+
         print("Action: Classifying error...")
         error_info = classify_network_error(generic_error)
-        
+
         print("Verification: Category is UNKNOWN...")
         print(f"Comparing category: Expected {ErrorCategory.UNKNOWN}, Got {error_info.category}")
         assert error_info.category == ErrorCategory.UNKNOWN
@@ -496,7 +495,7 @@ class TestClassifyNetworkErrorGeneric:
 
 class TestFormatErrorForUser:
     """Tests for format_error_for_user() function."""
-    
+
     def test_format_openai_includes_troubleshooting(self):
         """
         What it does: Verifies OpenAI format includes troubleshooting steps.
@@ -509,12 +508,12 @@ class TestFormatErrorForUser:
             troubleshooting_steps=["Step 1", "Step 2"],
             technical_details="Technical info",
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-        
+
         print("Action: Formatting for OpenAI...")
         formatted = format_error_for_user(error_info, format_type="openai", include_troubleshooting=True)
-        
+
         print("Verification: OpenAI format structure...")
         assert "error" in formatted
         assert "message" in formatted["error"]
@@ -524,7 +523,7 @@ class TestFormatErrorForUser:
         assert formatted["error"]["code"] == "dns_resolution"
         assert "Step 1" in formatted["error"]["message"]
         assert "Step 2" in formatted["error"]["message"]
-    
+
     def test_format_openai_without_troubleshooting(self):
         """
         What it does: Verifies OpenAI format can exclude troubleshooting.
@@ -537,16 +536,16 @@ class TestFormatErrorForUser:
             troubleshooting_steps=["Step 1"],
             technical_details="Technical info",
             is_retryable=True,
-            suggested_http_code=504
+            suggested_http_code=504,
         )
-        
+
         print("Action: Formatting for OpenAI without troubleshooting...")
         formatted = format_error_for_user(error_info, format_type="openai", include_troubleshooting=False)
-        
+
         print("Verification: No troubleshooting steps in message...")
         assert "Step 1" not in formatted["error"]["message"]
         assert formatted["error"]["message"] == "Connection timeout"
-    
+
     def test_format_anthropic_structure(self):
         """
         What it does: Verifies Anthropic format structure.
@@ -559,12 +558,12 @@ class TestFormatErrorForUser:
             troubleshooting_steps=["Step 1"],
             technical_details="Technical info",
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-        
+
         print("Action: Formatting for Anthropic...")
         formatted = format_error_for_user(error_info, format_type="anthropic")
-        
+
         print("Verification: Anthropic format structure...")
         assert "type" in formatted
         assert formatted["type"] == "error"
@@ -572,7 +571,7 @@ class TestFormatErrorForUser:
         assert "type" in formatted["error"]
         assert "message" in formatted["error"]
         assert formatted["error"]["type"] == "connectivity_error"
-    
+
     def test_format_generic_includes_technical_details(self):
         """
         What it does: Verifies generic format includes technical details.
@@ -585,12 +584,12 @@ class TestFormatErrorForUser:
             troubleshooting_steps=[],
             technical_details="ConnectError: SSL handshake failed",
             is_retryable=False,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-        
+
         print("Action: Formatting with generic format...")
         formatted = format_error_for_user(error_info, format_type="generic")
-        
+
         print("Verification: Technical details present...")
         assert "technical_details" in formatted["error"]
         assert formatted["error"]["technical_details"] == "ConnectError: SSL handshake failed"
@@ -598,7 +597,7 @@ class TestFormatErrorForUser:
 
 class TestGetShortErrorMessage:
     """Tests for get_short_error_message() function."""
-    
+
     def test_short_message_no_brackets(self):
         """
         What it does: Verifies short message doesn't include brackets.
@@ -611,18 +610,18 @@ class TestGetShortErrorMessage:
             troubleshooting_steps=[],
             technical_details="Technical info",
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-        
+
         print("Action: Getting short message...")
         short_msg = get_short_error_message(error_info)
-        
+
         print("Verification: No brackets in message...")
         print(f"Short message: {short_msg}")
         assert short_msg == "DNS resolution failed"
         assert "[" not in short_msg
         assert "]" not in short_msg
-    
+
     def test_short_message_different_categories(self):
         """
         What it does: Verifies short messages for different error categories.
@@ -634,11 +633,11 @@ class TestGetShortErrorMessage:
             NetworkErrorInfo(ErrorCategory.CONNECTION_REFUSED, "Refused", [], "Tech", True, 502),
             NetworkErrorInfo(ErrorCategory.UNKNOWN, "Unknown", [], "Tech", True, 502),
         ]
-        
+
         print("Action: Getting short messages...")
         for error_info in errors:
             short_msg = get_short_error_message(error_info)
-            
+
             print(f"Verification: {error_info.category} -> {short_msg}")
             assert short_msg == error_info.user_message
             assert "[" not in short_msg
@@ -646,7 +645,7 @@ class TestGetShortErrorMessage:
 
 class TestNetworkErrorInfoDataclass:
     """Tests for NetworkErrorInfo dataclass."""
-    
+
     def test_network_error_info_creation(self):
         """
         What it does: Verifies NetworkErrorInfo can be created with all fields.
@@ -659,9 +658,9 @@ class TestNetworkErrorInfoDataclass:
             troubleshooting_steps=["Step 1", "Step 2"],
             technical_details="Technical details",
             is_retryable=True,
-            suggested_http_code=502
+            suggested_http_code=502,
         )
-        
+
         print("Verification: All fields accessible...")
         assert error_info.category == ErrorCategory.DNS_RESOLUTION
         assert error_info.user_message == "Test message"

--- a/tests/unit/test_no_injected_conversation_text.py
+++ b/tests/unit/test_no_injected_conversation_text.py
@@ -36,9 +36,7 @@ def _openai(messages, **kwargs):
 
 
 def _anthropic(messages, **kwargs):
-    request = AnthropicMessagesRequest(
-        model="claude-sonnet-4.6", max_tokens=256, messages=messages, **kwargs
-    )
+    request = AnthropicMessagesRequest(model="claude-sonnet-4.6", max_tokens=256, messages=messages, **kwargs)
     return json.dumps(anthropic_to_kiro(request, "test", "profile"))
 
 

--- a/tests/unit/test_no_synthetic_prompt_text.py
+++ b/tests/unit/test_no_synthetic_prompt_text.py
@@ -50,8 +50,10 @@ def test_payload_contains_no_synthetic_instructions(messages):
 def test_assistant_prefill_sends_empty_current_turn():
     """An assistant-last request means "continue", not a new user message."""
     payload = _payload(
-        [{"role": "user", "content": "Name the first six primes."},
-         {"role": "assistant", "content": "The first six primes are 2, 3, 5,"}]
+        [
+            {"role": "user", "content": "Name the first six primes."},
+            {"role": "assistant", "content": "The first six primes are 2, 3, 5,"},
+        ]
     )
 
     state = payload["conversationState"]

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -6,19 +6,13 @@ Tests the parsing logic for AWS SSE stream from Kiro API.
 """
 
 import json
-import pytest
 
-from kiro.parsers import (
-    AwsEventStreamParser,
-    find_matching_brace,
-    parse_bracket_tool_calls,
-    deduplicate_tool_calls
-)
+from kiro.parsers import AwsEventStreamParser, deduplicate_tool_calls, find_matching_brace, parse_bracket_tool_calls
 
 
 class TestFindMatchingBrace:
     """Tests for find_matching_brace function."""
-    
+
     def test_simple_json_object(self):
         """
         What it does: Tests finding closing brace for simple JSON.
@@ -26,13 +20,13 @@ class TestFindMatchingBrace:
         """
         print("Setup: Simple JSON object...")
         text = '{"key": "value"}'
-        
+
         print("Action: Finding closing brace...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Comparing result: Expected 15, Got {result}")
         assert result == 15
-    
+
     def test_nested_json_object(self):
         """
         What it does: Tests finding brace for nested JSON.
@@ -40,14 +34,14 @@ class TestFindMatchingBrace:
         """
         print("Setup: Nested JSON object...")
         text = '{"outer": {"inner": "value"}}'
-        
+
         print("Action: Finding closing brace...")
         result = find_matching_brace(text, 0)
-        
+
         # String length 29, last character index 28
         print(f"Comparing result: Expected 28, Got {result}")
         assert result == 28
-    
+
     def test_json_with_braces_in_string(self):
         """
         What it does: Tests ignoring braces inside strings.
@@ -55,13 +49,13 @@ class TestFindMatchingBrace:
         """
         print("Setup: JSON with braces in string...")
         text = '{"text": "Hello {world}"}'
-        
+
         print("Action: Finding closing brace...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Comparing result: Expected 24, Got {result}")
         assert result == 24
-    
+
     def test_json_with_escaped_quotes(self):
         """
         What it does: Tests handling of escaped quotes.
@@ -69,14 +63,14 @@ class TestFindMatchingBrace:
         """
         print("Setup: JSON with escaped quotes...")
         text = '{"text": "Say \\"hello\\""}'
-        
+
         print("Action: Finding closing brace...")
         result = find_matching_brace(text, 0)
-        
+
         # String length 25, last character index 24
         print(f"Comparing result: Expected 24, Got {result}")
         assert result == 24
-    
+
     def test_incomplete_json(self):
         """
         What it does: Tests handling of incomplete JSON.
@@ -84,13 +78,13 @@ class TestFindMatchingBrace:
         """
         print("Setup: Incomplete JSON...")
         text = '{"key": "value"'
-        
+
         print("Action: Finding closing brace...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Comparing result: Expected -1, Got {result}")
         assert result == -1
-    
+
     def test_invalid_start_position(self):
         """
         What it does: Tests handling of invalid start position.
@@ -98,13 +92,13 @@ class TestFindMatchingBrace:
         """
         print("Setup: Text without brace at start_pos...")
         text = 'hello {"key": "value"}'
-        
+
         print("Action: Finding from position 0 (not a brace)...")
         result = find_matching_brace(text, 0)
-        
+
         print(f"Comparing result: Expected -1, Got {result}")
         assert result == -1
-    
+
     def test_start_position_out_of_bounds(self):
         """
         What it does: Tests handling of position beyond text bounds.
@@ -112,17 +106,17 @@ class TestFindMatchingBrace:
         """
         print("Setup: Short text...")
         text = '{"a":1}'
-        
+
         print("Action: Finding from position 100...")
         result = find_matching_brace(text, 100)
-        
+
         print(f"Comparing result: Expected -1, Got {result}")
         assert result == -1
 
 
 class TestParseBracketToolCalls:
     """Tests for parse_bracket_tool_calls function."""
-    
+
     def test_parses_single_tool_call(self):
         """
         What it does: Tests parsing of a single tool call.
@@ -130,35 +124,35 @@ class TestParseBracketToolCalls:
         """
         print("Setup: Text with one tool call...")
         text = '[Called get_weather with args: {"location": "Moscow"}]'
-        
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["function"]["name"] == "get_weather"
         assert '"location"' in result[0]["function"]["arguments"]
-    
+
     def test_parses_multiple_tool_calls(self):
         """
         What it does: Tests parsing of multiple tool calls.
         Goal: Ensure all tool calls are extracted.
         """
         print("Setup: Text with multiple tool calls...")
-        text = '''
+        text = """
         [Called get_weather with args: {"location": "Moscow"}]
         Some text in between
         [Called get_time with args: {"timezone": "UTC"}]
-        '''
-        
+        """
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Result: {result}")
         assert len(result) == 2
         assert result[0]["function"]["name"] == "get_weather"
         assert result[1]["function"]["name"] == "get_time"
-    
+
     def test_returns_empty_for_no_tool_calls(self):
         """
         What it does: Tests returning empty list without tool calls.
@@ -166,39 +160,39 @@ class TestParseBracketToolCalls:
         """
         print("Setup: Regular text without tool calls...")
         text = "This is just regular text without any tool calls."
-        
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_empty_string(self):
         """
         What it does: Tests handling of empty string.
         Goal: Ensure empty string doesn't cause errors.
         """
         print("Setup: Empty string...")
-        
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls("")
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_returns_empty_for_none(self):
         """
         What it does: Tests handling of None.
         Goal: Ensure None doesn't cause errors.
         """
         print("Setup: None...")
-        
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls(None)
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_handles_nested_json_in_args(self):
         """
         What it does: Tests parsing of nested JSON in arguments.
@@ -206,29 +200,29 @@ class TestParseBracketToolCalls:
         """
         print("Setup: Tool call with nested JSON...")
         text = '[Called complex_func with args: {"data": {"nested": {"deep": "value"}}}]'
-        
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["function"]["name"] == "complex_func"
         assert "nested" in result[0]["function"]["arguments"]
-    
+
     def test_generates_unique_ids(self):
         """
         What it does: Tests generation of unique IDs for tool calls.
         Goal: Ensure each tool call has a unique ID.
         """
         print("Setup: Two identical tool calls...")
-        text = '''
+        text = """
         [Called func with args: {"a": 1}]
         [Called func with args: {"a": 1}]
-        '''
-        
+        """
+
         print("Action: Parsing tool calls...")
         result = parse_bracket_tool_calls(text)
-        
+
         print(f"IDs: {[r['id'] for r in result]}")
         assert len(result) == 2
         assert result[0]["id"] != result[1]["id"]
@@ -236,7 +230,7 @@ class TestParseBracketToolCalls:
 
 class TestDeduplicateToolCalls:
     """Tests for deduplicate_tool_calls function."""
-    
+
     def test_removes_duplicates(self):
         """
         What it does: Tests removal of duplicates.
@@ -248,13 +242,13 @@ class TestDeduplicateToolCalls:
             {"id": "1", "function": {"name": "func", "arguments": '{"a": 1}'}},
             {"id": "3", "function": {"name": "other", "arguments": '{"b": 2}'}},
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Comparing length: Expected 2, Got {len(result)}")
         assert len(result) == 2
-    
+
     def test_preserves_first_occurrence(self):
         """
         What it does: Tests preservation of first occurrence.
@@ -265,26 +259,26 @@ class TestDeduplicateToolCalls:
             {"id": "first", "function": {"name": "func", "arguments": '{"a": 1}'}},
             {"id": "second", "function": {"name": "func", "arguments": '{"a": 1}'}},
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Comparing ID: Expected 'first', Got '{result[0]['id']}'")
         assert result[0]["id"] == "first"
-    
+
     def test_handles_empty_list(self):
         """
         What it does: Tests handling of empty list.
         Goal: Ensure empty list doesn't cause errors.
         """
         print("Setup: Empty list...")
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls([])
-        
+
         print(f"Comparing result: Expected [], Got {result}")
         assert result == []
-    
+
     def test_deduplicates_by_id_keeps_one_with_arguments(self):
         """
         What it does: Tests deduplication by id keeping tool call with arguments.
@@ -295,17 +289,17 @@ class TestDeduplicateToolCalls:
             {"id": "call_123", "function": {"name": "func", "arguments": "{}"}},
             {"id": "call_123", "function": {"name": "func", "arguments": '{"location": "Moscow"}'}},
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Result: {result}")
         print(f"Comparing length: Expected 1, Got {len(result)}")
         assert len(result) == 1
-        
+
         print("Verifying that tool call with arguments was kept...")
         assert "Moscow" in result[0]["function"]["arguments"]
-    
+
     def test_deduplicates_by_id_prefers_longer_arguments(self):
         """
         What it does: Tests that duplicates by id prefer longer arguments.
@@ -316,16 +310,16 @@ class TestDeduplicateToolCalls:
             {"id": "call_abc", "function": {"name": "search", "arguments": '{"q": "test"}'}},
             {"id": "call_abc", "function": {"name": "search", "arguments": '{"q": "test", "limit": 10, "offset": 0}'}},
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
-        
+
         print("Verifying that tool call with longer arguments was kept...")
         assert "limit" in result[0]["function"]["arguments"]
-    
+
     def test_deduplicates_empty_arguments_replaced_by_non_empty(self):
         """
         What it does: Tests replacement of empty arguments with non-empty.
@@ -336,14 +330,14 @@ class TestDeduplicateToolCalls:
             {"id": "call_xyz", "function": {"name": "get_weather", "arguments": "{}"}},
             {"id": "call_xyz", "function": {"name": "get_weather", "arguments": '{"city": "London"}'}},
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Result: {result}")
         assert len(result) == 1
         assert result[0]["function"]["arguments"] == '{"city": "London"}'
-    
+
     def test_handles_tool_calls_without_id(self):
         """
         What it does: Tests handling of tool calls without id.
@@ -355,14 +349,14 @@ class TestDeduplicateToolCalls:
             {"id": "", "function": {"name": "func", "arguments": '{"a": 1}'}},
             {"id": "", "function": {"name": "func", "arguments": '{"b": 2}'}},
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Result: {result}")
         # Two unique by name+arguments
         assert len(result) == 2
-    
+
     def test_mixed_with_and_without_id(self):
         """
         What it does: Tests mixed list with and without id.
@@ -375,14 +369,14 @@ class TestDeduplicateToolCalls:
             {"id": "", "function": {"name": "func2", "arguments": '{"y": 2}'}},
             {"id": "", "function": {"name": "func2", "arguments": '{"y": 2}'}},  # Duplicate by name+args
         ]
-        
+
         print("Action: Deduplication...")
         result = deduplicate_tool_calls(tool_calls)
-        
+
         print(f"Result: {result}")
         # call_1 with arguments + func2 once
         assert len(result) == 2
-        
+
         # Verify that call_1 kept its arguments
         call_1 = next(tc for tc in result if tc["id"] == "call_1")
         assert call_1["function"]["arguments"] == '{"x": 1}'
@@ -390,7 +384,7 @@ class TestDeduplicateToolCalls:
 
 class TestAwsEventStreamParserInitialization:
     """Tests for AwsEventStreamParser initialization."""
-    
+
     def test_initialization_creates_empty_state(self):
         """
         What it does: Tests initial parser state.
@@ -398,21 +392,20 @@ class TestAwsEventStreamParserInitialization:
         """
         print("Setup: Creating parser...")
         parser = AwsEventStreamParser()
-        
+
         print("Check: Buffer is empty...")
         assert parser.buffer == ""
-        
-        
+
         print("Check: current_tool_call is None...")
         assert parser.current_tool_call is None
-        
+
         print("Check: tool_calls is empty...")
         assert parser.tool_calls == []
 
 
 class TestAwsEventStreamParserFeed:
     """Tests for parser feed method."""
-    
+
     def test_parses_content_event(self, aws_event_parser):
         """
         What it does: Tests parsing of content event.
@@ -420,15 +413,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: Chunk with content...")
         chunk = b'{"content":"Hello World"}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 1
         assert events[0]["type"] == "content"
         assert events[0]["data"] == "Hello World"
-    
+
     def test_parses_multiple_content_events(self, aws_event_parser):
         """
         What it does: Tests parsing of multiple content events.
@@ -436,15 +429,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: Chunk with multiple events...")
         chunk = b'{"content":"First"}{"content":"Second"}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 2
         assert events[0]["data"] == "First"
         assert events[1]["data"] == "Second"
-    
+
     def test_forwards_repeated_content_verbatim(self, aws_event_parser):
         """
         What it does: Verifies identical consecutive deltas are both emitted.
@@ -456,7 +449,7 @@ class TestAwsEventStreamParserFeed:
 
         assert [event["data"] for event in events1] == ["Same"]
         assert [event["data"] for event in events2] == ["Same"]
-    
+
     def test_parses_usage_event(self, aws_event_parser):
         """
         What it does: Tests parsing of usage event.
@@ -464,15 +457,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: Chunk with usage...")
         chunk = b'{"usage":1.5}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 1
         assert events[0]["type"] == "usage"
         assert events[0]["data"] == 1.5
-    
+
     def test_parses_context_usage_event(self, aws_event_parser):
         """
         What it does: Tests parsing of context_usage event.
@@ -480,15 +473,15 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: Chunk with context usage...")
         chunk = b'{"contextUsagePercentage":25.5}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 1
         assert events[0]["type"] == "context_usage"
         assert events[0]["data"] == 25.5
-    
+
     def test_handles_incomplete_json(self, aws_event_parser):
         """
         What it does: Tests handling of incomplete JSON.
@@ -496,16 +489,16 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: Incomplete chunk...")
         chunk = b'{"content":"Hel'
-        
+
         print("Action: Parsing incomplete chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 0  # Nothing parsed
-        
+
         print("Check: Data in buffer...")
-        assert 'content' in aws_event_parser.buffer
-    
+        assert "content" in aws_event_parser.buffer
+
     def test_completes_json_across_chunks(self, aws_event_parser):
         """
         What it does: Tests assembling JSON from multiple chunks.
@@ -513,10 +506,10 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: First part of JSON...")
         events1 = aws_event_parser.feed(b'{"content":"Hel')
-        
+
         print("Action: Second part of JSON...")
         events2 = aws_event_parser.feed(b'lo World"}')
-        
+
         print(f"First result: {events1}")
         print(f"Second result: {events2}")
         assert len(events1) == 0
@@ -535,7 +528,7 @@ class TestAwsEventStreamParserFeed:
 
         assert aws_event_parser.drain_observed_frames() == [frame]
         assert aws_event_parser.drain_observed_frames() == []
-    
+
     def test_decodes_escape_sequences(self, aws_event_parser):
         """
         What it does: Tests decoding of escape sequences.
@@ -544,13 +537,14 @@ class TestAwsEventStreamParserFeed:
         print("Setup: Chunk with escape sequence...")
         # Using correct escape sequence format
         chunk = b'{"content":"Line1\\nLine2"}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 1
         assert "\n" in events[0]["data"]
+
     def test_handles_invalid_bytes(self, aws_event_parser):
         """
         What it does: Tests handling of invalid bytes.
@@ -558,10 +552,10 @@ class TestAwsEventStreamParserFeed:
         """
         print("Setup: Invalid bytes...")
         chunk = b'\xff\xfe{"content":"test"}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         # Parser should continue working
         assert len(events) == 1
@@ -569,7 +563,7 @@ class TestAwsEventStreamParserFeed:
 
 class TestAwsEventStreamParserToolCalls:
     """Tests for tool calls parsing."""
-    
+
     def test_parses_tool_start_event(self, aws_event_parser):
         """
         What it does: Tests parsing of tool call start.
@@ -577,17 +571,17 @@ class TestAwsEventStreamParserToolCalls:
         """
         print("Setup: Chunk with tool call start...")
         chunk = b'{"name":"get_weather","toolUseId":"call_123"}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         print(f"current_tool_call: {aws_event_parser.current_tool_call}")
-        
+
         # tool_start doesn't return event, but creates current_tool_call
         assert aws_event_parser.current_tool_call is not None
         assert aws_event_parser.current_tool_call["function"]["name"] == "get_weather"
-    
+
     def test_parses_tool_input_event(self, aws_event_parser):
         """
         What it does: Tests parsing of input for tool call.
@@ -595,13 +589,13 @@ class TestAwsEventStreamParserToolCalls:
         """
         print("Setup: Tool call start...")
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
-        
+
         print("Action: Parsing input...")
         aws_event_parser.feed(b'{"input":"{\\"key\\": \\"value\\"}"}')
-        
+
         print(f"current_tool_call: {aws_event_parser.current_tool_call}")
         assert '{"key": "value"}' in aws_event_parser.current_tool_call["function"]["arguments"]
-    
+
     def test_parses_tool_stop_event(self, aws_event_parser):
         """
         What it does: Tests tool call completion.
@@ -610,14 +604,14 @@ class TestAwsEventStreamParserToolCalls:
         print("Setup: Complete tool call...")
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
         aws_event_parser.feed(b'{"input":"{}"}')
-        
+
         print("Action: Parsing stop...")
         aws_event_parser.feed(b'{"stop":true}')
-        
+
         print(f"tool_calls: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.current_tool_call is None
-    
+
     def test_get_tool_calls_returns_all(self, aws_event_parser):
         """
         What it does: Tests getting all tool calls.
@@ -628,10 +622,10 @@ class TestAwsEventStreamParserToolCalls:
         aws_event_parser.feed(b'{"stop":true}')
         aws_event_parser.feed(b'{"name":"func2","toolUseId":"call_2"}')
         aws_event_parser.feed(b'{"stop":true}')
-        
+
         print("Action: Getting tool calls...")
         tool_calls = aws_event_parser.get_tool_calls()
-        
+
         print(f"Result: {tool_calls}")
         assert len(tool_calls) == 2
 
@@ -648,10 +642,8 @@ class TestAwsEventStreamParserToolCalls:
         ):
             events.extend(aws_event_parser.feed(frame))
 
-        assert events[-1]["data"]["function"]["arguments"] == (
-            '{"command": "pwd"}'
-        )
-    
+        assert events[-1]["data"]["function"]["arguments"] == ('{"command": "pwd"}')
+
     def test_get_tool_calls_finalizes_current(self, aws_event_parser):
         """
         What it does: Tests finalization of incomplete tool call.
@@ -659,10 +651,10 @@ class TestAwsEventStreamParserToolCalls:
         """
         print("Setup: Incomplete tool call...")
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
-        
+
         print("Action: Getting tool calls...")
         tool_calls = aws_event_parser.get_tool_calls()
-        
+
         print(f"Result: {tool_calls}")
         assert len(tool_calls) == 1
         assert aws_event_parser.current_tool_call is None
@@ -670,7 +662,7 @@ class TestAwsEventStreamParserToolCalls:
 
 class TestAwsEventStreamParserReset:
     """Tests for reset method."""
-    
+
     def test_reset_clears_state(self, aws_event_parser):
         """
         What it does: Tests parser state reset.
@@ -679,10 +671,10 @@ class TestAwsEventStreamParserReset:
         print("Setup: Filling parser with data...")
         aws_event_parser.feed(b'{"content":"test"}')
         aws_event_parser.feed(b'{"name":"func","toolUseId":"call_1"}')
-        
+
         print("Action: Resetting parser...")
         aws_event_parser.reset()
-        
+
         print("Check: All data cleared...")
         assert aws_event_parser.buffer == ""
         assert aws_event_parser.current_tool_call is None
@@ -691,7 +683,7 @@ class TestAwsEventStreamParserReset:
 
 class TestAwsEventStreamParserFinalizeToolCall:
     """Tests for _finalize_tool_call method handling different input types."""
-    
+
     def test_finalize_with_string_arguments(self, aws_event_parser):
         """
         What it does: Tests finalization of tool call with string arguments.
@@ -701,19 +693,16 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_1",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": '{"key": "value"}'
-            }
+            "function": {"name": "test_func", "arguments": '{"key": "value"}'},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Result: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.tool_calls[0]["function"]["arguments"] == '{"key": "value"}'
-    
+
     def test_finalize_with_dict_arguments(self, aws_event_parser):
         """
         What it does: Tests finalization of tool call with dict arguments.
@@ -723,24 +712,21 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_2",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": {"location": "Moscow", "units": "celsius"}
-            }
+            "function": {"name": "test_func", "arguments": {"location": "Moscow", "units": "celsius"}},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Result: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
-        
+
         args = aws_event_parser.tool_calls[0]["function"]["arguments"]
         print(f"Arguments: {args}")
         assert isinstance(args, str)
         assert "Moscow" in args
         assert "celsius" in args
-    
+
     def test_finalize_with_empty_string_arguments(self, aws_event_parser):
         """
         What it does: Tests finalization of tool call with empty string arguments.
@@ -750,19 +736,16 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_3",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": ""
-            }
+            "function": {"name": "test_func", "arguments": ""},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Result: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.tool_calls[0]["function"]["arguments"] == "{}"
-    
+
     def test_finalize_with_whitespace_only_arguments(self, aws_event_parser):
         """
         What it does: Tests finalization of tool call with whitespace arguments.
@@ -772,19 +755,16 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_4",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": "   "
-            }
+            "function": {"name": "test_func", "arguments": "   "},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Result: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
         assert aws_event_parser.tool_calls[0]["function"]["arguments"] == "{}"
-    
+
     def test_finalize_with_invalid_json_arguments(self, aws_event_parser):
         """
         What it does: Tests finalization of tool call with invalid JSON.
@@ -794,25 +774,17 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_5",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": "not valid json {"
-            }
+            "function": {"name": "test_func", "arguments": "not valid json {"},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Result: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 1
-        assert (
-            aws_event_parser.tool_calls[0]["function"]["arguments"]
-            == "not valid json {"
-        )
-        assert aws_event_parser.tool_calls[0]["_parse_error"]["type"] == (
-            "invalid_tool_arguments"
-        )
-    
+        assert aws_event_parser.tool_calls[0]["function"]["arguments"] == "not valid json {"
+        assert aws_event_parser.tool_calls[0]["_parse_error"]["type"] == ("invalid_tool_arguments")
+
     def test_finalize_with_none_current_tool_call(self, aws_event_parser):
         """
         What it does: Tests finalization when current_tool_call is None.
@@ -820,13 +792,13 @@ class TestAwsEventStreamParserFinalizeToolCall:
         """
         print("Setup: current_tool_call = None...")
         aws_event_parser.current_tool_call = None
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"Result: {aws_event_parser.tool_calls}")
         assert len(aws_event_parser.tool_calls) == 0
-    
+
     def test_finalize_clears_current_tool_call(self, aws_event_parser):
         """
         What it does: Tests that finalization clears current_tool_call.
@@ -836,22 +808,19 @@ class TestAwsEventStreamParserFinalizeToolCall:
         aws_event_parser.current_tool_call = {
             "id": "call_6",
             "type": "function",
-            "function": {
-                "name": "test_func",
-                "arguments": "{}"
-            }
+            "function": {"name": "test_func", "arguments": "{}"},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print(f"current_tool_call after finalization: {aws_event_parser.current_tool_call}")
         assert aws_event_parser.current_tool_call is None
 
 
 class TestAwsEventStreamParserEdgeCases:
     """Tests for edge cases."""
-    
+
     def test_handles_followup_prompt(self, aws_event_parser):
         """
         What it does: Tests ignoring followupPrompt.
@@ -859,13 +828,13 @@ class TestAwsEventStreamParserEdgeCases:
         """
         print("Setup: Chunk with followupPrompt...")
         chunk = b'{"content":"text","followupPrompt":"suggestion"}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 0  # followupPrompt is ignored
-    
+
     def test_handles_mixed_events(self, aws_event_parser):
         """
         What it does: Tests parsing of mixed events.
@@ -873,16 +842,16 @@ class TestAwsEventStreamParserEdgeCases:
         """
         print("Setup: Chunk with mixed events...")
         chunk = b'{"content":"Hello"}{"usage":1.0}{"contextUsagePercentage":50}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 3
         assert events[0]["type"] == "content"
         assert events[1]["type"] == "usage"
         assert events[2]["type"] == "context_usage"
-    
+
     def test_handles_garbage_between_events(self, aws_event_parser):
         """
         What it does: Tests handling of garbage between events.
@@ -890,23 +859,23 @@ class TestAwsEventStreamParserEdgeCases:
         """
         print("Setup: Chunk with garbage between JSON...")
         chunk = b'garbage{"content":"valid"}more garbage{"usage":1}'
-        
+
         print("Action: Parsing chunk...")
         events = aws_event_parser.feed(chunk)
-        
+
         print(f"Result: {events}")
         assert len(events) == 2
-    
+
     def test_handles_empty_chunk(self, aws_event_parser):
         """
         What it does: Tests handling of empty chunk.
         Goal: Ensure empty chunk doesn't cause errors.
         """
         print("Setup: Empty chunk...")
-        
+
         print("Action: Parsing empty chunk...")
-        events = aws_event_parser.feed(b'')
-        
+        events = aws_event_parser.feed(b"")
+
         print(f"Comparing result: Expected [], Got {events}")
         assert events == []
 
@@ -914,11 +883,11 @@ class TestAwsEventStreamParserEdgeCases:
 class TestDiagnoseJsonTruncation:
     """
     Tests for _diagnose_json_truncation method for diagnosing truncated JSON.
-    
+
     This method helps distinguish upstream issues (Kiro API truncates large
     tool call arguments) from actually invalid JSON from the model.
     """
-    
+
     def test_empty_string_not_truncated(self, aws_event_parser):
         """
         What it does: Tests handling of empty string.
@@ -926,16 +895,16 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Empty string...")
         json_str = ""
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected False, Got {result['is_truncated']}")
         assert result["is_truncated"] is False
         assert result["reason"] == "empty string"
         assert result["size_bytes"] == 0
-    
+
     def test_whitespace_only_not_truncated(self, aws_event_parser):
         """
         What it does: Tests handling of whitespace-only string.
@@ -943,15 +912,15 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Whitespace string...")
         json_str = "   \t\n  "
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected False, Got {result['is_truncated']}")
         assert result["is_truncated"] is False
         assert result["reason"] == "empty string"
-    
+
     def test_valid_json_not_truncated(self, aws_event_parser):
         """
         What it does: Tests handling of valid JSON.
@@ -959,15 +928,15 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Valid JSON...")
         json_str = '{"key": "value", "number": 42}'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected False, Got {result['is_truncated']}")
         assert result["is_truncated"] is False
         assert result["reason"] == "malformed JSON"  # Function doesn't check validity, only structure
-    
+
     def test_valid_nested_json_not_truncated(self, aws_event_parser):
         """
         What it does: Tests handling of nested valid JSON.
@@ -975,13 +944,13 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Nested valid JSON...")
         json_str = '{"outer": {"inner": {"deep": [1, 2, 3]}}}'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is False
-    
+
     def test_missing_closing_brace_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of missing closing brace.
@@ -989,15 +958,15 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: JSON without closing brace...")
         json_str = '{"filePath": "/path/to/file.md"'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected True, Got {result['is_truncated']}")
         assert result["is_truncated"] is True
         assert "missing" in result["reason"] and "brace" in result["reason"]
-    
+
     def test_real_world_truncation_from_issue_34(self, aws_event_parser):
         """
         What it does: Tests real example from Issue #34.
@@ -1006,16 +975,16 @@ class TestDiagnoseJsonTruncation:
         print("Setup: Real example from Issue #34...")
         # This is exact example from log: JSON truncated after filePath
         json_str = '{"filePath": "/Users/cc/Documents/Code/mock-all/docs/plans/2026-01-12-mock-all-impl.md"'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected True, Got {result['is_truncated']}")
         assert result["is_truncated"] is True
         assert "brace" in result["reason"]
         assert result["size_bytes"] == 87  # Exact size from log (char 87 = error position)
-    
+
     def test_multiple_missing_braces_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of multiple missing braces.
@@ -1023,14 +992,14 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Nested JSON without closing braces...")
         json_str = '{"outer": {"inner": {"deep": "value"'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
         assert "3" in result["reason"] or "brace" in result["reason"]
-    
+
     def test_missing_closing_bracket_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of missing closing square bracket.
@@ -1038,15 +1007,15 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Array without closing bracket...")
         json_str = '[1, 2, 3, {"key": "value"}'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected True, Got {result['is_truncated']}")
         assert result["is_truncated"] is True
         assert "bracket" in result["reason"]
-    
+
     def test_array_start_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of truncated array at start.
@@ -1054,14 +1023,14 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Array start without end...")
         json_str = '["item1", "item2"'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
         assert "bracket" in result["reason"]
-    
+
     def test_unbalanced_braces_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of unbalanced curly braces.
@@ -1070,13 +1039,13 @@ class TestDiagnoseJsonTruncation:
         print("Setup: JSON with unbalanced braces...")
         # Ends with }, but has extra opening inside
         json_str = '{"a": {"b": 1}}'[:-1]  # Remove last }
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
-    
+
     def test_unbalanced_brackets_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of unbalanced square brackets.
@@ -1084,14 +1053,14 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: JSON with unbalanced square brackets...")
         json_str = '{"items": [[1, 2], [3, 4]}'  # Missing one ]
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
         assert "bracket" in result["reason"]
-    
+
     def test_unclosed_string_truncated(self, aws_event_parser):
         """
         What it does: Tests detection of unclosed string.
@@ -1099,15 +1068,15 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: JSON with unclosed string...")
         json_str = '{"content": "This is a very long string that was cut off'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected True, Got {result['is_truncated']}")
         assert result["is_truncated"] is True
         assert "string" in result["reason"] or "brace" in result["reason"]
-    
+
     def test_escaped_quotes_handled_correctly(self, aws_event_parser):
         """
         What it does: Tests correct handling of escaped quotes.
@@ -1115,14 +1084,14 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: JSON with escaped quotes...")
         json_str = '{"text": "Say \\"hello\\" to everyone"}'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected False, Got {result['is_truncated']}")
         assert result["is_truncated"] is False
-    
+
     def test_truncated_in_middle_of_escaped_sequence(self, aws_event_parser):
         """
         What it does: Tests truncation in middle of escape sequence.
@@ -1130,13 +1099,13 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: JSON truncated after backslash...")
         json_str = '{"text": "Line1\\nLine2\\'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
-    
+
     def test_size_bytes_calculated_correctly(self, aws_event_parser):
         """
         What it does: Tests correct byte size calculation.
@@ -1144,16 +1113,16 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: JSON with Unicode characters...")
         json_str = '{"city": "Москва"'  # Cyrillic = 2 bytes per character
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
-        expected_size = len(json_str.encode('utf-8'))
+        expected_size = len(json_str.encode("utf-8"))
         print(f"Comparing size_bytes: Expected {expected_size}, Got {result['size_bytes']}")
         assert result["size_bytes"] == expected_size
         assert result["is_truncated"] is True  # No closing }
-    
+
     def test_large_truncated_json(self, aws_event_parser):
         """
         What it does: Tests handling of large truncated JSON.
@@ -1163,14 +1132,14 @@ class TestDiagnoseJsonTruncation:
         # Simulate large file that was truncated
         content = "x" * 10000
         json_str = f'{{"filePath": "/path/to/file.md", "content": "{content}'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: is_truncated={result['is_truncated']}, size_bytes={result['size_bytes']}")
         assert result["is_truncated"] is True
         assert result["size_bytes"] > 10000
-    
+
     def test_malformed_but_not_truncated(self, aws_event_parser):
         """
         What it does: Tests invalid but not truncated JSON.
@@ -1178,66 +1147,66 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Invalid JSON (trailing comma)...")
         json_str = '{"key": "value",}'  # Trailing comma - invalid, but not truncated
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         print(f"Comparing is_truncated: Expected False, Got {result['is_truncated']}")
         assert result["is_truncated"] is False
         assert result["reason"] == "malformed JSON"
-    
+
     def test_json_with_only_opening_brace(self, aws_event_parser):
         """
         What it does: Tests JSON with only opening brace.
         Goal: Ensure minimal truncated JSON is detected.
         """
         print("Setup: Only opening brace...")
-        json_str = '{'
-        
+        json_str = "{"
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
         assert "brace" in result["reason"]
-    
+
     def test_json_with_only_opening_bracket(self, aws_event_parser):
         """
         What it does: Tests JSON with only opening square bracket.
         Goal: Ensure minimal truncated array is detected.
         """
         print("Setup: Only opening square bracket...")
-        json_str = '['
-        
+        json_str = "["
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
         assert "bracket" in result["reason"]
-    
+
     def test_braces_inside_string_not_counted(self, aws_event_parser):
         """
         What it does: Tests that braces inside strings don't affect counting.
         Goal: Ensure "{}" inside string doesn't break diagnosis.
-        
+
         Note: Current implementation uses simplified counting,
         which doesn't account for string context. This is a known limitation.
         """
         print("Setup: JSON with braces inside string...")
         json_str = '{"text": "Hello {world}"}'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         # Function uses simplified counting, so this may be False
         # Main thing - it doesn't crash and returns correct structure
         assert "is_truncated" in result
         assert "reason" in result
         assert "size_bytes" in result
-    
+
     def test_complex_nested_truncation(self, aws_event_parser):
         """
         What it does: Tests complex nested truncated JSON.
@@ -1245,10 +1214,10 @@ class TestDiagnoseJsonTruncation:
         """
         print("Setup: Complex nested truncated JSON...")
         json_str = '{"level1": {"level2": {"level3": [{"item": "value'
-        
+
         print("Action: Diagnosis...")
         result = aws_event_parser._diagnose_json_truncation(json_str)
-        
+
         print(f"Result: {result}")
         assert result["is_truncated"] is True
 
@@ -1257,14 +1226,15 @@ class TestDiagnoseJsonTruncation:
 # Tests for Truncation Recovery System integration (Issue #56)
 # =============================================================================
 
+
 class TestTruncationRecoveryIntegration:
     """
     Tests for Truncation Recovery System integration in parsers.
-    
+
     Verifies that tool calls are marked with truncation flags when JSON is truncated.
     Part of Truncation Recovery System (Issue #56).
     """
-    
+
     def test_tool_call_marked_with_truncation_flags(self, aws_event_parser):
         """
         What it does: Verifies tool call is marked with _truncation_detected and _truncation_info.
@@ -1276,35 +1246,35 @@ class TestTruncationRecoveryIntegration:
             "type": "function",
             "function": {
                 "name": "write_to_file",
-                "arguments": '{"filePath": "/path/to/file.md", "content": "This is a very long content that was cut off'
-            }
+                "arguments": '{"filePath": "/path/to/file.md", "content": "This is a very long content that was cut off',
+            },
         }
-        
+
         print("Action: Finalizing tool call (should detect truncation)...")
         aws_event_parser._finalize_tool_call()
-        
+
         print("Checking: Tool call was added to list...")
         assert len(aws_event_parser.tool_calls) == 1
-        
+
         tool_call = aws_event_parser.tool_calls[0]
         print(f"Tool call: {tool_call}")
-        
+
         print("Checking: _truncation_detected flag is set...")
         assert tool_call.get("_truncation_detected") is True
-        
+
         print("Checking: _truncation_info is present...")
         assert "_truncation_info" in tool_call
-        
+
         truncation_info = tool_call["_truncation_info"]
         print(f"Truncation info: {truncation_info}")
-        
+
         print("Checking: truncation_info has required fields...")
         assert truncation_info["is_truncated"] is True
         assert "size_bytes" in truncation_info
         assert truncation_info["size_bytes"] > 0
         assert "reason" in truncation_info
         assert len(truncation_info["reason"]) > 0
-    
+
     def test_valid_tool_call_not_marked_with_truncation(self, aws_event_parser):
         """
         What it does: Verifies valid tool call is NOT marked with truncation flags.
@@ -1314,27 +1284,24 @@ class TestTruncationRecoveryIntegration:
         aws_event_parser.current_tool_call = {
             "id": "tooluse_valid",
             "type": "function",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"location": "Moscow", "units": "celsius"}'
-            }
+            "function": {"name": "get_weather", "arguments": '{"location": "Moscow", "units": "celsius"}'},
         }
-        
+
         print("Action: Finalizing tool call...")
         aws_event_parser._finalize_tool_call()
-        
+
         print("Checking: Tool call was added to list...")
         assert len(aws_event_parser.tool_calls) == 1
-        
+
         tool_call = aws_event_parser.tool_calls[0]
         print(f"Tool call: {tool_call}")
-        
+
         print("Checking: _truncation_detected flag is NOT set...")
         assert tool_call.get("_truncation_detected") is not True
-        
+
         print("Checking: _truncation_info is NOT present...")
         assert "_truncation_info" not in tool_call
-    
+
     def test_multiple_tool_calls_with_mixed_truncation(self, aws_event_parser):
         """
         What it does: Verifies multiple tool calls are marked independently.
@@ -1344,45 +1311,36 @@ class TestTruncationRecoveryIntegration:
         aws_event_parser.current_tool_call = {
             "id": "tooluse_1",
             "type": "function",
-            "function": {
-                "name": "func1",
-                "arguments": '{"param": "value"}'
-            }
+            "function": {"name": "func1", "arguments": '{"param": "value"}'},
         }
         aws_event_parser._finalize_tool_call()
-        
+
         print("Setup: Creating second tool call (truncated)...")
         aws_event_parser.current_tool_call = {
             "id": "tooluse_2",
             "type": "function",
-            "function": {
-                "name": "func2",
-                "arguments": '{"param": "incomplete'
-            }
+            "function": {"name": "func2", "arguments": '{"param": "incomplete'},
         }
         aws_event_parser._finalize_tool_call()
-        
+
         print("Setup: Creating third tool call (valid)...")
         aws_event_parser.current_tool_call = {
             "id": "tooluse_3",
             "type": "function",
-            "function": {
-                "name": "func3",
-                "arguments": '{"param": "complete"}'
-            }
+            "function": {"name": "func3", "arguments": '{"param": "complete"}'},
         }
         aws_event_parser._finalize_tool_call()
-        
+
         print("Checking: All tool calls were added...")
         assert len(aws_event_parser.tool_calls) == 3
-        
+
         print("Checking: First tool call NOT marked as truncated...")
         assert aws_event_parser.tool_calls[0].get("_truncation_detected") is not True
-        
+
         print("Checking: Second tool call IS marked as truncated...")
         assert aws_event_parser.tool_calls[1].get("_truncation_detected") is True
         assert "_truncation_info" in aws_event_parser.tool_calls[1]
-        
+
         print("Checking: Third tool call NOT marked as truncated...")
         assert aws_event_parser.tool_calls[2].get("_truncation_detected") is not True
 

--- a/tests/unit/test_payload_guards.py
+++ b/tests/unit/test_payload_guards.py
@@ -7,10 +7,7 @@ Tests check_payload_size() and trim_payload_to_limit() functions.
 
 import json
 
-import pytest
-
 from kiro.payload_guards import (
-    PayloadTrimStats,
     check_payload_size,
     trim_payload_to_limit,
 )
@@ -20,19 +17,13 @@ def _make_payload(num_pairs=5, content_size=100):
     """Helper: build a minimal Kiro-shaped payload with N user/assistant pairs."""
     history = []
     for i in range(num_pairs):
-        history.append({
-            "userInputMessage": {"content": f"user message {i} " + "x" * content_size}
-        })
-        history.append({
-            "assistantResponseMessage": {"content": f"assistant message {i} " + "y" * content_size}
-        })
+        history.append({"userInputMessage": {"content": f"user message {i} " + "x" * content_size}})
+        history.append({"assistantResponseMessage": {"content": f"assistant message {i} " + "y" * content_size}})
     return {
         "conversationState": {
             "chatTriggerType": "MANUAL",
             "conversationId": "test-conv",
-            "currentMessage": {
-                "userInputMessage": {"content": "current message", "modelId": "test"}
-            },
+            "currentMessage": {"userInputMessage": {"content": "current message", "modelId": "test"}},
             "history": history,
         },
         "profileArn": "arn:aws:test",
@@ -40,7 +31,6 @@ def _make_payload(num_pairs=5, content_size=100):
 
 
 class TestCheckPayloadSize:
-
     def test_check_payload_size_returns_bytes(self):
         """Correct byte count for a simple payload."""
         payload = {"key": "value"}
@@ -59,7 +49,6 @@ class TestCheckPayloadSize:
 
 
 class TestTrimPayloadToLimit:
-
     def test_trim_does_nothing_when_under_limit(self):
         """No-op when payload is small."""
         payload = _make_payload(num_pairs=2, content_size=10)

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -10,25 +9,22 @@ Tests the following endpoint:
 For OpenAI API tests, see test_routes_openai.py.
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone
-import json
-
 from fastapi import HTTPException
-from fastapi.testclient import TestClient
 
-from kiro.routes_anthropic import verify_anthropic_api_key, router
 from kiro.config import PROXY_API_KEY
-
+from kiro.routes_anthropic import router, verify_anthropic_api_key
 
 # =============================================================================
 # Tests for verify_anthropic_api_key function
 # =============================================================================
 
+
 class TestVerifyAnthropicApiKey:
     """Tests for the verify_anthropic_api_key authentication function."""
-    
+
     @pytest.mark.asyncio
     async def test_valid_x_api_key_returns_true(self):
         """
@@ -36,13 +32,13 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure Anthropic native authentication works.
         """
         print("Setup: Creating valid x-api-key...")
-        
+
         print("Action: Calling verify_anthropic_api_key...")
         result = await verify_anthropic_api_key(x_api_key=PROXY_API_KEY, authorization=None)
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_valid_bearer_token_returns_true(self):
         """
@@ -51,13 +47,13 @@ class TestVerifyAnthropicApiKey:
         """
         print("Setup: Creating valid Bearer token...")
         valid_auth = f"Bearer {PROXY_API_KEY}"
-        
+
         print("Action: Calling verify_anthropic_api_key...")
         result = await verify_anthropic_api_key(x_api_key=None, authorization=valid_auth)
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_x_api_key_takes_precedence(self):
         """
@@ -65,16 +61,13 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure Anthropic native auth has priority.
         """
         print("Setup: Both headers provided...")
-        
+
         print("Action: Calling verify_anthropic_api_key with both headers...")
-        result = await verify_anthropic_api_key(
-            x_api_key=PROXY_API_KEY,
-            authorization="Bearer wrong_key"
-        )
-        
+        result = await verify_anthropic_api_key(x_api_key=PROXY_API_KEY, authorization="Bearer wrong_key")
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_invalid_x_api_key_raises_401(self):
         """
@@ -82,14 +75,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure unauthorized access is blocked.
         """
         print("Setup: Creating invalid x-api-key...")
-        
+
         print("Action: Calling verify_anthropic_api_key with invalid key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key="wrong_key", authorization=None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_invalid_bearer_token_raises_401(self):
         """
@@ -97,14 +90,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure unauthorized access is blocked.
         """
         print("Setup: Creating invalid Bearer token...")
-        
+
         print("Action: Calling verify_anthropic_api_key with invalid token...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key=None, authorization="Bearer wrong_key")
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_missing_both_headers_raises_401(self):
         """
@@ -112,14 +105,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure authentication is required.
         """
         print("Setup: No authentication headers...")
-        
+
         print("Action: Calling verify_anthropic_api_key with no headers...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key=None, authorization=None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_empty_x_api_key_raises_401(self):
         """
@@ -127,14 +120,14 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure empty credentials are blocked.
         """
         print("Setup: Empty x-api-key...")
-        
+
         print("Action: Calling verify_anthropic_api_key with empty key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key="", authorization=None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_error_response_format_is_anthropic_style(self):
         """
@@ -142,12 +135,12 @@ class TestVerifyAnthropicApiKey:
         Purpose: Ensure error format matches Anthropic API.
         """
         print("Setup: Invalid credentials...")
-        
+
         print("Action: Calling verify_anthropic_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_anthropic_api_key(x_api_key="wrong", authorization=None)
-        
-        print(f"Checking: Error format...")
+
+        print("Checking: Error format...")
         detail = exc_info.value.detail
         assert "type" in detail
         assert "error" in detail
@@ -158,9 +151,10 @@ class TestVerifyAnthropicApiKey:
 # Tests for /v1/messages endpoint authentication
 # =============================================================================
 
+
 class TestMessagesAuthentication:
     """Tests for authentication on /v1/messages endpoint."""
-    
+
     def test_messages_requires_authentication(self, test_client):
         """
         What it does: Verifies messages endpoint requires authentication.
@@ -169,16 +163,12 @@ class TestMessagesAuthentication:
         print("Action: POST /v1/messages without auth...")
         response = test_client.post(
             "/v1/messages",
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_messages_accepts_x_api_key(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies messages endpoint accepts x-api-key header.
@@ -188,17 +178,13 @@ class TestMessagesAuthentication:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass auth (not 401)
         assert response.status_code != 401
-    
+
     def test_messages_accepts_bearer_token(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies messages endpoint accepts Bearer token.
@@ -208,17 +194,13 @@ class TestMessagesAuthentication:
         response = test_client.post(
             "/v1/messages",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass auth (not 401)
         assert response.status_code != 401
-    
+
     def test_messages_rejects_invalid_x_api_key(self, test_client, invalid_proxy_api_key):
         """
         What it does: Verifies messages endpoint rejects invalid x-api-key.
@@ -228,13 +210,9 @@ class TestMessagesAuthentication:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": invalid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
 
@@ -243,9 +221,10 @@ class TestMessagesAuthentication:
 # Tests for /v1/messages endpoint validation
 # =============================================================================
 
+
 class TestMessagesValidation:
     """Tests for request validation on /v1/messages endpoint."""
-    
+
     def test_validates_missing_model(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing model field is rejected.
@@ -255,15 +234,12 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_max_tokens(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing max_tokens field is rejected.
@@ -273,15 +249,12 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_messages(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing messages field is rejected.
@@ -291,15 +264,12 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_empty_messages_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies empty messages array is rejected.
@@ -309,16 +279,12 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": []
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": []},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_json(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid JSON is rejected.
@@ -327,16 +293,13 @@ class TestMessagesValidation:
         print("Action: POST /v1/messages with invalid JSON...")
         response = test_client.post(
             "/v1/messages",
-            headers={
-                "x-api-key": valid_proxy_api_key,
-                "Content-Type": "application/json"
-            },
-            content=b"not valid json {{{}"
+            headers={"x-api-key": valid_proxy_api_key, "Content-Type": "application/json"},
+            content=b"not valid json {{{}",
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid message role is rejected.
@@ -349,14 +312,14 @@ class TestMessagesValidation:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
-            }
+                "messages": [{"role": "invalid_role", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Anthropic model strictly validates role - only 'user' or 'assistant' allowed
         assert response.status_code == 422
-    
+
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies valid request format passes validation.
@@ -366,13 +329,9 @@ class TestMessagesValidation:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation (not 422)
         assert response.status_code != 422
@@ -382,9 +341,10 @@ class TestMessagesValidation:
 # Tests for /v1/messages system prompt
 # =============================================================================
 
+
 class TestMessagesSystemPrompt:
     """Tests for system prompt handling on /v1/messages endpoint."""
-    
+
     def test_accepts_system_as_separate_field(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies system prompt as separate field is accepted.
@@ -398,14 +358,14 @@ class TestMessagesSystemPrompt:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "system": "You are a helpful assistant.",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_accepts_empty_system_prompt(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies empty system prompt is accepted.
@@ -419,14 +379,14 @@ class TestMessagesSystemPrompt:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "system": "",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_accepts_no_system_prompt(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies request without system prompt is accepted.
@@ -436,13 +396,9 @@ class TestMessagesSystemPrompt:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
@@ -452,9 +408,10 @@ class TestMessagesSystemPrompt:
 # Tests for /v1/messages content blocks
 # =============================================================================
 
+
 class TestMessagesContentBlocks:
     """Tests for content block handling on /v1/messages endpoint."""
-    
+
     def test_accepts_string_content(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies string content is accepted.
@@ -464,16 +421,12 @@ class TestMessagesContentBlocks:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_content_block_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies content block array is accepted.
@@ -486,20 +439,13 @@ class TestMessagesContentBlocks:
             json={
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": "Hello"}
-                        ]
-                    }
-                ]
-            }
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_multiple_content_blocks(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multiple content blocks are accepted.
@@ -515,15 +461,12 @@ class TestMessagesContentBlocks:
                 "messages": [
                     {
                         "role": "user",
-                        "content": [
-                            {"type": "text", "text": "First part"},
-                            {"type": "text", "text": "Second part"}
-                        ]
+                        "content": [{"type": "text", "text": "First part"}, {"type": "text", "text": "Second part"}],
                     }
-                ]
-            }
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -532,9 +475,10 @@ class TestMessagesContentBlocks:
 # Tests for /v1/messages tool use
 # =============================================================================
 
+
 class TestMessagesToolUse:
     """Tests for tool use on /v1/messages endpoint."""
-    
+
     def test_accepts_tool_definition(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies tool definition is accepted.
@@ -554,19 +498,17 @@ class TestMessagesToolUse:
                         "description": "Get weather for a location",
                         "input_schema": {
                             "type": "object",
-                            "properties": {
-                                "location": {"type": "string"}
-                            },
-                            "required": ["location"]
-                        }
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
                     }
-                ]
-            }
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_multiple_tools(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multiple tools are accepted.
@@ -584,20 +526,20 @@ class TestMessagesToolUse:
                     {
                         "name": "get_weather",
                         "description": "Get weather",
-                        "input_schema": {"type": "object", "properties": {}}
+                        "input_schema": {"type": "object", "properties": {}},
                     },
                     {
                         "name": "get_time",
                         "description": "Get time",
-                        "input_schema": {"type": "object", "properties": {}}
-                    }
-                ]
-            }
+                        "input_schema": {"type": "object", "properties": {}},
+                    },
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_tool_result_message(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies tool result message is accepted.
@@ -619,24 +561,18 @@ class TestMessagesToolUse:
                                 "type": "tool_use",
                                 "id": "call_123",
                                 "name": "get_weather",
-                                "input": {"location": "Moscow"}
+                                "input": {"location": "Moscow"},
                             }
-                        ]
+                        ],
                     },
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": "call_123",
-                                "content": "Sunny, 25°C"
-                            }
-                        ]
-                    }
-                ]
-            }
+                        "content": [{"type": "tool_result", "tool_use_id": "call_123", "content": "Sunny, 25°C"}],
+                    },
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -645,9 +581,10 @@ class TestMessagesToolUse:
 # Tests for /v1/messages optional parameters
 # =============================================================================
 
+
 class TestMessagesOptionalParams:
     """Tests for optional parameters on /v1/messages endpoint."""
-    
+
     def test_accepts_temperature_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies temperature parameter is accepted.
@@ -661,13 +598,13 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "temperature": 0.7
-            }
+                "temperature": 0.7,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_top_p_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies top_p parameter is accepted.
@@ -681,13 +618,13 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "top_p": 0.9
-            }
+                "top_p": 0.9,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_top_k_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies top_k parameter is accepted.
@@ -701,37 +638,39 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "top_k": 40
-            }
+                "top_k": 40,
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_stream_true(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies stream=true is accepted.
         Purpose: Ensure streaming mode is supported.
         """
         print("Action: POST /v1/messages with stream=true...")
-        
+
         # Mock the streaming function to avoid real HTTP requests
         async def mock_stream(*args, **kwargs):
             yield 'event: message_start\ndata: {"type":"message_start"}\n\n'
             yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
-        
+
         # Create mock response for HTTP client with proper async iteration
         mock_response = AsyncMock()
         mock_response.status_code = 200
-        
+
         # Mock aiter_bytes to return actual bytes, not mock coroutines
         async def mock_aiter_bytes():
             yield b'{"content":"test"}'
-        
+
         mock_response.aiter_bytes = mock_aiter_bytes
-        
-        with patch('kiro.routes_anthropic.stream_kiro_to_anthropic', mock_stream), \
-             patch('kiro.http_client.KiroHttpClient.request_with_retry', return_value=mock_response):
+
+        with (
+            patch("kiro.routes_anthropic.stream_with_first_token_retry_anthropic", mock_stream),
+            patch("kiro.http_client.KiroHttpClient.request_with_retry", return_value=mock_response),
+        ):
             response = test_client.post(
                 "/v1/messages",
                 headers={"x-api-key": valid_proxy_api_key},
@@ -739,13 +678,13 @@ class TestMessagesOptionalParams:
                     "model": "claude-sonnet-4-5",
                     "max_tokens": 1024,
                     "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True
-                }
+                    "stream": True,
+                },
             )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_stop_sequences(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies stop_sequences parameter is accepted.
@@ -759,13 +698,13 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "stop_sequences": ["END", "STOP"]
-            }
+                "stop_sequences": ["END", "STOP"],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_metadata(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies metadata parameter is accepted.
@@ -779,10 +718,10 @@ class TestMessagesOptionalParams:
                 "model": "claude-sonnet-4-5",
                 "max_tokens": 1024,
                 "messages": [{"role": "user", "content": "Hello"}],
-                "metadata": {"user_id": "test_user"}
-            }
+                "metadata": {"user_id": "test_user"},
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -791,9 +730,10 @@ class TestMessagesOptionalParams:
 # Tests for /v1/messages anthropic-version header
 # =============================================================================
 
+
 class TestMessagesAnthropicVersion:
     """Tests for anthropic-version header handling."""
-    
+
     def test_accepts_anthropic_version_header(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies anthropic-version header is accepted.
@@ -802,21 +742,14 @@ class TestMessagesAnthropicVersion:
         print("Action: POST /v1/messages with anthropic-version header...")
         response = test_client.post(
             "/v1/messages",
-            headers={
-                "x-api-key": valid_proxy_api_key,
-                "anthropic-version": "2023-06-01"
-            },
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            headers={"x-api-key": valid_proxy_api_key, "anthropic-version": "2023-06-01"},
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_works_without_anthropic_version_header(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies request works without anthropic-version header.
@@ -826,13 +759,9 @@ class TestMessagesAnthropicVersion:
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
@@ -842,9 +771,10 @@ class TestMessagesAnthropicVersion:
 # Tests for router integration
 # =============================================================================
 
+
 class TestAnthropicRouterIntegration:
     """Tests for Anthropic router configuration and integration."""
-    
+
     def test_router_has_messages_endpoint(self):
         """
         What it does: Verifies messages endpoint is registered.
@@ -852,10 +782,10 @@ class TestAnthropicRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/v1/messages" in routes
-    
+
     def test_messages_endpoint_uses_post_method(self):
         """
         What it does: Verifies messages endpoint uses POST method.
@@ -868,7 +798,7 @@ class TestAnthropicRouterIntegration:
                 assert "POST" in route.methods
                 return
         pytest.fail("Messages endpoint not found")
-    
+
     def test_router_has_anthropic_tag(self):
         """
         What it does: Verifies router has Anthropic API tag.
@@ -883,9 +813,10 @@ class TestAnthropicRouterIntegration:
 # Tests for conversation history
 # =============================================================================
 
+
 class TestMessagesConversationHistory:
     """Tests for conversation history handling on /v1/messages endpoint."""
-    
+
     def test_accepts_multi_turn_conversation(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multi-turn conversation is accepted.
@@ -901,14 +832,14 @@ class TestMessagesConversationHistory:
                 "messages": [
                     {"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi there!"},
-                    {"role": "user", "content": "How are you?"}
-                ]
-            }
+                    {"role": "user", "content": "How are you?"},
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_long_conversation(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies long conversation is accepted.
@@ -920,17 +851,13 @@ class TestMessagesConversationHistory:
             messages.append({"role": "user", "content": f"Message {i}"})
             messages.append({"role": "assistant", "content": f"Response {i}"})
         messages.append({"role": "user", "content": "Final question"})
-        
+
         response = test_client.post(
             "/v1/messages",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": messages
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": messages},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -939,9 +866,10 @@ class TestMessagesConversationHistory:
 # Tests for error response format
 # =============================================================================
 
+
 class TestMessagesErrorFormat:
     """Tests for error response format on /v1/messages endpoint."""
-    
+
     def test_validation_error_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies validation error response format.
@@ -954,13 +882,13 @@ class TestMessagesErrorFormat:
             json={
                 "model": "claude-sonnet-4-5"
                 # Missing required fields
-            }
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
         assert response.status_code == 422
-    
+
     def test_auth_error_format_is_anthropic_style(self, test_client):
         """
         What it does: Verifies auth error follows Anthropic format.
@@ -969,17 +897,13 @@ class TestMessagesErrorFormat:
         print("Action: POST /v1/messages without auth...")
         response = test_client.post(
             "/v1/messages",
-            json={
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 1024,
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
         assert response.status_code == 401
-        
+
         # Check Anthropic error format
         data = response.json()
         assert "detail" in data
@@ -992,36 +916,30 @@ class TestMessagesErrorFormat:
 # Tests for HTTP client selection (issue #54)
 # =============================================================================
 
+
 class TestAnthropicHTTPClientSelection:
     """
     Tests for HTTP client selection in Anthropic routes (issue #54).
-    
+
     Verifies that streaming requests use per-request clients to avoid CLOSE_WAIT leak
     when network interface changes (VPN disconnect/reconnect), while non-streaming
     requests use shared client for connection pooling.
     """
-    
-    @patch('kiro.routes_anthropic.KiroHttpClient')
-    def test_streaming_uses_per_request_client(
-        self,
-        mock_kiro_http_client_class,
-        test_client,
-        valid_proxy_api_key
-    ):
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    def test_streaming_uses_per_request_client(self, mock_kiro_http_client_class, test_client, valid_proxy_api_key):
         """
         What it does: Verifies streaming requests create per-request HTTP client.
         Purpose: Prevent CLOSE_WAIT leak on VPN disconnect (issue #54).
         """
         print("\n--- Test: Anthropic streaming uses per-request client ---")
-        
+
         # Setup mock
         mock_client_instance = AsyncMock()
-        mock_client_instance.request_with_retry = AsyncMock(
-            side_effect=Exception("Network blocked")
-        )
+        mock_client_instance.request_with_retry = AsyncMock(side_effect=Exception("Network blocked"))
         mock_client_instance.close = AsyncMock()
         mock_kiro_http_client_class.return_value = mock_client_instance
-        
+
         print("Action: POST /v1/messages with stream=true...")
         try:
             test_client.post(
@@ -1031,41 +949,33 @@ class TestAnthropicHTTPClientSelection:
                     "model": "claude-sonnet-4-5",
                     "max_tokens": 100,
                     "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True
-                }
+                    "stream": True,
+                },
             )
         except Exception:
             pass
-        
+
         print("Checking: KiroHttpClient(shared_client=None)...")
         assert mock_kiro_http_client_class.called
         call_args = mock_kiro_http_client_class.call_args
         print(f"Call args: {call_args}")
-        assert call_args[1]['shared_client'] is None, \
-            "Streaming should use per-request client"
+        assert call_args[1]["shared_client"] is None, "Streaming should use per-request client"
         print("✅ Anthropic streaming correctly uses per-request client")
-    
-    @patch('kiro.routes_anthropic.KiroHttpClient')
-    def test_non_streaming_uses_shared_client(
-        self,
-        mock_kiro_http_client_class,
-        test_client,
-        valid_proxy_api_key
-    ):
+
+    @patch("kiro.routes_anthropic.KiroHttpClient")
+    def test_non_streaming_uses_shared_client(self, mock_kiro_http_client_class, test_client, valid_proxy_api_key):
         """
         What it does: Verifies non-streaming requests use shared HTTP client.
         Purpose: Ensure connection pooling for non-streaming requests.
         """
         print("\n--- Test: Anthropic non-streaming uses shared client ---")
-        
+
         # Setup mock
         mock_client_instance = AsyncMock()
-        mock_client_instance.request_with_retry = AsyncMock(
-            side_effect=Exception("Network blocked")
-        )
+        mock_client_instance.request_with_retry = AsyncMock(side_effect=Exception("Network blocked"))
         mock_client_instance.close = AsyncMock()
         mock_kiro_http_client_class.return_value = mock_client_instance
-        
+
         print("Action: POST /v1/messages with stream=false...")
         try:
             test_client.post(
@@ -1075,18 +985,17 @@ class TestAnthropicHTTPClientSelection:
                     "model": "claude-sonnet-4-5",
                     "max_tokens": 100,
                     "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": False
-                }
+                    "stream": False,
+                },
             )
         except Exception:
             pass
-        
+
         print("Checking: KiroHttpClient(shared_client=app.state.http_client)...")
         assert mock_kiro_http_client_class.called
         call_args = mock_kiro_http_client_class.call_args
         print(f"Call args: {call_args}")
-        assert call_args[1]['shared_client'] is not None, \
-            "Non-streaming should use shared client"
+        assert call_args[1]["shared_client"] is not None, "Non-streaming should use shared client"
         print("✅ Anthropic non-streaming correctly uses shared client")
 
 
@@ -1094,9 +1003,10 @@ class TestAnthropicHTTPClientSelection:
 # Tests for Truncation Recovery message modification (Issue #56)
 # =============================================================================
 
+
 class TestWebSearchAutoInjection:
     """Tests for WebSearch auto-injection (Path B - MCP Tool Emulation)."""
-    
+
     def test_auto_injection_logic(self, monkeypatch):
         """
         What it does: Verifies web_search tool auto-injection logic.
@@ -1104,36 +1014,31 @@ class TestWebSearchAutoInjection:
         """
         print("Setup: Testing auto-injection logic...")
         from kiro.models_anthropic import AnthropicTool
-        
+
         # Simulate auto-injection logic
         WEB_SEARCH_ENABLED = True
         tools = []
-        
+
         if WEB_SEARCH_ENABLED:
-            has_ws = any(
-                getattr(tool, "name", "") == "web_search"
-                for tool in tools
-            )
-            
+            has_ws = any(getattr(tool, "name", "") == "web_search" for tool in tools)
+
             if not has_ws:
                 web_search_tool = AnthropicTool(
                     name="web_search",
                     description="Search the web for current information. Use when you need up-to-date data from the internet.",
                     input_schema={
                         "type": "object",
-                        "properties": {
-                            "query": {"type": "string", "description": "Search query"}
-                        },
-                        "required": ["query"]
-                    }
+                        "properties": {"query": {"type": "string", "description": "Search query"}},
+                        "required": ["query"],
+                    },
                 )
                 tools.append(web_search_tool)
-        
-        print(f"Checking: web_search tool was added...")
+
+        print("Checking: web_search tool was added...")
         assert len(tools) == 1
         assert tools[0].name == "web_search"
         assert tools[0].input_schema is not None
-    
+
     def test_no_duplicate_injection_logic(self):
         """
         What it does: Verifies duplicate detection logic.
@@ -1141,41 +1046,38 @@ class TestWebSearchAutoInjection:
         """
         print("Setup: Testing duplicate detection...")
         from kiro.models_anthropic import AnthropicTool
-        
+
         # Simulate existing web_search tool
         existing_tools = [
             AnthropicTool(
-                name="web_search",
-                description="Existing web search",
-                input_schema={"type": "object", "properties": {}}
+                name="web_search", description="Existing web search", input_schema={"type": "object", "properties": {}}
             )
         ]
-        
+
         # Simulate auto-injection logic with duplicate check
         WEB_SEARCH_ENABLED = True
-        
+
         if WEB_SEARCH_ENABLED:
-            has_ws = any(
-                getattr(tool, "name", "") == "web_search"
-                for tool in existing_tools
-            )
-            
+            has_ws = any(getattr(tool, "name", "") == "web_search" for tool in existing_tools)
+
             if not has_ws:
                 # Would add web_search here
-                existing_tools.append(AnthropicTool(
-                    name="web_search",
-                    description="Auto-injected",
-                    input_schema={"type": "object", "properties": {}}
-                ))
-        
-        print(f"Checking: Only one web_search tool...")
+                existing_tools.append(
+                    AnthropicTool(
+                        name="web_search",
+                        description="Auto-injected",
+                        input_schema={"type": "object", "properties": {}},
+                    )
+                )
+
+        print("Checking: Only one web_search tool...")
         web_search_count = sum(1 for t in existing_tools if t.name == "web_search")
         assert web_search_count == 1
 
 
 class TestWebSearchNativeDetection:
     """Tests for native Anthropic server-side tools detection (Path A)."""
-    
+
     def test_native_tool_type_detection(self):
         """
         What it does: Verifies detection of native server-side tools by type field.
@@ -1183,15 +1085,9 @@ class TestWebSearchNativeDetection:
         """
         print("Setup: Creating tools list with native server-side tool...")
         from kiro.models_anthropic import AnthropicTool
-        
-        tools = [
-            AnthropicTool(
-                type="web_search_20250305",
-                name="web_search",
-                max_uses=8
-            )
-        ]
-        
+
+        tools = [AnthropicTool(type="web_search_20250305", name="web_search", max_uses=8)]
+
         print("Action: Checking for native web_search...")
         has_native_web_search = False
         for tool in tools:
@@ -1199,10 +1095,10 @@ class TestWebSearchNativeDetection:
             if tool_type and tool_type.startswith("web_search"):
                 has_native_web_search = True
                 break
-        
-        print(f"Checking: Native web_search detected...")
+
+        print("Checking: Native web_search detected...")
         assert has_native_web_search is True
-    
+
     def test_user_defined_tool_not_detected_as_native(self):
         """
         What it does: Verifies user-defined tools are not detected as native.
@@ -1210,15 +1106,15 @@ class TestWebSearchNativeDetection:
         """
         print("Setup: Creating tools list with user-defined tool...")
         from kiro.models_anthropic import AnthropicTool
-        
+
         tools = [
             AnthropicTool(
                 name="web_search",
                 description="User-defined web search",
-                input_schema={"type": "object", "properties": {}}
+                input_schema={"type": "object", "properties": {}},
             )
         ]
-        
+
         print("Action: Checking for native web_search...")
         has_native_web_search = False
         for tool in tools:
@@ -1226,8 +1122,8 @@ class TestWebSearchNativeDetection:
             if tool_type and tool_type.startswith("web_search"):
                 has_native_web_search = True
                 break
-        
-        print(f"Checking: Native web_search NOT detected...")
+
+        print("Checking: Native web_search NOT detected...")
         assert has_native_web_search is False
 
 
@@ -1235,9 +1131,10 @@ class TestWebSearchNativeDetection:
 # Tests for Account System Failover Loop
 # ==================================================================================================
 
+
 class TestMessagesFailoverLoop:
     """Tests for Account System failover loop in /v1/messages endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_get_next_account(self):
         """
@@ -1246,21 +1143,21 @@ class TestMessagesFailoverLoop:
         """
         print("Setup: Mock AccountManager with get_next_account...")
         from unittest.mock import AsyncMock
-        
+
         mock_manager = AsyncMock()
         mock_manager.get_next_account = AsyncMock(return_value=None)
-        
+
         model = "claude-opus-4.5"
         exclude_accounts = {"account1", "account2"}
-        
+
         print("Action: Calling get_next_account with exclude_accounts...")
-        result = await mock_manager.get_next_account(model, exclude_accounts=exclude_accounts)
-        
+        await mock_manager.get_next_account(model, exclude_accounts=exclude_accounts)
+
         print("Checking: get_next_account was called with correct parameters...")
         mock_manager.get_next_account.assert_called_once_with(model, exclude_accounts=exclude_accounts)
-        
+
         print("✅ get_next_account called with exclude_accounts")
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_success_first_account(self):
         """
@@ -1268,28 +1165,29 @@ class TestMessagesFailoverLoop:
         Purpose: Ensure failover loop returns immediately on success.
         """
         print("Setup: Mock successful response on first account...")
+        from unittest.mock import AsyncMock
+
         from kiro.account_manager import Account, AccountStats
-        from unittest.mock import AsyncMock, MagicMock, patch
-        
+
         # Create mock account
         account = Account(
             id="account1",
             auth_manager=MagicMock(),
             model_cache=MagicMock(),
             model_resolver=MagicMock(),
-            stats=AccountStats()
+            stats=AccountStats(),
         )
         account.auth_manager.api_host = "https://api.example.com"
-        
+
         mock_manager = AsyncMock()
         mock_manager.get_next_account = AsyncMock(return_value=account)
         mock_manager.report_success = AsyncMock()
         mock_manager._accounts = {"account1": account}
-        
+
         print("Checking: Success on first attempt...")
         # Verify that report_success is called and no retry happens
         assert True  # Placeholder
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_recoverable_try_next(self):
         """
@@ -1298,17 +1196,17 @@ class TestMessagesFailoverLoop:
         """
         print("Setup: Mock RECOVERABLE error (429 rate limit)...")
         from kiro.account_errors import ErrorType, classify_error
-        
+
         # Test classification
         error_type = classify_error(429, None)
-        
-        print(f"Checking: 429 classified as RECOVERABLE...")
+
+        print("Checking: 429 classified as RECOVERABLE...")
         assert error_type == ErrorType.RECOVERABLE
-        
+
         print("Checking: Failover loop would continue to next account...")
         # In real implementation, loop continues after report_failure
         assert True
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_fatal_immediate_return(self):
         """
@@ -1317,17 +1215,17 @@ class TestMessagesFailoverLoop:
         """
         print("Setup: Mock FATAL error (400 CONTENT_LENGTH_EXCEEDS_THRESHOLD)...")
         from kiro.account_errors import ErrorType, classify_error
-        
+
         # Test classification
         error_type = classify_error(400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD")
-        
-        print(f"Checking: 400 + CONTENT_LENGTH classified as FATAL...")
+
+        print("Checking: 400 + CONTENT_LENGTH classified as FATAL...")
         assert error_type == ErrorType.FATAL
-        
+
         print("Checking: Failover loop would stop and return error...")
         # In real implementation, error is returned immediately
         assert True
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_single_account_original_error(self):
         """
@@ -1335,20 +1233,20 @@ class TestMessagesFailoverLoop:
         Purpose: Ensure single account mode shows specific errors.
         """
         print("Setup: Single account with error...")
-        
+
         # Single account should return original error, not generic
         all_accounts = ["account1"]
         last_error_message = "Token expired"
         last_error_status = 403
-        
+
         print("Checking: Single account returns specific error...")
         if len(all_accounts) == 1:
             # Should return last_error_message with last_error_status
             assert last_error_message == "Token expired"
             assert last_error_status == 403
-        
+
         print("✅ Single account returns original error")
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_multi_account_generic_error(self):
         """
@@ -1356,23 +1254,23 @@ class TestMessagesFailoverLoop:
         Purpose: Ensure multi-account mode doesn't expose account details.
         """
         print("Setup: Multiple accounts all failed...")
-        
+
         # Multiple accounts should return generic error
         all_accounts = ["account1", "account2", "account3"]
         last_error_message = "Token expired on account1"
-        
+
         print("Checking: Multi-account returns generic error...")
         if len(all_accounts) > 1:
             # Should return generic message with context
             generic_message = "No available accounts for this model."
             if last_error_message:
                 generic_message += f" Error from last account: {last_error_message}"
-            
+
             assert "No available accounts" in generic_message
             assert last_error_message in generic_message
-        
+
         print("✅ Multi-account returns generic error with context")
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_all_unavailable(self):
         """
@@ -1381,21 +1279,21 @@ class TestMessagesFailoverLoop:
         """
         print("Setup: All accounts unavailable...")
         from unittest.mock import AsyncMock
-        
+
         mock_manager = AsyncMock()
         mock_manager.get_next_account = AsyncMock(return_value=None)
         mock_manager._accounts = {"acc1": None, "acc2": None}
-        
+
         print("Action: get_next_account returns None...")
         account = await mock_manager.get_next_account("claude-opus-4.5", exclude_accounts=set())
-        
+
         print("Checking: None returned...")
         assert account is None
-        
+
         print("Checking: Would return 503 error...")
         # In real implementation, returns 503 with appropriate message
         assert True
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_report_success(self):
         """
@@ -1404,21 +1302,21 @@ class TestMessagesFailoverLoop:
         """
         print("Setup: Mock successful request...")
         from unittest.mock import AsyncMock
-        
+
         mock_manager = AsyncMock()
         mock_manager.report_success = AsyncMock()
-        
+
         account_id = "test_account"
         model = "claude-opus-4.5"
-        
+
         print("Action: Calling report_success...")
         await mock_manager.report_success(account_id, model)
-        
+
         print("Checking: report_success was called...")
         mock_manager.report_success.assert_called_once_with(account_id, model)
-        
+
         print("✅ report_success called on success")
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_report_failure(self):
         """
@@ -1426,28 +1324,27 @@ class TestMessagesFailoverLoop:
         Purpose: Ensure failure tracking works correctly.
         """
         print("Setup: Mock failed request...")
-        from kiro.account_errors import ErrorType
         from unittest.mock import AsyncMock
-        
+
+        from kiro.account_errors import ErrorType
+
         mock_manager = AsyncMock()
         mock_manager.report_failure = AsyncMock()
-        
+
         account_id = "test_account"
         model = "claude-opus-4.5"
         error_type = ErrorType.RECOVERABLE
         status_code = 429
         reason = None
-        
+
         print("Action: Calling report_failure...")
         await mock_manager.report_failure(account_id, model, error_type, status_code, reason)
-        
+
         print("Checking: report_failure was called...")
-        mock_manager.report_failure.assert_called_once_with(
-            account_id, model, error_type, status_code, reason
-        )
-        
+        mock_manager.report_failure.assert_called_once_with(account_id, model, error_type, status_code, reason)
+
         print("✅ report_failure called on error")
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_exclude_tried_accounts(self):
         """
@@ -1455,23 +1352,23 @@ class TestMessagesFailoverLoop:
         Purpose: Ensure accounts aren't retried in same failover loop.
         """
         print("Setup: Simulating multiple attempts...")
-        
+
         tried_accounts = set()
         accounts = ["acc1", "acc2", "acc3"]
-        
+
         print("Action: Adding accounts to exclude set...")
         for account_id in accounts:
             tried_accounts.add(account_id)
             print(f"  Tried: {tried_accounts}")
-        
+
         print("Checking: All accounts in exclude set...")
         assert len(tried_accounts) == 3
         assert "acc1" in tried_accounts
         assert "acc2" in tried_accounts
         assert "acc3" in tried_accounts
-        
+
         print("✅ exclude_accounts grows correctly")
-    
+
     @pytest.mark.asyncio
     async def test_messages_failover_max_attempts(self):
         """
@@ -1479,13 +1376,13 @@ class TestMessagesFailoverLoop:
         Purpose: Ensure infinite loops are prevented.
         """
         print("Setup: Calculating MAX_ATTEMPTS...")
-        
+
         all_accounts = ["acc1", "acc2", "acc3"]
         MAX_ATTEMPTS = len(all_accounts) * 2  # Full circle with margin
-        
+
         print(f"Checking: MAX_ATTEMPTS = {MAX_ATTEMPTS}...")
         assert MAX_ATTEMPTS == 6
-        
+
         print("Checking: Loop would stop after 6 attempts...")
         # In real implementation, for loop has range(MAX_ATTEMPTS)
         attempts = 0
@@ -1493,14 +1390,14 @@ class TestMessagesFailoverLoop:
             attempts += 1
             if attempts >= MAX_ATTEMPTS:
                 break
-        
+
         assert attempts == MAX_ATTEMPTS
         print("✅ MAX_ATTEMPTS prevents infinite loops")
 
 
 class TestMessagesLegacyMode:
     """Tests for legacy mode (ACCOUNT_SYSTEM=false) in /v1/messages endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_messages_legacy_get_first_account(self):
         """
@@ -1509,29 +1406,28 @@ class TestMessagesLegacyMode:
         """
         print("Setup: Mock legacy mode (account_system=false)...")
         from kiro.account_manager import Account, AccountStats
-        from unittest.mock import MagicMock
-        
+
         # Create mock account
         account = Account(
             id="legacy_account",
             auth_manager=MagicMock(),
             model_cache=MagicMock(),
             model_resolver=MagicMock(),
-            stats=AccountStats()
+            stats=AccountStats(),
         )
-        
+
         mock_manager = MagicMock()
         mock_manager.get_first_account = MagicMock(return_value=account)
-        
+
         print("Action: Calling get_first_account...")
         result = mock_manager.get_first_account()
-        
+
         print("Checking: get_first_account was called...")
         mock_manager.get_first_account.assert_called_once()
         assert result == account
-        
+
         print("✅ Legacy mode uses get_first_account()")
-    
+
     @pytest.mark.asyncio
     async def test_messages_legacy_no_failover(self):
         """
@@ -1539,9 +1435,9 @@ class TestMessagesLegacyMode:
         Purpose: Ensure legacy mode behavior is unchanged.
         """
         print("Setup: Legacy mode configuration...")
-        
+
         account_system = False
-        
+
         print("Checking: No failover loop in legacy mode...")
         if not account_system:
             # Legacy path: get_first_account() → direct request → return
@@ -1550,13 +1446,13 @@ class TestMessagesLegacyMode:
             print("  ✓ No failover loop")
             print("  ✓ Returns original error")
             assert True
-        
+
         print("✅ Legacy mode has no failover")
 
 
 class TestMessagesNativeWebSearchAccountSelection:
     """Tests for native WebSearch account selection in /v1/messages endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_messages_native_websearch_get_first_account(self):
         """
@@ -1564,40 +1460,35 @@ class TestMessagesNativeWebSearchAccountSelection:
         Purpose: Ensure Path A doesn't use failover (early return).
         """
         print("Setup: Mock native WebSearch request...")
-        from kiro.models_anthropic import AnthropicTool
         from kiro.account_manager import Account, AccountStats
-        from unittest.mock import MagicMock
-        
+        from kiro.models_anthropic import AnthropicTool
+
         # Create tool with native server-side type
-        native_tool = AnthropicTool(
-            type="web_search_20250305",
-            name="web_search",
-            max_uses=8
-        )
-        
+        native_tool = AnthropicTool(type="web_search_20250305", name="web_search", max_uses=8)
+
         print("Checking: Tool has native type...")
         assert native_tool.type.startswith("web_search")
-        
+
         print("Setup: Mock AccountManager...")
         account = Account(
             id="websearch_account",
             auth_manager=MagicMock(),
             model_cache=MagicMock(),
             model_resolver=MagicMock(),
-            stats=AccountStats()
+            stats=AccountStats(),
         )
-        
+
         mock_manager = MagicMock()
         mock_manager.get_first_account = MagicMock(return_value=account)
-        
+
         print("Action: Path A early return uses get_first_account...")
         # In real implementation, Path A returns early before failover loop
         result = mock_manager.get_first_account()
-        
+
         print("Checking: get_first_account was called...")
         mock_manager.get_first_account.assert_called_once()
         assert result == account
-        
+
         print("✅ Native WebSearch uses get_first_account() (no failover)")
 
 
@@ -1605,43 +1496,39 @@ class TestMessagesNativeWebSearchAccountSelection:
 # Tests for /v1/messages/count_tokens endpoint
 # ==================================================================================================
 
+
 class TestCountTokensEndpoint:
     """Tests for /v1/messages/count_tokens endpoint."""
-    
+
     def test_count_tokens_basic(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests basic token counting with one message.
         Purpose: Ensure endpoint returns token count for simple request.
         """
         print("Setup: Creating basic request with one message...")
-        request_data = {
-            "model": "claude-sonnet-4-5",
-            "messages": [{"role": "user", "content": "Hello, world!"}]
-        }
-        
+        request_data = {"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello, world!"}]}
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200...")
         assert response.status_code == 200
-        
+
         print("Checking: Response structure...")
         data = response.json()
         assert "input_tokens" in data
-        
+
         print("Checking: input_tokens is int and > 0...")
         assert isinstance(data["input_tokens"], int)
         assert data["input_tokens"] > 0
-        
+
         print(f"✅ Token count: {data['input_tokens']} tokens")
-    
+
     def test_count_tokens_with_tools(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests token counting with tool definitions.
@@ -1651,50 +1538,47 @@ class TestCountTokensEndpoint:
         request_data = {
             "model": "claude-sonnet-4-5",
             "messages": [{"role": "user", "content": "What's the weather?"}],
-            "tools": [{
-                "name": "get_weather",
-                "description": "Get weather for location",
-                "input_schema": {
-                    "type": "object",
-                    "properties": {"location": {"type": "string"}},
-                    "required": ["location"]
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather for location",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
                 }
-            }]
+            ],
         }
-        
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200...")
         assert response.status_code == 200
-        
+
         print("Checking: Token count includes tools...")
         data = response.json()
         tokens_with_tools = data["input_tokens"]
-        
+
         # Compare with request without tools
         response_no_tools = test_client.post(
             "/v1/messages/count_tokens",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "What's the weather?"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "What's the weather?"}]},
         )
         tokens_no_tools = response_no_tools.json()["input_tokens"]
-        
+
         print(f"Tokens with tools: {tokens_with_tools}, without tools: {tokens_no_tools}")
         assert tokens_with_tools > tokens_no_tools
-        
+
         print("✅ Tools increase token count")
-    
+
     def test_count_tokens_with_system_string(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests token counting with system prompt (string format).
@@ -1704,42 +1588,37 @@ class TestCountTokensEndpoint:
         request_data = {
             "model": "claude-sonnet-4-5",
             "messages": [{"role": "user", "content": "Hello"}],
-            "system": "You are a helpful assistant."
+            "system": "You are a helpful assistant.",
         }
-        
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200...")
         assert response.status_code == 200
-        
+
         print("Checking: Token count includes system prompt...")
         data = response.json()
         tokens_with_system = data["input_tokens"]
-        
+
         # Compare with request without system
         response_no_system = test_client.post(
             "/v1/messages/count_tokens",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
         tokens_no_system = response_no_system.json()["input_tokens"]
-        
+
         print(f"Tokens with system: {tokens_with_system}, without system: {tokens_no_system}")
         assert tokens_with_system > tokens_no_system
-        
+
         print("✅ System prompt increases token count")
-    
+
     def test_count_tokens_with_system_blocks(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests token counting with system prompt (list format for prompt caching).
@@ -1751,88 +1630,76 @@ class TestCountTokensEndpoint:
             "messages": [{"role": "user", "content": "Hello"}],
             "system": [
                 {"type": "text", "text": "You are a helpful assistant."},
-                {"type": "text", "text": "Be concise.", "cache_control": {"type": "ephemeral"}}
-            ]
+                {"type": "text", "text": "Be concise.", "cache_control": {"type": "ephemeral"}},
+            ],
         }
-        
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200...")
         assert response.status_code == 200
-        
+
         print("Checking: input_tokens > 0...")
         data = response.json()
         assert data["input_tokens"] > 0
-        
+
         print(f"✅ System blocks counted: {data['input_tokens']} tokens")
-    
+
     def test_count_tokens_empty_messages(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests validation with empty messages array.
         Purpose: Ensure at least one message is required (Pydantic validation).
         """
         print("Setup: Creating request with empty messages...")
-        request_data = {
-            "model": "claude-sonnet-4-5",
-            "messages": []
-        }
-        
+        request_data = {"model": "claude-sonnet-4-5", "messages": []}
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 422 (validation error)...")
         assert response.status_code == 422
-        
+
         print("✅ Empty messages rejected")
-    
+
     def test_count_tokens_invalid_api_key(self, test_client, invalid_proxy_api_key):
         """
         What it does: Tests authentication with invalid API key.
         Purpose: Ensure endpoint is protected by authentication.
         """
         print("Setup: Creating request with invalid API key...")
-        request_data = {
-            "model": "claude-sonnet-4-5",
-            "messages": [{"role": "user", "content": "Hello"}]
-        }
-        
+        request_data = {"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]}
+
         print("Action: POST /v1/messages/count_tokens with invalid key...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": invalid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": invalid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 401 (unauthorized)...")
         assert response.status_code == 401
-        
+
         print("Checking: Error format is Anthropic-style...")
         data = response.json()
         assert "detail" in data
         detail = data["detail"]
         assert "error" in detail
         assert detail["error"]["type"] == "authentication_error"
-        
+
         print("✅ Invalid API key rejected")
-    
+
     def test_count_tokens_multiple_messages(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests token counting for dialogue with history.
@@ -1844,43 +1711,38 @@ class TestCountTokensEndpoint:
             "messages": [
                 {"role": "user", "content": "Hello"},
                 {"role": "assistant", "content": "Hi there!"},
-                {"role": "user", "content": "How are you?"}
-            ]
+                {"role": "user", "content": "How are you?"},
+            ],
         }
-        
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200...")
         assert response.status_code == 200
-        
+
         print("Checking: Token count for multiple messages...")
         data = response.json()
         tokens_multi = data["input_tokens"]
-        
+
         # Compare with single message
         response_single = test_client.post(
             "/v1/messages/count_tokens",
             headers={"x-api-key": valid_proxy_api_key},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
         tokens_single = response_single.json()["input_tokens"]
-        
+
         print(f"Tokens multi: {tokens_multi}, single: {tokens_single}")
         assert tokens_multi > tokens_single
-        
+
         print("✅ Multiple messages increase token count")
-    
+
     def test_count_tokens_with_images(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests token counting for messages with images.
@@ -1889,58 +1751,55 @@ class TestCountTokensEndpoint:
         print("Setup: Creating request with image...")
         request_data = {
             "model": "claude-sonnet-4-5",
-            "messages": [{
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "What's in this image?"},
-                    {
-                        "type": "image",
-                        "source": {
-                            "type": "base64",
-                            "media_type": "image/jpeg",
-                            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
-                        }
-                    }
-                ]
-            }]
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What's in this image?"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                            },
+                        },
+                    ],
+                }
+            ],
         }
-        
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200...")
         assert response.status_code == 200
-        
+
         print("Checking: Image adds tokens...")
         data = response.json()
         tokens_with_image = data["input_tokens"]
-        
+
         # Compare with text-only
         response_text_only = test_client.post(
             "/v1/messages/count_tokens",
             headers={"x-api-key": valid_proxy_api_key},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{
-                    "role": "user",
-                    "content": [{"type": "text", "text": "What's in this image?"}]
-                }]
-            }
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "What's in this image?"}]}],
+            },
         )
         tokens_text_only = response_text_only.json()["input_tokens"]
-        
+
         print(f"Tokens with image: {tokens_with_image}, text only: {tokens_text_only}")
         assert tokens_with_image > tokens_text_only
-        
+
         print("✅ Image increases token count")
-    
+
     def test_count_tokens_consistency(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests deterministic behavior - same input gives same output.
@@ -1949,38 +1808,34 @@ class TestCountTokensEndpoint:
         print("Setup: Creating identical requests...")
         request_data = {
             "model": "claude-sonnet-4-5",
-            "messages": [{"role": "user", "content": "Test message for consistency"}]
+            "messages": [{"role": "user", "content": "Test message for consistency"}],
         }
-        
+
         print("Action: Sending same request twice...")
         response1 = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         response2 = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Response 1: {response1.json()}")
         print(f"Response 2: {response2.json()}")
-        
+
         print("Checking: Both requests successful...")
         assert response1.status_code == 200
         assert response2.status_code == 200
-        
+
         print("Checking: Token counts are identical...")
         tokens1 = response1.json()["input_tokens"]
         tokens2 = response2.json()["input_tokens"]
-        
+
         print(f"Tokens 1: {tokens1}, Tokens 2: {tokens2}")
         assert tokens1 == tokens2
-        
+
         print("✅ Token counting is deterministic")
-    
+
     def test_count_tokens_no_max_tokens_required(self, test_client, valid_proxy_api_key):
         """
         What it does: Tests that max_tokens is NOT required (unlike /v1/messages).
@@ -1989,26 +1844,24 @@ class TestCountTokensEndpoint:
         print("Setup: Creating request WITHOUT max_tokens...")
         request_data = {
             "model": "claude-sonnet-4-5",
-            "messages": [{"role": "user", "content": "Hello"}]
+            "messages": [{"role": "user", "content": "Hello"}],
             # Intentionally NO max_tokens field
         }
-        
+
         print("Action: POST /v1/messages/count_tokens...")
         response = test_client.post(
-            "/v1/messages/count_tokens",
-            headers={"x-api-key": valid_proxy_api_key},
-            json=request_data
+            "/v1/messages/count_tokens", headers={"x-api-key": valid_proxy_api_key}, json=request_data
         )
-        
+
         print(f"Status: {response.status_code}")
         print(f"Response: {response.json()}")
-        
+
         print("Checking: HTTP 200 (NOT 422)...")
         assert response.status_code == 200
-        
+
         print("Checking: Token count returned...")
         data = response.json()
         assert "input_tokens" in data
         assert data["input_tokens"] > 0
-        
+
         print("✅ max_tokens is NOT required for count_tokens")

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -13,26 +12,23 @@ Tests the following endpoints:
 For Anthropic API tests, see test_routes_anthropic.py.
 """
 
-import pytest
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
-from datetime import datetime, timezone
-import json
 import time
+from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from fastapi import HTTPException
-from fastapi.testclient import TestClient
 
-from kiro.routes_openai import verify_api_key, router
-from kiro.config import PROXY_API_KEY, APP_VERSION
-
+from kiro.config import APP_VERSION, PROXY_API_KEY
+from kiro.routes_openai import router, verify_api_key
 
 # =============================================================================
 # Tests for verify_api_key function
 # =============================================================================
 
+
 class TestVerifyApiKey:
     """Tests for the verify_api_key authentication function."""
-    
+
     @pytest.mark.asyncio
     async def test_valid_bearer_token_returns_true(self):
         """
@@ -41,13 +37,13 @@ class TestVerifyApiKey:
         """
         print("Setup: Creating valid Bearer token...")
         valid_header = f"Bearer {PROXY_API_KEY}"
-        
+
         print("Action: Calling verify_api_key...")
         result = await verify_api_key(valid_header)
-        
+
         print(f"Comparing result: Expected True, Got {result}")
         assert result is True
-    
+
     @pytest.mark.asyncio
     async def test_invalid_api_key_raises_401(self):
         """
@@ -56,15 +52,15 @@ class TestVerifyApiKey:
         """
         print("Setup: Creating invalid Bearer token...")
         invalid_header = "Bearer wrong_key_12345"
-        
+
         print("Action: Calling verify_api_key with invalid key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(invalid_header)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
         assert "Invalid or missing API Key" in exc_info.value.detail
-    
+
     @pytest.mark.asyncio
     async def test_missing_api_key_raises_401(self):
         """
@@ -72,14 +68,14 @@ class TestVerifyApiKey:
         Purpose: Ensure requests without authentication are blocked.
         """
         print("Setup: No API key provided...")
-        
+
         print("Action: Calling verify_api_key with None...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(None)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_empty_api_key_raises_401(self):
         """
@@ -87,14 +83,14 @@ class TestVerifyApiKey:
         Purpose: Ensure empty credentials are blocked.
         """
         print("Setup: Empty API key...")
-        
+
         print("Action: Calling verify_api_key with empty string...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key("")
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_key_without_bearer_prefix_raises_401(self):
         """
@@ -103,14 +99,14 @@ class TestVerifyApiKey:
         """
         print("Setup: API key without Bearer prefix...")
         wrong_format = PROXY_API_KEY  # Without "Bearer "
-        
+
         print("Action: Calling verify_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(wrong_format)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_bearer_with_extra_spaces_raises_401(self):
         """
@@ -119,14 +115,14 @@ class TestVerifyApiKey:
         """
         print("Setup: Bearer token with extra spaces...")
         malformed = f"Bearer  {PROXY_API_KEY}"  # Double space
-        
+
         print("Action: Calling verify_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(malformed)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
-    
+
     @pytest.mark.asyncio
     async def test_lowercase_bearer_raises_401(self):
         """
@@ -135,18 +131,19 @@ class TestVerifyApiKey:
         """
         print("Setup: Lowercase bearer prefix...")
         lowercase = f"bearer {PROXY_API_KEY}"
-        
+
         print("Action: Calling verify_api_key...")
         with pytest.raises(HTTPException) as exc_info:
             await verify_api_key(lowercase)
-        
-        print(f"Checking: HTTPException with status 401...")
+
+        print("Checking: HTTPException with status 401...")
         assert exc_info.value.status_code == 401
 
 
 # =============================================================================
 # Tests for root endpoint (/)
 # =============================================================================
+
 
 class TestPublicStatusEndpoint:
     """Tests for the public JSON status endpoint (GET /healthz).
@@ -187,9 +184,10 @@ class TestPublicStatusEndpoint:
 # Tests for health endpoint (/health)
 # =============================================================================
 
+
 class TestHealthEndpoint:
     """Tests for the GET /health endpoint."""
-    
+
     def test_health_returns_healthy_status(self, test_client):
         """
         What it does: Verifies health endpoint returns healthy status.
@@ -197,11 +195,11 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health...")
         response = test_client.get("/health")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["status"] == "healthy"
-    
+
     def test_health_returns_timestamp(self, test_client):
         """
         What it does: Verifies health endpoint returns timestamp.
@@ -209,14 +207,14 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health...")
         response = test_client.get("/health")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert "timestamp" in response.json()
         # Verify timestamp is ISO format
         timestamp = response.json()["timestamp"]
         assert "T" in timestamp  # ISO format contains T
-    
+
     def test_health_returns_version(self, test_client):
         """
         What it does: Verifies health endpoint returns version.
@@ -224,11 +222,11 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health...")
         response = test_client.get("/health")
-        
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["version"] == APP_VERSION
-    
+
     def test_health_does_not_require_auth(self, test_client):
         """
         What it does: Verifies health endpoint is accessible without authentication.
@@ -236,7 +234,7 @@ class TestHealthEndpoint:
         """
         print("Action: GET /health without auth headers...")
         response = test_client.get("/health")
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 200
 
@@ -245,9 +243,10 @@ class TestHealthEndpoint:
 # Tests for models endpoint (/v1/models)
 # =============================================================================
 
+
 class TestModelsEndpoint:
     """Tests for the GET /v1/models endpoint."""
-    
+
     def test_models_requires_authentication(self, test_client):
         """
         What it does: Verifies models endpoint requires authentication.
@@ -255,111 +254,93 @@ class TestModelsEndpoint:
         """
         print("Action: GET /v1/models without auth...")
         response = test_client.get("/v1/models")
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_models_rejects_invalid_key(self, test_client, invalid_proxy_api_key):
         """
         What it does: Verifies models endpoint rejects invalid API key.
         Purpose: Ensure authentication is enforced.
         """
         print("Action: GET /v1/models with invalid key...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {invalid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {invalid_proxy_api_key}"})
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_models_returns_list_object(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies models endpoint returns list object type.
         Purpose: Ensure OpenAI API compatibility.
         """
         print("Action: GET /v1/models with valid auth...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert response.json()["object"] == "list"
-    
+
     def test_models_returns_data_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies models endpoint returns data array.
         Purpose: Ensure response structure matches OpenAI format.
         """
         print("Action: GET /v1/models with valid auth...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
         assert "data" in response.json()
         assert isinstance(response.json()["data"], list)
-    
+
     def test_models_contains_available_models(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies all configured models are returned.
         Purpose: Ensure model list is complete.
         """
         print("Action: GET /v1/models with valid auth...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
-        
+
         model_ids = [m["id"] for m in response.json()["data"]]
         print(f"Model IDs: {model_ids}")
-        
+
         # At minimum, hidden models should be present
         # (even if Kiro API cache is empty)
         assert len(model_ids) >= 1, "Expected at least one model (hidden models)"
-    
+
     def test_models_format_is_openai_compatible(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies model objects have OpenAI-compatible format.
         Purpose: Ensure compatibility with OpenAI clients.
         """
         print("Action: GET /v1/models with valid auth...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
-        
+
         for model in response.json()["data"]:
             print(f"Checking model format: {model}")
             assert "id" in model, "Model missing 'id' field"
             assert "object" in model, "Model missing 'object' field"
             assert model["object"] == "model", "Model object type should be 'model'"
             assert "owned_by" in model, "Model missing 'owned_by' field"
-    
+
     def test_models_owned_by_anthropic(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies models are owned by Anthropic.
         Purpose: Ensure correct model attribution.
         """
         print("Action: GET /v1/models with valid auth...")
-        response = test_client.get(
-            "/v1/models",
-            headers={"Authorization": f"Bearer {valid_proxy_api_key}"}
-        )
-        
+        response = test_client.get("/v1/models", headers={"Authorization": f"Bearer {valid_proxy_api_key}"})
+
         print(f"Result: {response.json()}")
         assert response.status_code == 200
-        
+
         for model in response.json()["data"]:
             assert model["owned_by"] == "anthropic"
 
@@ -368,9 +349,10 @@ class TestModelsEndpoint:
 # Tests for chat completions endpoint (/v1/chat/completions)
 # =============================================================================
 
+
 class TestChatCompletionsAuthentication:
     """Tests for authentication on /v1/chat/completions endpoint."""
-    
+
     def test_chat_completions_requires_authentication(self, test_client):
         """
         What it does: Verifies chat completions requires authentication.
@@ -379,15 +361,12 @@ class TestChatCompletionsAuthentication:
         print("Action: POST /v1/chat/completions without auth...")
         response = test_client.post(
             "/v1/chat/completions",
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
-    
+
     def test_chat_completions_rejects_invalid_key(self, test_client, invalid_proxy_api_key):
         """
         What it does: Verifies chat completions rejects invalid API key.
@@ -397,19 +376,16 @@ class TestChatCompletionsAuthentication:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {invalid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 401
 
 
 class TestChatCompletionsValidation:
     """Tests for request validation on /v1/chat/completions endpoint."""
-    
+
     def test_validates_empty_messages_array(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies empty messages array is rejected.
@@ -419,15 +395,12 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": []
-            }
+            json={"model": "claude-sonnet-4-5", "messages": []},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_model(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing model field is rejected.
@@ -437,14 +410,12 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "messages": [{"role": "user", "content": "Hello"}]
-            }
+            json={"messages": [{"role": "user", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_missing_messages(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies missing messages field is rejected.
@@ -454,14 +425,12 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5"
-            }
+            json={"model": "claude-sonnet-4-5"},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_json(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid JSON is rejected.
@@ -470,16 +439,13 @@ class TestChatCompletionsValidation:
         print("Action: POST /v1/chat/completions with invalid JSON...")
         response = test_client.post(
             "/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {valid_proxy_api_key}",
-                "Content-Type": "application/json"
-            },
-            content=b"not valid json {{{}"
+            headers={"Authorization": f"Bearer {valid_proxy_api_key}", "Content-Type": "application/json"},
+            content=b"not valid json {{{}",
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code == 422
-    
+
     def test_validates_invalid_role(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies invalid message role passes Pydantic validation.
@@ -491,17 +457,14 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "invalid_role", "content": "Hello"}]
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "invalid_role", "content": "Hello"}]},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Pydantic model accepts any string as role, so validation passes (not 422)
         # The request may fail later during processing (500) due to network blocking
         assert response.status_code != 422
-    
+
     def test_accepts_valid_request_format(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies valid request format passes validation.
@@ -511,18 +474,14 @@ class TestChatCompletionsValidation:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "stream": False
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "stream": False},
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation (not 422)
         # May fail on HTTP call due to network blocking, but that's expected
         assert response.status_code != 422
-    
+
     def test_accepts_message_without_content(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies message without content is accepted.
@@ -534,10 +493,10 @@ class TestChatCompletionsValidation:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user"}]  # No content
-            }
+                "messages": [{"role": "user"}],  # No content
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation (content is optional)
         assert response.status_code != 422 or "content" not in str(response.json())
@@ -545,7 +504,7 @@ class TestChatCompletionsValidation:
 
 class TestChatCompletionsWithTools:
     """Tests for tool calling on /v1/chat/completions endpoint."""
-    
+
     def test_accepts_valid_tool_definition(self, test_client, valid_proxy_api_key, sample_tool_definition):
         """
         What it does: Verifies valid tool definition is accepted.
@@ -558,14 +517,14 @@ class TestChatCompletionsWithTools:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "What's the weather?"}],
-                "tools": [sample_tool_definition]
-            }
+                "tools": [sample_tool_definition],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         # Should pass validation
         assert response.status_code != 422
-    
+
     def test_accepts_multiple_tools(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multiple tools are accepted.
@@ -578,36 +537,32 @@ class TestChatCompletionsWithTools:
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             },
             {
                 "type": "function",
                 "function": {
                     "name": "get_time",
                     "description": "Get time",
-                    "parameters": {"type": "object", "properties": {}}
-                }
-            }
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
         ]
-        
+
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "tools": tools
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "tools": tools},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
 
 class TestChatCompletionsOptionalParams:
     """Tests for optional parameters on /v1/chat/completions endpoint."""
-    
+
     def test_accepts_temperature_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies temperature parameter is accepted.
@@ -617,16 +572,12 @@ class TestChatCompletionsOptionalParams:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "temperature": 0.7
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "temperature": 0.7},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_max_tokens_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies max_tokens parameter is accepted.
@@ -636,16 +587,12 @@ class TestChatCompletionsOptionalParams:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "max_tokens": 100
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 100},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_stream_true(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies stream=true is accepted.
@@ -655,16 +602,12 @@ class TestChatCompletionsOptionalParams:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "stream": True
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "stream": True},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_top_p_parameter(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies top_p parameter is accepted.
@@ -674,20 +617,16 @@ class TestChatCompletionsOptionalParams:
         response = test_client.post(
             "/v1/chat/completions",
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-            json={
-                "model": "claude-sonnet-4-5",
-                "messages": [{"role": "user", "content": "Hello"}],
-                "top_p": 0.9
-            }
+            json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "top_p": 0.9},
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
 
 class TestChatCompletionsMessageTypes:
     """Tests for different message types on /v1/chat/completions endpoint."""
-    
+
     def test_accepts_system_message(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies system message is accepted.
@@ -699,16 +638,13 @@ class TestChatCompletionsMessageTypes:
             headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
             json={
                 "model": "claude-sonnet-4-5",
-                "messages": [
-                    {"role": "system", "content": "You are helpful."},
-                    {"role": "user", "content": "Hello"}
-                ]
-            }
+                "messages": [{"role": "system", "content": "You are helpful."}, {"role": "user", "content": "Hello"}],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_assistant_message(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies assistant message is accepted.
@@ -723,14 +659,14 @@ class TestChatCompletionsMessageTypes:
                 "messages": [
                     {"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi there!"},
-                    {"role": "user", "content": "How are you?"}
-                ]
-            }
+                    {"role": "user", "content": "How are you?"},
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
-    
+
     def test_accepts_multipart_content(self, test_client, valid_proxy_api_key):
         """
         What it does: Verifies multipart content array is accepted.
@@ -743,17 +679,11 @@ class TestChatCompletionsMessageTypes:
             json={
                 "model": "claude-sonnet-4-5",
                 "messages": [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": "Hello"},
-                            {"type": "text", "text": "World"}
-                        ]
-                    }
-                ]
-            }
+                    {"role": "user", "content": [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]}
+                ],
+            },
         )
-        
+
         print(f"Status: {response.status_code}")
         assert response.status_code != 422
 
@@ -762,9 +692,10 @@ class TestChatCompletionsMessageTypes:
 # Tests for router integration
 # =============================================================================
 
+
 class TestRouterIntegration:
     """Tests for router configuration and integration."""
-    
+
     def test_router_has_root_endpoint(self):
         """
         What it does: Verifies the public status endpoint is registered.
@@ -772,10 +703,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/healthz" in routes
-    
+
     def test_router_has_health_endpoint(self):
         """
         What it does: Verifies health endpoint is registered.
@@ -783,10 +714,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/health" in routes
-    
+
     def test_router_has_models_endpoint(self):
         """
         What it does: Verifies models endpoint is registered.
@@ -794,10 +725,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/v1/models" in routes
-    
+
     def test_router_has_chat_completions_endpoint(self):
         """
         What it does: Verifies chat completions endpoint is registered.
@@ -805,10 +736,10 @@ class TestRouterIntegration:
         """
         print("Checking: Router endpoints...")
         routes = [route.path for route in router.routes]
-        
+
         print(f"Found routes: {routes}")
         assert "/v1/chat/completions" in routes
-    
+
     def test_root_endpoint_uses_get_method(self):
         """
         What it does: Verifies the public status endpoint uses GET.
@@ -821,7 +752,7 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Public status endpoint not found")
-    
+
     def test_health_endpoint_uses_get_method(self):
         """
         What it does: Verifies health endpoint uses GET method.
@@ -834,7 +765,7 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Health endpoint not found")
-    
+
     def test_models_endpoint_uses_get_method(self):
         """
         What it does: Verifies models endpoint uses GET method.
@@ -847,7 +778,7 @@ class TestRouterIntegration:
                 assert "GET" in route.methods
                 return
         pytest.fail("Models endpoint not found")
-    
+
     def test_chat_completions_endpoint_uses_post_method(self):
         """
         What it does: Verifies chat completions endpoint uses POST method.
@@ -866,79 +797,61 @@ class TestRouterIntegration:
 # Tests for HTTP client selection (issue #54)
 # =============================================================================
 
+
 class TestHTTPClientSelection:
     """
     Tests for HTTP client selection in routes (issue #54).
-    
+
     Verifies that streaming requests use per-request clients to avoid CLOSE_WAIT leak
     when network interface changes (VPN disconnect/reconnect), while non-streaming
     requests use shared client for connection pooling.
     """
-    
-    @patch('kiro.routes_openai.KiroHttpClient')
-    def test_streaming_uses_per_request_client(
-        self,
-        mock_kiro_http_client_class,
-        test_client,
-        valid_proxy_api_key
-    ):
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    def test_streaming_uses_per_request_client(self, mock_kiro_http_client_class, test_client, valid_proxy_api_key):
         """
         What it does: Verifies streaming requests create per-request HTTP client.
         Purpose: Prevent CLOSE_WAIT leak on VPN disconnect (issue #54).
         """
         print("\n--- Test: Streaming uses per-request client ---")
-        
+
         # Setup mock
         mock_client_instance = AsyncMock()
-        mock_client_instance.request_with_retry = AsyncMock(
-            side_effect=Exception("Network blocked")
-        )
+        mock_client_instance.request_with_retry = AsyncMock(side_effect=Exception("Network blocked"))
         mock_client_instance.close = AsyncMock()
         mock_kiro_http_client_class.return_value = mock_client_instance
-        
+
         print("Action: POST with stream=true...")
         try:
             test_client.post(
                 "/v1/chat/completions",
                 headers={"Authorization": f"Bearer {valid_proxy_api_key}"},
-                json={
-                    "model": "claude-sonnet-4-5",
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": True
-                }
+                json={"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "Hello"}], "stream": True},
             )
         except Exception:
             pass
-        
+
         print("Checking: KiroHttpClient(shared_client=None)...")
         assert mock_kiro_http_client_class.called
         call_args = mock_kiro_http_client_class.call_args
         print(f"Call args: {call_args}")
-        assert call_args[1]['shared_client'] is None, \
-            "Streaming should use per-request client"
+        assert call_args[1]["shared_client"] is None, "Streaming should use per-request client"
         print("✅ Streaming correctly uses per-request client")
-    
-    @patch('kiro.routes_openai.KiroHttpClient')
-    def test_non_streaming_uses_shared_client(
-        self,
-        mock_kiro_http_client_class,
-        test_client,
-        valid_proxy_api_key
-    ):
+
+    @patch("kiro.routes_openai.KiroHttpClient")
+    def test_non_streaming_uses_shared_client(self, mock_kiro_http_client_class, test_client, valid_proxy_api_key):
         """
         What it does: Verifies non-streaming requests use shared HTTP client.
         Purpose: Ensure connection pooling for non-streaming requests.
         """
         print("\n--- Test: Non-streaming uses shared client ---")
-        
+
         # Setup mock
         mock_client_instance = AsyncMock()
-        mock_client_instance.request_with_retry = AsyncMock(
-            side_effect=Exception("Network blocked")
-        )
+        mock_client_instance.request_with_retry = AsyncMock(side_effect=Exception("Network blocked"))
         mock_client_instance.close = AsyncMock()
         mock_kiro_http_client_class.return_value = mock_client_instance
-        
+
         print("Action: POST with stream=false...")
         try:
             test_client.post(
@@ -947,18 +860,17 @@ class TestHTTPClientSelection:
                 json={
                     "model": "claude-sonnet-4-5",
                     "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": False
-                }
+                    "stream": False,
+                },
             )
         except Exception:
             pass
-        
+
         print("Checking: KiroHttpClient(shared_client=app.state.http_client)...")
         assert mock_kiro_http_client_class.called
         call_args = mock_kiro_http_client_class.call_args
         print(f"Call args: {call_args}")
-        assert call_args[1]['shared_client'] is not None, \
-            "Non-streaming should use shared client"
+        assert call_args[1]["shared_client"] is not None, "Non-streaming should use shared client"
         print("✅ Non-streaming correctly uses shared client")
 
 
@@ -966,9 +878,10 @@ class TestHTTPClientSelection:
 # Tests for Truncation Recovery message modification (Issue #56)
 # =============================================================================
 
+
 class TestWebSearchAutoInjectionOpenAI:
     """Tests for WebSearch auto-injection in OpenAI endpoint (Path B only)."""
-    
+
     def test_auto_injection_logic_openai(self):
         """
         What it does: Verifies web_search function tool auto-injection logic for OpenAI.
@@ -976,18 +889,18 @@ class TestWebSearchAutoInjectionOpenAI:
         """
         print("Setup: Testing OpenAI auto-injection logic...")
         from kiro.models_openai import Tool, ToolFunction
-        
+
         # Simulate auto-injection logic for OpenAI
         WEB_SEARCH_ENABLED = True
         tools = []
-        
+
         if WEB_SEARCH_ENABLED:
             has_ws = any(
-                getattr(tool, "type", None) == "function" and
-                getattr(getattr(tool, "function", None), "name", None) == "web_search"
+                getattr(tool, "type", None) == "function"
+                and getattr(getattr(tool, "function", None), "name", None) == "web_search"
                 for tool in tools
             )
-            
+
             if not has_ws:
                 web_search_tool = Tool(
                     type="function",
@@ -996,24 +909,19 @@ class TestWebSearchAutoInjectionOpenAI:
                         description="Search the web for current information. Use when you need up-to-date data from the internet.",
                         parameters={
                             "type": "object",
-                            "properties": {
-                                "query": {
-                                    "type": "string",
-                                    "description": "Search query"
-                                }
-                            },
-                            "required": ["query"]
-                        }
-                    )
+                            "properties": {"query": {"type": "string", "description": "Search query"}},
+                            "required": ["query"],
+                        },
+                    ),
                 )
                 tools.append(web_search_tool)
-        
-        print(f"Checking: web_search tool was added...")
+
+        print("Checking: web_search tool was added...")
         assert len(tools) == 1
         assert tools[0].type == "function"
         assert tools[0].function.name == "web_search"
         assert tools[0].function.parameters is not None
-    
+
     def test_no_duplicate_injection_logic_openai(self):
         """
         What it does: Verifies duplicate detection logic for OpenAI format.
@@ -1021,7 +929,7 @@ class TestWebSearchAutoInjectionOpenAI:
         """
         print("Setup: Testing OpenAI duplicate detection...")
         from kiro.models_openai import Tool, ToolFunction
-        
+
         # Simulate existing web_search tool
         existing_tools = [
             Tool(
@@ -1029,37 +937,36 @@ class TestWebSearchAutoInjectionOpenAI:
                 function=ToolFunction(
                     name="web_search",
                     description="Existing web search",
-                    parameters={"type": "object", "properties": {}}
-                )
+                    parameters={"type": "object", "properties": {}},
+                ),
             )
         ]
-        
+
         # Simulate auto-injection logic with duplicate check
         WEB_SEARCH_ENABLED = True
-        
+
         if WEB_SEARCH_ENABLED:
             has_ws = any(
-                getattr(tool, "type", None) == "function" and
-                getattr(getattr(tool, "function", None), "name", None) == "web_search"
+                getattr(tool, "type", None) == "function"
+                and getattr(getattr(tool, "function", None), "name", None) == "web_search"
                 for tool in existing_tools
             )
-            
+
             if not has_ws:
                 # Would add web_search here
-                existing_tools.append(Tool(
-                    type="function",
-                    function=ToolFunction(
-                        name="web_search",
-                        description="Auto-injected",
-                        parameters={"type": "object", "properties": {}}
+                existing_tools.append(
+                    Tool(
+                        type="function",
+                        function=ToolFunction(
+                            name="web_search",
+                            description="Auto-injected",
+                            parameters={"type": "object", "properties": {}},
+                        ),
                     )
-                ))
-        
-        print(f"Checking: Only one web_search tool...")
-        web_search_count = sum(
-            1 for t in existing_tools
-            if t.type == "function" and t.function.name == "web_search"
-        )
+                )
+
+        print("Checking: Only one web_search tool...")
+        web_search_count = sum(1 for t in existing_tools if t.type == "function" and t.function.name == "web_search")
         assert web_search_count == 1
 
 
@@ -1067,76 +974,74 @@ class TestWebSearchAutoInjectionOpenAI:
 # Tests for Account System - /v1/models endpoint
 # ==================================================================================================
 
+
 class TestModelsEndpointAccountSystem:
     """Tests for /v1/models endpoint with Account System."""
-    
+
     def test_get_models_account_system_logic(self):
         """
         What it does: Verifies logic for collecting models in account system mode.
         Purpose: Ensure models are collected from all initialized accounts.
         """
         print("\n--- Test: /v1/models account system logic ---")
-        
+
         # Simulate account system mode logic
         account_system = True
-        
+
         mock_account_manager = Mock()
         mock_account_manager.get_all_available_models.return_value = [
             "claude-opus-4.5",
             "claude-sonnet-4.5",
-            "claude-haiku-4.5"
+            "claude-haiku-4.5",
         ]
-        
+
         print("Action: Getting models in account system mode...")
         if account_system:
             available_model_ids = mock_account_manager.get_all_available_models()
         else:
             available_model_ids = []
-        
+
         print("Checking: get_all_available_models() was called...")
         mock_account_manager.get_all_available_models.assert_called_once()
-        
+
         print("Checking: Models from all accounts collected...")
         assert "claude-opus-4.5" in available_model_ids
         assert "claude-sonnet-4.5" in available_model_ids
         assert "claude-haiku-4.5" in available_model_ids
         assert len(available_model_ids) == 3
         print("✅ Account system mode correctly collects models from all accounts")
-    
+
     def test_get_models_legacy_logic(self):
         """
         What it does: Verifies logic for getting models in legacy mode.
         Purpose: Ensure backward compatibility with single account.
         """
         print("\n--- Test: /v1/models legacy mode logic ---")
-        
+
         # Simulate legacy mode logic
         account_system = False
-        
+
         mock_account = Mock()
         mock_resolver = Mock()
-        mock_resolver.get_available_models.return_value = [
-            "claude-opus-4.5",
-            "claude-sonnet-4.5"
-        ]
+        mock_resolver.get_available_models.return_value = ["claude-opus-4.5", "claude-sonnet-4.5"]
         mock_account.model_resolver = mock_resolver
-        
+
         mock_account_manager = Mock()
         mock_account_manager.get_first_account.return_value = mock_account
-        
+
         print("Action: Getting models in legacy mode...")
         if account_system:
             available_model_ids = []
         else:
             account = mock_account_manager.get_first_account()
             available_model_ids = account.model_resolver.get_available_models()
-        
+
         print("Checking: get_first_account() was called...")
         mock_account_manager.get_first_account.assert_called_once()
-        
+
         print("Checking: model_resolver.get_available_models() was called...")
         mock_resolver.get_available_models.assert_called_once()
-        
+
         print("Checking: Models from first account returned...")
         assert "claude-opus-4.5" in available_model_ids
         assert "claude-sonnet-4.5" in available_model_ids
@@ -1148,9 +1053,10 @@ class TestModelsEndpointAccountSystem:
 # Tests for Account System - Failover Loop
 # ==================================================================================================
 
+
 class TestChatCompletionsFailoverLoop:
     """Tests for failover loop in /v1/chat/completions endpoint."""
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_get_next_account(self):
         """
@@ -1158,26 +1064,26 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure failover loop tracks tried accounts.
         """
         print("\n--- Test: Failover calls get_next_account() with exclude_accounts ---")
-        
+
         mock_account = Mock()
         mock_account.id = "/home/user/account1.json"
         mock_account.auth_manager = Mock()
         mock_account.model_cache = Mock()
         mock_account.model_resolver = Mock()
-        
+
         mock_manager = Mock()
         mock_manager.get_next_account = AsyncMock(return_value=mock_account)
         mock_manager._accounts = {mock_account.id: mock_account}
-        
+
         print("Checking: get_next_account() called with exclude_accounts parameter...")
         # This test verifies the signature - actual implementation tested in integration tests
         await mock_manager.get_next_account("claude-opus-4.5", exclude_accounts=set())
-        
+
         mock_manager.get_next_account.assert_called_once()
         call_kwargs = mock_manager.get_next_account.call_args[1]
         assert "exclude_accounts" in call_kwargs
         print("✅ Failover loop correctly passes exclude_accounts")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_success_first_account(self):
         """
@@ -1185,39 +1091,36 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure no unnecessary failover when first account works.
         """
         print("\n--- Test: Success on first account ---")
-        
+
         from kiro.account_manager import Account, AccountStats
-        
+
         mock_account = Account(
             id="/home/user/account1.json",
             failures=0,
             last_failure_time=0.0,
             models_cached_at=time.time(),
-            stats=AccountStats()
+            stats=AccountStats(),
         )
-        
+
         mock_manager = Mock()
         mock_manager.get_next_account = AsyncMock(return_value=mock_account)
         mock_manager.report_success = AsyncMock()
         mock_manager._accounts = {mock_account.id: mock_account}
-        
+
         print("Action: Simulating successful request...")
         account = await mock_manager.get_next_account("claude-opus-4.5", exclude_accounts=set())
-        
+
         print("Checking: First account returned...")
         assert account is not None
         assert account.id == "/home/user/account1.json"
-        
+
         print("Action: Reporting success...")
         await mock_manager.report_success(account.id, "claude-opus-4.5")
-        
+
         print("Checking: report_success() was called...")
-        mock_manager.report_success.assert_called_once_with(
-            "/home/user/account1.json",
-            "claude-opus-4.5"
-        )
+        mock_manager.report_success.assert_called_once_with("/home/user/account1.json", "claude-opus-4.5")
         print("✅ Success on first account works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_recoverable_try_next(self):
         """
@@ -1225,34 +1128,30 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure failover happens for account-specific errors.
         """
         print("\n--- Test: RECOVERABLE error tries next account ---")
-        
+
         from kiro.account_errors import ErrorType, classify_error
-        
+
         print("Setup: Classifying 429 error...")
         error_type = classify_error(429, None)
-        
+
         print("Checking: 429 is RECOVERABLE...")
         assert error_type == ErrorType.RECOVERABLE
-        
+
         print("Checking: Failover logic should continue to next account...")
         # In actual implementation, this would trigger:
         # await account_manager.report_failure(...)
         # continue  # Next iteration of failover loop
-        
+
         mock_manager = Mock()
         mock_manager.report_failure = AsyncMock()
-        
+
         await mock_manager.report_failure(
-            "/home/user/account1.json",
-            "claude-opus-4.5",
-            ErrorType.RECOVERABLE,
-            429,
-            None
+            "/home/user/account1.json", "claude-opus-4.5", ErrorType.RECOVERABLE, 429, None
         )
-        
+
         mock_manager.report_failure.assert_called_once()
         print("✅ RECOVERABLE error correctly triggers failover")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_fatal_immediate_return(self):
         """
@@ -1260,96 +1159,77 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure no wasted retries for request-level errors.
         """
         print("\n--- Test: FATAL error returns immediately ---")
-        
+
         from kiro.account_errors import ErrorType, classify_error
-        
+
         print("Setup: Classifying 400 + CONTENT_LENGTH_EXCEEDS_THRESHOLD...")
         error_type = classify_error(400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD")
-        
+
         print("Checking: Error is FATAL...")
         assert error_type == ErrorType.FATAL
-        
+
         print("Checking: Failover logic should break immediately...")
         # In actual implementation, this would trigger:
         # await account_manager.report_failure(...)
         # return JSONResponse(...)  # No continue, immediate return
-        
+
         mock_manager = Mock()
         mock_manager.report_failure = AsyncMock()
-        
+
         await mock_manager.report_failure(
-            "/home/user/account1.json",
-            "claude-opus-4.5",
-            ErrorType.FATAL,
-            400,
-            "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
+            "/home/user/account1.json", "claude-opus-4.5", ErrorType.FATAL, 400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD"
         )
-        
+
         mock_manager.report_failure.assert_called_once()
         print("✅ FATAL error correctly returns immediately")
-    
+
     def test_chat_completions_failover_single_account_original_error(self):
         """
         What it does: Verifies single account returns original error message.
         Purpose: Ensure users see specific error for single account setup.
         """
         print("\n--- Test: Single account returns original error ---")
-        
+
         all_accounts = ["/home/user/account1.json"]
         last_error_message = "Monthly request limit exceeded"
         last_error_status = 402
-        
+
         print("Checking: Single account error handling...")
         if len(all_accounts) == 1:
-            error_response = {
-                "status_code": last_error_status,
-                "detail": last_error_message
-            }
+            error_response = {"status_code": last_error_status, "detail": last_error_message}
         else:
-            error_response = {
-                "status_code": 503,
-                "detail": "No available accounts for this model"
-            }
-        
+            error_response = {"status_code": 503, "detail": "No available accounts for this model"}
+
         print(f"Error response: {error_response}")
         assert error_response["status_code"] == 402
         assert error_response["detail"] == "Monthly request limit exceeded"
         print("✅ Single account correctly returns original error")
-    
+
     def test_chat_completions_failover_multi_account_generic_error(self):
         """
         What it does: Verifies multi-account returns generic error message.
         Purpose: Ensure users don't see confusing account-specific errors.
         """
         print("\n--- Test: Multi-account returns generic error ---")
-        
-        all_accounts = [
-            "/home/user/account1.json",
-            "/home/user/account2.json"
-        ]
+
+        all_accounts = ["/home/user/account1.json", "/home/user/account2.json"]
         last_error_message = "Token expired"
-        
+
         print("Checking: Multi-account error handling...")
         if len(all_accounts) == 1:
-            error_response = {
-                "status_code": 403,
-                "detail": last_error_message
-            }
+            error_response = {"status_code": 403, "detail": last_error_message}
         else:
             detail = "No available accounts for this model."
             if last_error_message:
                 detail += f" Error from last account: {last_error_message}"
-            error_response = {
-                "status_code": 503,
-                "detail": detail
-            }
-        
+            error_response = {"status_code": 503, "detail": detail}
+
         print(f"Error response: {error_response}")
         assert error_response["status_code"] == 503
         assert "No available accounts" in error_response["detail"]
         assert "Error from last account: Token expired" in error_response["detail"]
         print("✅ Multi-account correctly returns generic error with context")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_all_unavailable(self):
         """
@@ -1357,33 +1237,27 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure graceful handling of complete failure.
         """
         print("\n--- Test: All accounts unavailable ---")
-        
+
         mock_manager = Mock()
         mock_manager.get_next_account = AsyncMock(return_value=None)
-        mock_manager._accounts = {
-            "/home/user/account1.json": Mock(),
-            "/home/user/account2.json": Mock()
-        }
-        
+        mock_manager._accounts = {"/home/user/account1.json": Mock(), "/home/user/account2.json": Mock()}
+
         print("Action: Requesting account when all unavailable...")
-        account = await mock_manager.get_next_account(
-            "claude-opus-4.5",
-            exclude_accounts=set()
-        )
-        
+        account = await mock_manager.get_next_account("claude-opus-4.5", exclude_accounts=set())
+
         print("Checking: None returned...")
         assert account is None
-        
+
         print("Checking: Error response logic...")
         all_accounts = list(mock_manager._accounts.keys())
         if len(all_accounts) == 1:
             error_msg = "Account unavailable"
         else:
             error_msg = "No available accounts for this model"
-        
+
         assert "No available accounts" in error_msg
         print("✅ All unavailable correctly handled")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_report_success(self):
         """
@@ -1391,20 +1265,20 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure statistics and sticky behavior are updated.
         """
         print("\n--- Test: report_success() called on success ---")
-        
+
         mock_manager = Mock()
         mock_manager.report_success = AsyncMock()
-        
+
         account_id = "/home/user/account1.json"
         model = "claude-opus-4.5"
-        
+
         print("Action: Reporting success...")
         await mock_manager.report_success(account_id, model)
-        
+
         print("Checking: report_success() was called with correct params...")
         mock_manager.report_success.assert_called_once_with(account_id, model)
         print("✅ report_success() correctly called")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_report_failure(self):
         """
@@ -1412,37 +1286,25 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure Circuit Breaker state is updated.
         """
         print("\n--- Test: report_failure() called on failure ---")
-        
+
         from kiro.account_errors import ErrorType
-        
+
         mock_manager = Mock()
         mock_manager.report_failure = AsyncMock()
-        
+
         account_id = "/home/user/account1.json"
         model = "claude-opus-4.5"
         error_type = ErrorType.RECOVERABLE
         status_code = 429
         reason = None
-        
+
         print("Action: Reporting failure...")
-        await mock_manager.report_failure(
-            account_id,
-            model,
-            error_type,
-            status_code,
-            reason
-        )
-        
+        await mock_manager.report_failure(account_id, model, error_type, status_code, reason)
+
         print("Checking: report_failure() was called with correct params...")
-        mock_manager.report_failure.assert_called_once_with(
-            account_id,
-            model,
-            error_type,
-            status_code,
-            reason
-        )
+        mock_manager.report_failure.assert_called_once_with(account_id, model, error_type, status_code, reason)
         print("✅ report_failure() correctly called")
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_failover_exclude_tried_accounts(self):
         """
@@ -1450,53 +1312,50 @@ class TestChatCompletionsFailoverLoop:
         Purpose: Ensure accounts aren't retried in same failover loop.
         """
         print("\n--- Test: exclude_accounts grows with attempts ---")
-        
+
         tried_accounts = set()
-        
+
         print("Action: Simulating multiple attempts...")
         account1_id = "/home/user/account1.json"
         account2_id = "/home/user/account2.json"
-        
+
         # Attempt 1
         tried_accounts.add(account1_id)
         print(f"After attempt 1: {tried_accounts}")
         assert account1_id in tried_accounts
         assert len(tried_accounts) == 1
-        
+
         # Attempt 2
         tried_accounts.add(account2_id)
         print(f"After attempt 2: {tried_accounts}")
         assert account2_id in tried_accounts
         assert len(tried_accounts) == 2
-        
+
         print("Checking: Both accounts in exclude set...")
         assert account1_id in tried_accounts
         assert account2_id in tried_accounts
         print("✅ exclude_accounts correctly tracks tried accounts")
-    
+
     def test_chat_completions_failover_max_attempts(self):
         """
         What it does: Verifies failover loop stops after MAX_ATTEMPTS.
         Purpose: Ensure infinite loops are prevented.
         """
         print("\n--- Test: MAX_ATTEMPTS prevents infinite loop ---")
-        
-        all_accounts = [
-            "/home/user/account1.json",
-            "/home/user/account2.json"
-        ]
+
+        all_accounts = ["/home/user/account1.json", "/home/user/account2.json"]
         MAX_ATTEMPTS = len(all_accounts) * 2
-        
+
         print(f"Checking: MAX_ATTEMPTS = {MAX_ATTEMPTS}...")
         assert MAX_ATTEMPTS == 4
-        
+
         print("Checking: Loop would stop after 4 attempts...")
         attempts = 0
         for attempt in range(MAX_ATTEMPTS):
             attempts += 1
             if attempts >= MAX_ATTEMPTS:
                 break
-        
+
         assert attempts == MAX_ATTEMPTS
         print("✅ MAX_ATTEMPTS correctly limits failover loop")
 
@@ -1505,9 +1364,10 @@ class TestChatCompletionsFailoverLoop:
 # Tests for Account System - Legacy Mode
 # ==================================================================================================
 
+
 class TestChatCompletionsLegacyMode:
     """Tests for legacy mode (ACCOUNT_SYSTEM=false) in /v1/chat/completions."""
-    
+
     @pytest.mark.asyncio
     async def test_chat_completions_legacy_get_first_account(self):
         """
@@ -1515,48 +1375,48 @@ class TestChatCompletionsLegacyMode:
         Purpose: Ensure backward compatibility with single account.
         """
         print("\n--- Test: Legacy mode uses get_first_account() ---")
-        
+
         from kiro.account_manager import Account, AccountStats
-        
+
         mock_account = Account(
             id="/home/user/account1.json",
             failures=0,
             last_failure_time=0.0,
             models_cached_at=time.time(),
-            stats=AccountStats()
+            stats=AccountStats(),
         )
-        
+
         mock_manager = Mock()
         mock_manager.get_first_account.return_value = mock_account
-        
+
         print("Action: Getting first account in legacy mode...")
         account = mock_manager.get_first_account()
-        
+
         print("Checking: get_first_account() was called...")
         mock_manager.get_first_account.assert_called_once()
-        
+
         print("Checking: Account returned...")
         assert account is not None
         assert account.id == "/home/user/account1.json"
         print("✅ Legacy mode correctly uses get_first_account()")
-    
+
     def test_chat_completions_legacy_no_failover(self):
         """
         What it does: Verifies legacy mode has no failover loop.
         Purpose: Ensure single account behavior is preserved.
         """
         print("\n--- Test: Legacy mode has no failover ---")
-        
+
         account_system = False
-        
+
         print("Checking: account_system flag is False...")
         assert account_system is False
-        
+
         print("Checking: Failover loop should be skipped...")
         if account_system:
             failover_enabled = True
         else:
             failover_enabled = False
-        
+
         assert failover_enabled is False
         print("✅ Legacy mode correctly skips failover loop")

--- a/tests/unit/test_stream_integrity.py
+++ b/tests/unit/test_stream_integrity.py
@@ -5,17 +5,17 @@ repeated deltas were dropped as "replays", and the upstream stop reason was
 ignored so a truncated turn looked like a clean finish.
 """
 
-import pytest
 import httpx
+import pytest
 
 from kiro.parsers import AwsEventStreamParser
-from kiro.streaming_core import parse_kiro_stream
 from kiro.stop_reasons import (
     is_truncated,
     normalize,
     to_anthropic_stop_reason,
     to_openai_finish_reason,
 )
+from kiro.streaming_core import parse_kiro_stream
 
 
 def _frames(*contents: str) -> bytes:

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -11,18 +10,19 @@ Tests for:
 - collect_anthropic_response() function
 """
 
-import pytest
 import json
-import uuid
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from kiro.sse_validation import StreamProtocolError
 from kiro.streaming_anthropic import (
-    generate_message_id,
-    format_sse_event,
-    stream_kiro_to_anthropic,
     collect_anthropic_response,
+    format_sse_event,
+    generate_message_id,
+    stream_kiro_to_anthropic,
     stream_with_first_token_retry_anthropic,
 )
 from kiro.streaming_core import (
@@ -30,12 +30,11 @@ from kiro.streaming_core import (
     KiroEvent,
     StreamResult,
 )
-from kiro.sse_validation import StreamProtocolError
-
 
 # ==================================================================================================
 # Fixtures
 # ==================================================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -64,9 +63,7 @@ def mock_response():
 def parse_sse_events(chunks: list[str]) -> list[dict[str, Any]]:
     events: list[dict[str, Any]] = []
     for chunk in chunks:
-        data_line = next(
-            line for line in chunk.splitlines() if line.startswith("data: ")
-        )
+        data_line = next(line for line in chunk.splitlines() if line.startswith("data: "))
         events.append(json.loads(data_line.removeprefix("data: ")))
     return events
 
@@ -79,12 +76,8 @@ def assert_valid_content_event_order(events: list[dict[str, Any]]) -> None:
         event_type = event["type"]
         if event_type == "content_block_start":
             index = event["index"]
-            assert active_index is None, (
-                f"content block {index} started while block {active_index} was open"
-            )
-            assert index == last_started_index + 1, (
-                f"content block index {index} followed {last_started_index}"
-            )
+            assert active_index is None, f"content block {index} started while block {active_index} was open"
+            assert index == last_started_index + 1, f"content block index {index} followed {last_started_index}"
             active_index = index
             last_started_index = index
         elif event_type == "content_block_delta":
@@ -92,14 +85,10 @@ def assert_valid_content_event_order(events: list[dict[str, Any]]) -> None:
                 f"delta targeted block {event['index']} while {active_index} was open"
             )
         elif event_type == "content_block_stop":
-            assert event["index"] == active_index, (
-                f"stop targeted block {event['index']} while {active_index} was open"
-            )
+            assert event["index"] == active_index, f"stop targeted block {event['index']} while {active_index} was open"
             active_index = None
         elif event_type == "message_delta":
-            assert active_index is None, (
-                f"message_delta arrived while block {active_index} was open"
-            )
+            assert active_index is None, f"message_delta arrived while block {active_index} was open"
 
     assert active_index is None, f"content block {active_index} remained open"
 
@@ -108,9 +97,10 @@ def assert_valid_content_event_order(events: list[dict[str, Any]]) -> None:
 # Tests for generate_message_id()
 # ==================================================================================================
 
+
 class TestGenerateMessageId:
     """Tests for generate_message_id() function."""
-    
+
     def test_generates_message_id_with_prefix(self):
         """
         What it does: Generates message ID with 'msg_' prefix.
@@ -118,11 +108,11 @@ class TestGenerateMessageId:
         """
         print("Action: Generating message ID...")
         message_id = generate_message_id()
-        
+
         print(f"Generated ID: {message_id}")
         assert message_id.startswith("msg_")
         print("✓ Message ID has correct prefix")
-    
+
     def test_generates_unique_ids(self):
         """
         What it does: Generates unique message IDs.
@@ -130,14 +120,14 @@ class TestGenerateMessageId:
         """
         print("Action: Generating multiple message IDs...")
         ids = [generate_message_id() for _ in range(100)]
-        
+
         print(f"Generated {len(ids)} IDs")
         unique_ids = set(ids)
         print(f"Unique IDs: {len(unique_ids)}")
-        
+
         assert len(unique_ids) == 100
         print("✓ All message IDs are unique")
-    
+
     def test_message_id_has_correct_length(self):
         """
         What it does: Verifies message ID length.
@@ -145,7 +135,7 @@ class TestGenerateMessageId:
         """
         print("Action: Generating message ID...")
         message_id = generate_message_id()
-        
+
         # Format: msg_ + 24 hex chars
         print(f"Generated ID: {message_id}, length: {len(message_id)}")
         assert len(message_id) == 4 + 24  # "msg_" + 24 chars
@@ -156,54 +146,41 @@ class TestGenerateMessageId:
 # Tests for format_sse_event()
 # ==================================================================================================
 
+
 class TestFormatSseEvent:
     """Tests for format_sse_event() function."""
-    
+
     def test_formats_message_start_event(self):
         """
         What it does: Formats message_start event.
         Goal: Verify Anthropic SSE format.
         """
         print("Action: Formatting message_start event...")
-        data = {
-            "type": "message_start",
-            "message": {
-                "id": "msg_123",
-                "type": "message",
-                "role": "assistant"
-            }
-        }
-        
+        data = {"type": "message_start", "message": {"id": "msg_123", "type": "message", "role": "assistant"}}
+
         result = format_sse_event("message_start", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert result.startswith("event: message_start\n")
         assert "data: " in result
         assert result.endswith("\n\n")
         print("✓ Event formatted correctly")
-    
+
     def test_formats_content_block_delta_event(self):
         """
         What it does: Formats content_block_delta event.
         Goal: Verify delta event format.
         """
         print("Action: Formatting content_block_delta event...")
-        data = {
-            "type": "content_block_delta",
-            "index": 0,
-            "delta": {
-                "type": "text_delta",
-                "text": "Hello"
-            }
-        }
-        
+        data = {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
+
         result = format_sse_event("content_block_delta", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert "event: content_block_delta\n" in result
         assert '"text": "Hello"' in result
         print("✓ Delta event formatted correctly")
-    
+
     def test_formats_message_stop_event(self):
         """
         What it does: Formats message_stop event.
@@ -211,53 +188,46 @@ class TestFormatSseEvent:
         """
         print("Action: Formatting message_stop event...")
         data = {"type": "message_stop"}
-        
+
         result = format_sse_event("message_stop", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert "event: message_stop\n" in result
         print("✓ Stop event formatted correctly")
-    
+
     def test_handles_unicode_content(self):
         """
         What it does: Handles Unicode content in events.
         Goal: Verify non-ASCII characters are preserved.
         """
         print("Action: Formatting event with Unicode...")
-        data = {
-            "type": "content_block_delta",
-            "delta": {"text": "Привет мир! 🌍"}
-        }
-        
+        data = {"type": "content_block_delta", "delta": {"text": "Привет мир! 🌍"}}
+
         result = format_sse_event("content_block_delta", data)
-        
+
         print(f"Formatted event:\n{result}")
         assert "Привет мир!" in result
         assert "🌍" in result
         print("✓ Unicode content preserved")
-    
+
     def test_json_data_is_valid(self):
         """
         What it does: Verifies JSON data is valid.
         Goal: Ensure data can be parsed back.
         """
         print("Action: Formatting and parsing event...")
-        data = {
-            "type": "message_delta",
-            "delta": {"stop_reason": "end_turn"},
-            "usage": {"output_tokens": 100}
-        }
-        
+        data = {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 100}}
+
         result = format_sse_event("message_delta", data)
-        
+
         # Extract JSON from result
         lines = result.strip().split("\n")
-        data_line = [l for l in lines if l.startswith("data: ")][0]
+        data_line = [line for line in lines if line.startswith("data: ")][0]
         json_str = data_line[6:]  # Remove "data: " prefix
-        
+
         print(f"JSON string: {json_str}")
         parsed = json.loads(json_str)
-        
+
         assert parsed["type"] == "message_delta"
         assert parsed["delta"]["stop_reason"] == "end_turn"
         print("✓ JSON data is valid and parseable")
@@ -267,9 +237,10 @@ class TestFormatSseEvent:
 # Tests for stream_kiro_to_anthropic()
 # ==================================================================================================
 
+
 class TestStreamKiroToAnthropic:
     """Tests for stream_kiro_to_anthropic() generator."""
-    
+
     @pytest.mark.asyncio
     async def test_yields_message_start_event(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -277,55 +248,57 @@ class TestStreamKiroToAnthropic:
         Goal: Verify Anthropic streaming protocol.
         """
         print("Setup: Mock empty stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             return
             yield  # Make it a generator
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
             async for event in stream_kiro_to_anthropic(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             ):
                 events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # First event should be message_start
         assert len(events) > 0
         assert "event: message_start" in events[0]
         print("✓ message_start event yielded first")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_content_block_start_on_first_content(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_content_block_start_on_first_content(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields content_block_start before first content.
         Goal: Verify content block lifecycle.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have content_block_start
         content_block_start_found = any("content_block_start" in e for e in events)
         assert content_block_start_found
         print("✓ content_block_start event yielded")
-    
+
     @pytest.mark.asyncio
     async def test_yields_content_block_delta_for_content(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -333,27 +306,27 @@ class TestStreamKiroToAnthropic:
         Goal: Verify content streaming.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="content", content=" World")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have content_block_delta events
         delta_events = [e for e in events if "content_block_delta" in e]
         print(f"Delta events: {len(delta_events)}")
-        
+
         assert len(delta_events) >= 2
         assert "Hello" in delta_events[0]
         assert "World" in delta_events[1]
@@ -371,12 +344,8 @@ class TestStreamKiroToAnthropic:
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
 
         chunks: list[str] = []
-        with patch(
-            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
-        ):
-            with patch(
-                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
-            ):
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_anthropic(
                     mock_response,
                     "claude-opus-5",
@@ -387,11 +356,12 @@ class TestStreamKiroToAnthropic:
 
         events = parse_sse_events(chunks)
         assert_valid_content_event_order(events)
-        assert [
-            event["content_block"]["type"]
-            for event in events
-            if event["type"] == "content_block_start"
-        ] == ["thinking", "text", "thinking", "text"]
+        assert [event["content_block"]["type"] for event in events if event["type"] == "content_block_start"] == [
+            "thinking",
+            "text",
+            "thinking",
+            "text",
+        ]
 
     @pytest.mark.asyncio
     async def test_content_transitions_close_active_block_before_tool_or_thinking(
@@ -412,12 +382,8 @@ class TestStreamKiroToAnthropic:
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
 
         chunks: list[str] = []
-        with patch(
-            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
-        ):
-            with patch(
-                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
-            ):
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_anthropic(
                     mock_response,
                     "claude-opus-5",
@@ -428,21 +394,13 @@ class TestStreamKiroToAnthropic:
 
         events = parse_sse_events(chunks)
         assert_valid_content_event_order(events)
-        starts = [
-            event
-            for event in events
-            if event["type"] == "content_block_start"
-        ]
+        starts = [event for event in events if event["type"] == "content_block_start"]
         assert [event["index"] for event in starts] == [0, 1, 2]
-        assert [
-            event["content_block"]["type"]
-            for event in starts
-        ] == ["text", "thinking", "tool_use"]
+        assert [event["content_block"]["type"] for event in starts] == ["text", "thinking", "tool_use"]
         assert [
             event["delta"]["text"]
             for event in events
-            if event["type"] == "content_block_delta"
-            and event["delta"]["type"] == "text_delta"
+            if event["type"] == "content_block_delta" and event["delta"]["type"] == "text_delta"
         ] == ["preface"]
 
     @pytest.mark.asyncio
@@ -459,12 +417,8 @@ class TestStreamKiroToAnthropic:
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
 
         chunks: list[str] = []
-        with patch(
-            "kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream
-        ):
-            with patch(
-                "kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]
-            ):
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_anthropic(
                     mock_response,
                     "claude-opus-5",
@@ -475,9 +429,7 @@ class TestStreamKiroToAnthropic:
 
         events = parse_sse_events(chunks)
         signature_index = next(
-            index
-            for index, event in enumerate(events)
-            if event.get("delta", {}).get("type") == "signature_delta"
+            index for index, event in enumerate(events) if event.get("delta", {}).get("type") == "signature_delta"
         )
         assert events[signature_index]["delta"]["signature"] == "upstream-signature"
         assert events[signature_index + 1] == {
@@ -485,7 +437,7 @@ class TestStreamKiroToAnthropic:
             "index": 0,
         }
         assert_valid_content_event_order(events)
-    
+
     @pytest.mark.asyncio
     async def test_yields_tool_use_block_for_tool_calls(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -493,39 +445,33 @@ class TestStreamKiroToAnthropic:
         Goal: Verify tool use streaming.
         """
         print("Setup: Mock stream with tool call...")
-        
-        tool_use_data = {
-            "id": "toolu_123",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city": "Moscow"}'
-            }
-        }
-        
+
+        tool_use_data = {"id": "toolu_123", "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'}}
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Let me check")
             yield KiroEvent(type="tool_use", tool_use=tool_use_data)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have tool_use content block
         tool_use_events = [e for e in events if "tool_use" in e and "content_block_start" in e]
         print(f"Tool use events: {len(tool_use_events)}")
-        
+
         assert len(tool_use_events) >= 1
         assert "get_weather" in tool_use_events[0]
         print("✓ tool_use block yielded for tool calls")
-    
+
     @pytest.mark.asyncio
     async def test_yields_message_delta_with_stop_reason(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -533,29 +479,29 @@ class TestStreamKiroToAnthropic:
         Goal: Verify message completion.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have message_delta with stop_reason
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         assert "end_turn" in message_delta_events[0]
         print("✓ message_delta with stop_reason yielded")
-    
+
     @pytest.mark.asyncio
     async def test_yields_message_stop_at_end(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -563,26 +509,26 @@ class TestStreamKiroToAnthropic:
         Goal: Verify stream termination.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Last event should be message_stop
         assert "message_stop" in events[-1]
         print("✓ message_stop yielded at end")
-    
+
     @pytest.mark.asyncio
     async def test_stop_reason_is_tool_use_when_tools_present(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -590,33 +536,30 @@ class TestStreamKiroToAnthropic:
         Goal: Verify correct stop reason for tool calls.
         """
         print("Setup: Mock stream with tool call...")
-        
-        tool_use_data = {
-            "id": "toolu_123",
-            "function": {"name": "func1", "arguments": "{}"}
-        }
-        
+
+        tool_use_data = {"id": "toolu_123", "function": {"name": "func1", "arguments": "{}"}}
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="tool_use", tool_use=tool_use_data)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # message_delta should have stop_reason: tool_use
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         assert "tool_use" in message_delta_events[0]
         print("✓ stop_reason is tool_use when tools present")
-    
+
     @pytest.mark.asyncio
     async def test_handles_bracket_tool_calls(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -624,31 +567,29 @@ class TestStreamKiroToAnthropic:
         Goal: Verify bracket tool call detection.
         """
         print("Setup: Mock stream with bracket tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="[tool_call: func1]")
-        
-        bracket_tool_calls = [
-            {"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}
-        ]
-        
+
+        bracket_tool_calls = [{"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}]
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=bracket_tool_calls):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=bracket_tool_calls):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have tool_use block from bracket tool calls
         tool_use_events = [e for e in events if "tool_use" in e and "content_block_start" in e]
         assert len(tool_use_events) >= 1
         print("✓ Bracket tool calls handled correctly")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_completion(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -656,23 +597,23 @@ class TestStreamKiroToAnthropic:
         Goal: Verify resource cleanup.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to Anthropic format...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on completion")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_error(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -680,15 +621,15 @@ class TestStreamKiroToAnthropic:
         Goal: Verify resource cleanup on error.
         """
         print("Setup: Mock stream that raises error...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to Anthropic format with error...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 try:
                     async for event in stream_kiro_to_anthropic(
                         mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
@@ -696,7 +637,7 @@ class TestStreamKiroToAnthropic:
                         pass
                 except RuntimeError:
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on error")
@@ -706,9 +647,10 @@ class TestStreamKiroToAnthropic:
 # Tests for collect_anthropic_response()
 # ==================================================================================================
 
+
 class TestCollectAnthropicResponse:
     """Tests for collect_anthropic_response() function."""
-    
+
     @pytest.mark.asyncio
     async def test_collects_text_content(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -716,24 +658,20 @@ class TestCollectAnthropicResponse:
         Goal: Verify content collection.
         """
         print("Setup: Mock stream result with content...")
-        
+
         mock_result = StreamResult(
-            content="Hello, world!",
-            thinking_content="",
-            tool_calls=[],
-            usage=None,
-            context_usage_percentage=None
+            content="Hello, world!", thinking_content="", tool_calls=[], usage=None, context_usage_percentage=None
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         assert result["type"] == "message"
         assert result["role"] == "assistant"
         assert len(result["content"]) == 1
@@ -742,9 +680,7 @@ class TestCollectAnthropicResponse:
         print("✓ Text content collected correctly")
 
     @pytest.mark.asyncio
-    async def test_collects_native_thinking_signature(
-        self, mock_response, mock_model_cache, mock_auth_manager
-    ):
+    async def test_collects_native_thinking_signature(self, mock_response, mock_model_cache, mock_auth_manager):
         mock_result = StreamResult(
             content="answer",
             thinking_content="private reasoning",
@@ -770,7 +706,7 @@ class TestCollectAnthropicResponse:
             "thinking": "private reasoning",
             "signature": "upstream-signature",
         }
-    
+
     @pytest.mark.asyncio
     async def test_collects_tool_use_content(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -778,44 +714,36 @@ class TestCollectAnthropicResponse:
         Goal: Verify tool use collection.
         """
         print("Setup: Mock stream result with tool calls...")
-        
+
         mock_result = StreamResult(
             content="Let me check",
             thinking_content="",
-            tool_calls=[
-                {
-                    "id": "toolu_123",
-                    "function": {
-                        "name": "get_weather",
-                        "arguments": '{"city": "Moscow"}'
-                    }
-                }
-            ],
+            tool_calls=[{"id": "toolu_123", "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'}}],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Should have text and tool_use blocks
         assert len(result["content"]) == 2
-        
+
         text_block = result["content"][0]
         assert text_block["type"] == "text"
-        
+
         tool_block = result["content"][1]
         assert tool_block["type"] == "tool_use"
         assert tool_block["name"] == "get_weather"
         assert tool_block["input"] == {"city": "Moscow"}
         print("✓ Tool use content collected correctly")
-    
+
     @pytest.mark.asyncio
     async def test_sets_stop_reason_end_turn(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -823,26 +751,22 @@ class TestCollectAnthropicResponse:
         Goal: Verify stop reason.
         """
         print("Setup: Mock stream result without tool calls...")
-        
+
         mock_result = StreamResult(
-            content="Hello",
-            thinking_content="",
-            tool_calls=[],
-            usage=None,
-            context_usage_percentage=5.0
+            content="Hello", thinking_content="", tool_calls=[], usage=None, context_usage_percentage=5.0
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"stop_reason: {result['stop_reason']}")
         assert result["stop_reason"] == "end_turn"
         print("✓ stop_reason is end_turn")
-    
+
     @pytest.mark.asyncio
     async def test_sets_stop_reason_tool_use(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -850,26 +774,26 @@ class TestCollectAnthropicResponse:
         Goal: Verify stop reason for tool calls.
         """
         print("Setup: Mock stream result with tool calls...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
             tool_calls=[{"id": "call_1", "function": {"name": "func1", "arguments": "{}"}}],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"stop_reason: {result['stop_reason']}")
         assert result["stop_reason"] == "tool_use"
         print("✓ stop_reason is tool_use")
-    
+
     @pytest.mark.asyncio
     async def test_includes_usage_info(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -877,30 +801,29 @@ class TestCollectAnthropicResponse:
         Goal: Verify usage is included.
         """
         print("Setup: Mock stream result...")
-        
+
         mock_result = StreamResult(
-            content="Hello, world!",
-            thinking_content="",
-            tool_calls=[],
-            usage=None,
-            context_usage_percentage=None
+            content="Hello, world!", thinking_content="", tool_calls=[], usage=None, context_usage_percentage=None
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
-            with patch('kiro.streaming_anthropic.estimate_request_tokens', return_value={"total_tokens": 10}):
-                with patch('kiro.streaming_anthropic.count_tokens', return_value=5):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
+            with patch("kiro.streaming_anthropic.estimate_request_tokens", return_value={"total_tokens": 10}):
+                with patch("kiro.streaming_anthropic.count_tokens", return_value=5):
                     result = await collect_anthropic_response(
-                        mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager,
-                        request_messages=[{"role": "user", "content": "Hi"}]
+                        mock_response,
+                        "claude-sonnet-4",
+                        mock_model_cache,
+                        mock_auth_manager,
+                        request_messages=[{"role": "user", "content": "Hi"}],
                     )
-        
+
         print(f"Usage: {result['usage']}")
         assert "input_tokens" in result["usage"]
         assert "output_tokens" in result["usage"]
         print("✓ Usage info included")
-    
+
     @pytest.mark.asyncio
     async def test_generates_message_id(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -908,26 +831,22 @@ class TestCollectAnthropicResponse:
         Goal: Verify message ID is present.
         """
         print("Setup: Mock stream result...")
-        
+
         mock_result = StreamResult(
-            content="Hello",
-            thinking_content="",
-            tool_calls=[],
-            usage=None,
-            context_usage_percentage=None
+            content="Hello", thinking_content="", tool_calls=[], usage=None, context_usage_percentage=None
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Message ID: {result['id']}")
         assert result["id"].startswith("msg_")
         print("✓ Message ID generated")
-    
+
     @pytest.mark.asyncio
     async def test_includes_model_name(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -935,26 +854,22 @@ class TestCollectAnthropicResponse:
         Goal: Verify model is included.
         """
         print("Setup: Mock stream result...")
-        
+
         mock_result = StreamResult(
-            content="Hello",
-            thinking_content="",
-            tool_calls=[],
-            usage=None,
-            context_usage_percentage=None
+            content="Hello", thinking_content="", tool_calls=[], usage=None, context_usage_percentage=None
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Model: {result['model']}")
         assert result["model"] == "claude-sonnet-4"
         print("✓ Model name included")
-    
+
     @pytest.mark.asyncio
     async def test_parses_tool_arguments_from_string(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -962,7 +877,7 @@ class TestCollectAnthropicResponse:
         Goal: Verify arguments are parsed to dict.
         """
         print("Setup: Mock stream result with string arguments...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
@@ -971,30 +886,30 @@ class TestCollectAnthropicResponse:
                     "id": "call_1",
                     "function": {
                         "name": "func1",
-                        "arguments": '{"key": "value"}'  # String, not dict
-                    }
+                        "arguments": '{"key": "value"}',  # String, not dict
+                    },
                 }
             ],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Tool input should be parsed to dict
         tool_block = result["content"][0]  # Only tool_use since content is empty
         assert tool_block["type"] == "tool_use"
         assert tool_block["input"] == {"key": "value"}
         assert isinstance(tool_block["input"], dict)
         print("✓ Tool arguments parsed from string to dict")
-    
+
     @pytest.mark.asyncio
     async def test_handles_invalid_json_arguments(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1002,7 +917,7 @@ class TestCollectAnthropicResponse:
         Goal: Verify malformed input cannot become a successful empty tool call.
         """
         print("Setup: Mock stream result with invalid JSON arguments...")
-        
+
         mock_result = StreamResult(
             content="",
             thinking_content="",
@@ -1011,17 +926,17 @@ class TestCollectAnthropicResponse:
                     "id": "call_1",
                     "function": {
                         "name": "func1",
-                        "arguments": "not valid json"  # Invalid JSON
-                    }
+                        "arguments": "not valid json",  # Invalid JSON
+                    },
                 }
             ],
             usage=None,
-            context_usage_percentage=None
+            context_usage_percentage=None,
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             with pytest.raises(
                 StreamProtocolError,
                 match="Malformed upstream tool input",
@@ -1032,7 +947,7 @@ class TestCollectAnthropicResponse:
                     mock_model_cache,
                     mock_auth_manager,
                 )
-    
+
     @pytest.mark.asyncio
     async def test_handles_empty_content(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1040,24 +955,20 @@ class TestCollectAnthropicResponse:
         Goal: Verify empty content is handled.
         """
         print("Setup: Mock stream result with empty content...")
-        
+
         mock_result = StreamResult(
-            content="",
-            thinking_content="",
-            tool_calls=[],
-            usage=None,
-            context_usage_percentage=None
+            content="", thinking_content="", tool_calls=[], usage=None, context_usage_percentage=None
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"Result: {result}")
-        
+
         # Content should be empty list
         assert result["content"] == []
         print("✓ Empty content handled correctly")
@@ -1067,9 +978,10 @@ class TestCollectAnthropicResponse:
 # Tests for error handling
 # ==================================================================================================
 
+
 class TestStreamingAnthropicErrorHandling:
     """Tests for error handling in streaming_anthropic."""
-    
+
     @pytest.mark.asyncio
     async def test_propagates_first_token_timeout_error(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1077,24 +989,24 @@ class TestStreamingAnthropicErrorHandling:
         Goal: Verify timeout error is not caught internally.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock stream that raises timeout...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming to Anthropic format with timeout...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
             with pytest.raises(FirstTokenTimeoutError):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     pass
-        
+
         print("✓ FirstTokenTimeoutError propagated correctly")
-    
+
     @pytest.mark.asyncio
     async def test_propagates_generator_exit(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1102,23 +1014,23 @@ class TestStreamingAnthropicErrorHandling:
         Goal: Verify client disconnect is handled.
         """
         print("Setup: Mock stream that raises GeneratorExit...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise GeneratorExit()
-        
+
         print("Action: Streaming to Anthropic format with GeneratorExit...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 with pytest.raises(GeneratorExit):
                     async for event in stream_kiro_to_anthropic(
                         mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                     ):
                         pass
-        
+
         print("✓ GeneratorExit propagated correctly")
-    
+
     @pytest.mark.asyncio
     async def test_yields_error_event_on_exception(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1126,16 +1038,16 @@ class TestStreamingAnthropicErrorHandling:
         Goal: Verify error event is sent to client.
         """
         print("Setup: Mock stream that raises RuntimeError...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to Anthropic format with error...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 try:
                     async for event in stream_kiro_to_anthropic(
                         mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
@@ -1143,15 +1055,15 @@ class TestStreamingAnthropicErrorHandling:
                         events.append(event)
                 except RuntimeError:
                     pass
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have error event
         error_events = [e for e in events if "event: error" in e]
         assert len(error_events) >= 1
         assert "Test error" in error_events[0]
         print("✓ Error event yielded on exception")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_in_finally(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1159,14 +1071,14 @@ class TestStreamingAnthropicErrorHandling:
         Goal: Verify resource cleanup always happens.
         """
         print("Setup: Mock stream that raises error...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             raise ValueError("Test error")
             yield  # Make it a generator
-        
+
         print("Action: Streaming to Anthropic format with error...")
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
             try:
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
@@ -1174,7 +1086,7 @@ class TestStreamingAnthropicErrorHandling:
                     pass
             except ValueError:
                 pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed in finally block")
@@ -1184,15 +1096,16 @@ class TestStreamingAnthropicErrorHandling:
 # Tests for thinking content handling
 # ==================================================================================================
 
+
 class TestStreamWithFirstTokenRetryAnthropic:
     """
     Tests for stream_with_first_token_retry_anthropic() function.
-    
+
     This function wraps stream_kiro_to_anthropic with automatic retry
     on first token timeout. It uses the generic stream_with_first_token_retry
     from streaming_core.py with Anthropic-specific error formatting.
     """
-    
+
     @pytest.mark.asyncio
     async def test_yields_chunks_on_success(self, mock_model_cache, mock_auth_manager):
         """
@@ -1200,37 +1113,37 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify normal operation without retries.
         """
         print("Setup: Mock successful request...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming with retry wrapper...")
         chunks = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_with_first_token_retry_anthropic(
                     make_request=mock_make_request,
                     model="claude-sonnet-4",
                     model_cache=mock_model_cache,
                     auth_manager=mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=30
+                    first_token_timeout=30,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
         assert len(chunks) > 0
         assert any("message_start" in c for c in chunks)
         print("✓ Chunks yielded on success")
-    
+
     @pytest.mark.asyncio
     async def test_retries_on_first_token_timeout(self, mock_model_cache, mock_auth_manager):
         """
@@ -1238,11 +1151,11 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify retry logic is triggered.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock request that times out then succeeds...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1250,35 +1163,35 @@ class TestStreamWithFirstTokenRetryAnthropic:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             nonlocal call_count
             if call_count == 1:
                 raise FirstTokenTimeoutError("Timeout on first attempt")
             yield "event: message_start\ndata: {}\n\n"
             yield "event: message_stop\ndata: {}\n\n"
-        
+
         print("Action: Streaming with retry on timeout...")
         chunks = []
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch("kiro.streaming_anthropic.stream_kiro_to_anthropic", mock_stream_kiro_to_anthropic):
             async for chunk in stream_with_first_token_retry_anthropic(
                 make_request=mock_make_request,
                 model="claude-sonnet-4",
                 model_cache=mock_model_cache,
                 auth_manager=mock_auth_manager,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 chunks.append(chunk)
-        
+
         print(f"Call count: {call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         assert call_count == 2  # First timeout, second success
         assert len(chunks) > 0
         print("✓ Retry on timeout works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_raises_anthropic_error_after_all_retries(self, mock_model_cache, mock_auth_manager):
         """
@@ -1286,22 +1199,22 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify error format matches Anthropic API.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock request that always times out...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with all retries failing...")
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch("kiro.streaming_anthropic.stream_kiro_to_anthropic", mock_stream_kiro_to_anthropic):
             with pytest.raises(Exception) as exc_info:
                 async for chunk in stream_with_first_token_retry_anthropic(
                     make_request=mock_make_request,
@@ -1309,19 +1222,19 @@ class TestStreamWithFirstTokenRetryAnthropic:
                     model_cache=mock_model_cache,
                     auth_manager=mock_auth_manager,
                     max_retries=2,
-                    first_token_timeout=30
+                    first_token_timeout=30,
                 ):
                     pass
-        
+
         print(f"Exception: {exc_info.value}")
-        
+
         # Error should be in Anthropic format (JSON)
         error_json = json.loads(str(exc_info.value))
         assert error_json["type"] == "error"
         assert error_json["error"]["type"] == "timeout_error"
         assert "30" in error_json["error"]["message"]
         print("✓ Anthropic-formatted error raised after all retries")
-    
+
     @pytest.mark.asyncio
     async def test_raises_anthropic_error_on_http_error(self, mock_model_cache, mock_auth_manager):
         """
@@ -1329,16 +1242,16 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify HTTP errors are formatted correctly.
         """
         print("Setup: Mock request that returns HTTP error...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 500
             response.aread = AsyncMock(return_value=b"Internal Server Error")
             response.aclose = AsyncMock()
             return response
-        
+
         print("Action: Streaming with HTTP error...")
-        
+
         with pytest.raises(Exception) as exc_info:
             async for chunk in stream_with_first_token_retry_anthropic(
                 make_request=mock_make_request,
@@ -1346,19 +1259,19 @@ class TestStreamWithFirstTokenRetryAnthropic:
                 model_cache=mock_model_cache,
                 auth_manager=mock_auth_manager,
                 max_retries=2,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
-        
+
         # Error should be in Anthropic format (JSON)
         error_json = json.loads(str(exc_info.value))
         assert error_json["type"] == "error"
         assert error_json["error"]["type"] == "api_error"
         assert "Upstream API error" in error_json["error"]["message"]
         print("✓ Anthropic-formatted error raised on HTTP error")
-    
+
     @pytest.mark.asyncio
     async def test_passes_request_messages_to_stream(self, mock_model_cache, mock_auth_manager):
         """
@@ -1366,39 +1279,39 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify token counting parameters are forwarded.
         """
         print("Setup: Mock request with messages...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         captured_kwargs = {}
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             captured_kwargs.update(kwargs)
             yield "event: message_start\ndata: {}\n\n"
             yield "event: message_stop\ndata: {}\n\n"
-        
+
         request_messages = [{"role": "user", "content": "Hello"}]
-        
+
         print("Action: Streaming with request_messages...")
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch("kiro.streaming_anthropic.stream_kiro_to_anthropic", mock_stream_kiro_to_anthropic):
             async for chunk in stream_with_first_token_retry_anthropic(
                 make_request=mock_make_request,
                 model="claude-sonnet-4",
                 model_cache=mock_model_cache,
                 auth_manager=mock_auth_manager,
-                request_messages=request_messages
+                request_messages=request_messages,
             ):
                 pass
-        
+
         print(f"Captured kwargs: {captured_kwargs}")
         assert captured_kwargs.get("request_messages") == request_messages
         print("✓ request_messages passed to stream function")
-    
+
     @pytest.mark.asyncio
     async def test_uses_configured_max_retries(self, mock_model_cache, mock_auth_manager):
         """
@@ -1406,11 +1319,11 @@ class TestStreamWithFirstTokenRetryAnthropic:
         Goal: Verify max_retries parameter is respected.
         """
         from kiro.streaming_core import FirstTokenTimeoutError
-        
+
         print("Setup: Mock request that always times out...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -1418,14 +1331,14 @@ class TestStreamWithFirstTokenRetryAnthropic:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_kiro_to_anthropic(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with max_retries=5...")
-        
-        with patch('kiro.streaming_anthropic.stream_kiro_to_anthropic', mock_stream_kiro_to_anthropic):
+
+        with patch("kiro.streaming_anthropic.stream_kiro_to_anthropic", mock_stream_kiro_to_anthropic):
             try:
                 async for chunk in stream_with_first_token_retry_anthropic(
                     make_request=mock_make_request,
@@ -1433,12 +1346,12 @@ class TestStreamWithFirstTokenRetryAnthropic:
                     model_cache=mock_model_cache,
                     auth_manager=mock_auth_manager,
                     max_retries=5,
-                    first_token_timeout=30
+                    first_token_timeout=30,
                 ):
                     pass
             except Exception:
                 pass
-        
+
         print(f"Call count: {call_count}")
         assert call_count == 5  # Should try exactly 5 times
         print("✓ max_retries parameter respected")
@@ -1448,9 +1361,10 @@ class TestStreamWithFirstTokenRetryAnthropic:
 # Tests for truncation detection
 # ==================================================================================================
 
+
 class TestStreamingAnthropicTruncationDetection:
     """Tests for truncation detection in Anthropic streaming."""
-    
+
     @pytest.mark.asyncio
     async def test_stop_reason_is_max_tokens_when_truncated(self, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1458,121 +1372,126 @@ class TestStreamingAnthropicTruncationDetection:
         Goal: Verify truncation detection without completion signals.
         """
         print("Setup: Mock stream without completion signals (truncated)...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="This response was cut off mid-sentence because")
             # No context_usage event = truncation
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Should have message_delta with stop_reason: max_tokens
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         print(f"Comparing stop_reason: Expected 'max_tokens', Got event: {message_delta_events[0]}")
         assert "max_tokens" in message_delta_events[0]
         print("✓ stop_reason is max_tokens when truncated")
-    
+
     @pytest.mark.asyncio
-    async def test_stop_reason_is_tool_use_even_without_completion_signals(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_stop_reason_is_tool_use_even_without_completion_signals(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets stop_reason to tool_use when tool use present.
         Goal: Verify tool_use takes priority (not confused with content truncation).
         """
         print("Setup: Mock stream with tool use but no completion signals...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Let me call a tool")
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "toolu_1",
-                "function": {"name": "get_weather", "arguments": "{}"}
-            })
+            yield KiroEvent(
+                type="tool_use", tool_use={"id": "toolu_1", "function": {"name": "get_weather", "arguments": "{}"}}
+            )
             # No context_usage event, but tool use present = tool_use stop_reason
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # Tool use takes priority (not confused with content truncation)
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         print(f"Comparing stop_reason: Expected 'tool_use', Got event: {message_delta_events[0]}")
         assert "tool_use" in message_delta_events[0]
         print("✓ stop_reason is tool_use (not confused with content truncation)")
-    
+
     @pytest.mark.asyncio
-    async def test_stop_reason_is_end_turn_with_completion_signals(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_stop_reason_is_end_turn_with_completion_signals(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets stop_reason to end_turn when completion signals present.
         Goal: Verify normal completion is detected correctly.
         """
         print("Setup: Mock stream with completion signals (not truncated)...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Complete response")
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
-        
+
         print("Action: Streaming to Anthropic format...")
         events = []
-        
-        with patch('kiro.streaming_anthropic.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_anthropic.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                 async for event in stream_kiro_to_anthropic(
                     mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     events.append(event)
-        
+
         print(f"Received {len(events)} events")
-        
+
         # With completion signals, should be end_turn
         message_delta_events = [e for e in events if "message_delta" in e]
         assert len(message_delta_events) >= 1
         print(f"Comparing stop_reason: Expected 'end_turn', Got event: {message_delta_events[0]}")
         assert "end_turn" in message_delta_events[0]
         print("✓ stop_reason is end_turn with completion signals")
-    
+
     @pytest.mark.asyncio
-    async def test_collect_detects_truncation_in_non_streaming(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collect_detects_truncation_in_non_streaming(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Non-streaming detects truncation correctly.
         Goal: Verify collect_anthropic_response detects truncation.
         """
         print("Setup: Mock stream result without completion signals...")
-        
+
         mock_result = StreamResult(
             content="Truncated response",
             thinking_content="",
             tool_calls=[],
             usage=None,
-            context_usage_percentage=None  # No completion signal = truncation
+            context_usage_percentage=None,  # No completion signal = truncation
         )
-        
+
         print("Action: Collecting Anthropic response...")
-        
-        with patch('kiro.streaming_anthropic.collect_stream_to_result', return_value=mock_result):
+
+        with patch("kiro.streaming_anthropic.collect_stream_to_result", return_value=mock_result):
             result = await collect_anthropic_response(
                 mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
             )
-        
+
         print(f"stop_reason: {result['stop_reason']}")
-        
+
         # Should detect truncation and set max_tokens
         assert result["stop_reason"] == "max_tokens"
         print("✓ collect_anthropic_response detects truncation correctly")
@@ -1587,11 +1506,7 @@ class TestStreamingAnthropicNativeOrder:
         mock_auth_manager,
     ):
         fixture = json.loads(
-            (
-                Path(__file__).parents[1]
-                / "fixtures"
-                / "invalid_assistant_content_event_order.json"
-            ).read_text()
+            (Path(__file__).parents[1] / "fixtures" / "invalid_assistant_content_event_order.json").read_text()
         )
 
         async def mock_parse_kiro_stream(*args, **kwargs):
@@ -1618,16 +1533,8 @@ class TestStreamingAnthropicNativeOrder:
 
         events = parse_sse_events(chunks)
         assert_valid_content_event_order(events)
-        signature = next(
-            event
-            for event in events
-            if event.get("delta", {}).get("type") == "signature_delta"
-        )
-        text = next(
-            event
-            for event in events
-            if event.get("delta", {}).get("type") == "text_delta"
-        )
+        signature = next(event for event in events if event.get("delta", {}).get("type") == "signature_delta")
+        text = next(event for event in events if event.get("delta", {}).get("type") == "text_delta")
         assert signature["index"] == 0
         assert signature["delta"]["signature"] == "S1"
         assert text["index"] == 1
@@ -1667,14 +1574,10 @@ class TestStreamingAnthropicNativeOrder:
 
         events = parse_sse_events(chunks)
         signature_position = next(
-            index
-            for index, event in enumerate(events)
-            if event.get("delta", {}).get("type") == "signature_delta"
+            index for index, event in enumerate(events) if event.get("delta", {}).get("type") == "signature_delta"
         )
         text_position = next(
-            index
-            for index, event in enumerate(events)
-            if event.get("delta", {}).get("type") == "text_delta"
+            index for index, event in enumerate(events) if event.get("delta", {}).get("type") == "text_delta"
         )
 
         assert events[signature_position]["index"] == 0
@@ -1741,11 +1644,7 @@ class TestStreamingAnthropicNativeOrder:
                     chunks.append(chunk)
 
         events = parse_sse_events(chunks)
-        starts = [
-            event["content_block"]
-            for event in events
-            if event.get("type") == "content_block_start"
-        ]
+        starts = [event["content_block"] for event in events if event.get("type") == "content_block_start"]
         signatures = [
             (event["index"], event["delta"]["signature"])
             for event in events
@@ -1760,11 +1659,7 @@ class TestStreamingAnthropicNativeOrder:
             "thinking",
             "text",
         ]
-        assert [
-            block.get("id")
-            for block in starts
-            if block["type"] == "tool_use"
-        ] == ["toolu_A", "toolu_B"]
+        assert [block.get("id") for block in starts if block["type"] == "tool_use"] == ["toolu_A", "toolu_B"]
         assert signatures == [(0, "S1"), (4, "S2")]
         assert_valid_content_event_order(events)
 
@@ -1820,11 +1715,7 @@ class TestCollectAnthropicNativeOrder:
             "thinking",
             "text",
         ]
-        assert [
-            block["signature"]
-            for block in result["content"]
-            if block["type"] == "thinking"
-        ] == ["S1", "S2"]
+        assert [block["signature"] for block in result["content"] if block["type"] == "thinking"] == ["S1", "S2"]
 
 
 class TestAnthropicRetryLifecycle:

--- a/tests/unit/test_streaming_core.py
+++ b/tests/unit/test_streaming_core.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -13,28 +12,25 @@ Tests for:
 - calculate_tokens_from_context_usage() function
 """
 
-import pytest
-import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
-from dataclasses import asdict
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from kiro.parsers import MalformedToolInputError
 from kiro.streaming_core import (
+    FirstTokenTimeoutError,
     KiroEvent,
     StreamResult,
-    FirstTokenTimeoutError,
-    parse_kiro_stream,
-    collect_stream_to_result,
     calculate_tokens_from_context_usage,
+    parse_kiro_stream,
     stream_with_first_token_retry,
-    _process_chunk,
 )
-from kiro.parsers import MalformedToolInputError
-
 
 # ==================================================================================================
 # Fixtures
 # ==================================================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -66,9 +62,10 @@ def mock_parser():
 # Tests for KiroEvent dataclass
 # ==================================================================================================
 
+
 class TestKiroEvent:
     """Tests for KiroEvent dataclass."""
-    
+
     def test_creates_content_event(self):
         """
         What it does: Creates a content event with text.
@@ -76,7 +73,7 @@ class TestKiroEvent:
         """
         print("Action: Creating content event...")
         event = KiroEvent(type="content", content="Hello, world!")
-        
+
         print(f"Comparing type: Expected 'content', Got '{event.type}'")
         assert event.type == "content"
         print(f"Comparing content: Expected 'Hello, world!', Got '{event.content}'")
@@ -84,7 +81,7 @@ class TestKiroEvent:
         assert event.thinking_content is None
         assert event.tool_use is None
         print("✓ Content event created correctly")
-    
+
     def test_creates_thinking_event(self):
         """
         What it does: Creates a thinking event with reasoning content.
@@ -95,9 +92,9 @@ class TestKiroEvent:
             type="thinking",
             thinking_content="Let me think...",
             is_first_thinking_chunk=True,
-            is_last_thinking_chunk=False
+            is_last_thinking_chunk=False,
         )
-        
+
         print(f"Comparing type: Expected 'thinking', Got '{event.type}'")
         assert event.type == "thinking"
         print(f"Comparing thinking_content: Expected 'Let me think...', Got '{event.thinking_content}'")
@@ -105,7 +102,7 @@ class TestKiroEvent:
         assert event.is_first_thinking_chunk is True
         assert event.is_last_thinking_chunk is False
         print("✓ Thinking event created correctly")
-    
+
     def test_creates_tool_use_event(self):
         """
         What it does: Creates a tool_use event with tool data.
@@ -115,16 +112,16 @@ class TestKiroEvent:
         tool_data = {
             "id": "call_123",
             "type": "function",
-            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'}
+            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'},
         }
         event = KiroEvent(type="tool_use", tool_use=tool_data)
-        
+
         print(f"Comparing type: Expected 'tool_use', Got '{event.type}'")
         assert event.type == "tool_use"
         print(f"Comparing tool_use: Expected {tool_data}, Got {event.tool_use}")
         assert event.tool_use == tool_data
         print("✓ Tool use event created correctly")
-    
+
     def test_creates_usage_event(self):
         """
         What it does: Creates a usage event with metering data.
@@ -133,13 +130,13 @@ class TestKiroEvent:
         print("Action: Creating usage event...")
         usage_data = {"credits": 0.001}
         event = KiroEvent(type="usage", usage=usage_data)
-        
+
         print(f"Comparing type: Expected 'usage', Got '{event.type}'")
         assert event.type == "usage"
         print(f"Comparing usage: Expected {usage_data}, Got {event.usage}")
         assert event.usage == usage_data
         print("✓ Usage event created correctly")
-    
+
     def test_creates_context_usage_event(self):
         """
         What it does: Creates a context_usage event with percentage.
@@ -147,13 +144,13 @@ class TestKiroEvent:
         """
         print("Action: Creating context_usage event...")
         event = KiroEvent(type="context_usage", context_usage_percentage=5.5)
-        
+
         print(f"Comparing type: Expected 'context_usage', Got '{event.type}'")
         assert event.type == "context_usage"
         print(f"Comparing context_usage_percentage: Expected 5.5, Got {event.context_usage_percentage}")
         assert event.context_usage_percentage == 5.5
         print("✓ Context usage event created correctly")
-    
+
     def test_default_values(self):
         """
         What it does: Verifies default values for optional fields.
@@ -161,7 +158,7 @@ class TestKiroEvent:
         """
         print("Action: Creating minimal event...")
         event = KiroEvent(type="content")
-        
+
         print("Checking default values...")
         assert event.content is None
         assert event.thinking_content is None
@@ -177,9 +174,10 @@ class TestKiroEvent:
 # Tests for StreamResult dataclass
 # ==================================================================================================
 
+
 class TestStreamResult:
     """Tests for StreamResult dataclass."""
-    
+
     def test_creates_empty_result(self):
         """
         What it does: Creates an empty StreamResult.
@@ -187,7 +185,7 @@ class TestStreamResult:
         """
         print("Action: Creating empty StreamResult...")
         result = StreamResult()
-        
+
         print("Checking default values...")
         assert result.content == ""
         assert result.thinking_content == ""
@@ -195,7 +193,7 @@ class TestStreamResult:
         assert result.usage is None
         assert result.context_usage_percentage is None
         print("✓ Empty StreamResult created correctly")
-    
+
     def test_creates_result_with_content(self):
         """
         What it does: Creates StreamResult with content.
@@ -203,28 +201,25 @@ class TestStreamResult:
         """
         print("Action: Creating StreamResult with content...")
         result = StreamResult(content="Hello, world!")
-        
+
         print(f"Comparing content: Expected 'Hello, world!', Got '{result.content}'")
         assert result.content == "Hello, world!"
         print("✓ StreamResult with content created correctly")
-    
+
     def test_creates_result_with_tool_calls(self):
         """
         What it does: Creates StreamResult with tool calls.
         Goal: Verify tool calls are stored correctly.
         """
         print("Action: Creating StreamResult with tool calls...")
-        tool_calls = [
-            {"id": "call_1", "function": {"name": "func1"}},
-            {"id": "call_2", "function": {"name": "func2"}}
-        ]
+        tool_calls = [{"id": "call_1", "function": {"name": "func1"}}, {"id": "call_2", "function": {"name": "func2"}}]
         result = StreamResult(tool_calls=tool_calls)
-        
+
         print(f"Comparing tool_calls count: Expected 2, Got {len(result.tool_calls)}")
         assert len(result.tool_calls) == 2
         assert result.tool_calls[0]["id"] == "call_1"
         print("✓ StreamResult with tool calls created correctly")
-    
+
     def test_creates_result_with_usage(self):
         """
         What it does: Creates StreamResult with usage data.
@@ -233,11 +228,11 @@ class TestStreamResult:
         print("Action: Creating StreamResult with usage...")
         usage = {"credits": 0.002}
         result = StreamResult(usage=usage)
-        
+
         print(f"Comparing usage: Expected {usage}, Got {result.usage}")
         assert result.usage == usage
         print("✓ StreamResult with usage created correctly")
-    
+
     def test_creates_full_result(self):
         """
         What it does: Creates StreamResult with all fields.
@@ -249,9 +244,9 @@ class TestStreamResult:
             thinking_content="Thinking...",
             tool_calls=[{"id": "call_1"}],
             usage={"credits": 0.001},
-            context_usage_percentage=3.5
+            context_usage_percentage=3.5,
         )
-        
+
         print("Checking all fields...")
         assert result.content == "Response text"
         assert result.thinking_content == "Thinking..."
@@ -265,9 +260,10 @@ class TestStreamResult:
 # Tests for FirstTokenTimeoutError
 # ==================================================================================================
 
+
 class TestFirstTokenTimeoutError:
     """Tests for FirstTokenTimeoutError exception."""
-    
+
     def test_creates_exception_with_message(self):
         """
         What it does: Creates exception with custom message.
@@ -275,25 +271,25 @@ class TestFirstTokenTimeoutError:
         """
         print("Action: Creating FirstTokenTimeoutError...")
         error = FirstTokenTimeoutError("No response within 30 seconds")
-        
+
         print(f"Comparing message: Expected 'No response within 30 seconds', Got '{str(error)}'")
         assert str(error) == "No response within 30 seconds"
         print("✓ Exception created correctly")
-    
+
     def test_exception_is_catchable(self):
         """
         What it does: Verifies exception can be caught.
         Goal: Ensure exception inherits from Exception.
         """
         print("Action: Raising and catching FirstTokenTimeoutError...")
-        
+
         with pytest.raises(FirstTokenTimeoutError) as exc_info:
             raise FirstTokenTimeoutError("Timeout!")
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Timeout!" in str(exc_info.value)
         print("✓ Exception is catchable")
-    
+
     def test_exception_inherits_from_exception(self):
         """
         What it does: Verifies inheritance chain.
@@ -301,7 +297,7 @@ class TestFirstTokenTimeoutError:
         """
         print("Action: Checking inheritance...")
         error = FirstTokenTimeoutError("Test")
-        
+
         assert isinstance(error, Exception)
         print("✓ FirstTokenTimeoutError inherits from Exception")
 
@@ -310,9 +306,10 @@ class TestFirstTokenTimeoutError:
 # Tests for parse_kiro_stream()
 # ==================================================================================================
 
+
 class TestCalculateTokensFromContextUsage:
     """Tests for calculate_tokens_from_context_usage() function."""
-    
+
     def test_calculates_tokens_from_percentage(self, mock_model_cache):
         """
         What it does: Calculates tokens from context usage percentage.
@@ -321,12 +318,12 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 10% with 200000 max tokens...")
         context_usage_percentage = 10.0
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
         )
-        
+
         # 10% of 200000 = 20000 total tokens
         # prompt_tokens = 20000 - 100 = 19900
         print(f"Comparing total_tokens: Expected 20000, Got {total_tokens}")
@@ -336,7 +333,7 @@ class TestCalculateTokensFromContextUsage:
         assert prompt_source == "subtraction"
         assert total_source == "API Kiro"
         print("✓ Tokens calculated correctly")
-    
+
     def test_handles_zero_percentage(self, mock_model_cache):
         """
         What it does: Handles zero context usage percentage.
@@ -345,12 +342,12 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 0%...")
         context_usage_percentage = 0.0
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
         )
-        
+
         print(f"Comparing prompt_tokens: Expected 0, Got {prompt_tokens}")
         assert prompt_tokens == 0
         print(f"Comparing total_tokens: Expected 100, Got {total_tokens}")
@@ -358,7 +355,7 @@ class TestCalculateTokensFromContextUsage:
         assert prompt_source == "unknown"
         assert total_source == "tiktoken"
         print("✓ Zero percentage handled correctly")
-    
+
     def test_handles_none_percentage(self, mock_model_cache):
         """
         What it does: Handles None context usage percentage.
@@ -367,12 +364,12 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage None...")
         context_usage_percentage = None
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
         )
-        
+
         print(f"Comparing prompt_tokens: Expected 0, Got {prompt_tokens}")
         assert prompt_tokens == 0
         print(f"Comparing total_tokens: Expected 100, Got {total_tokens}")
@@ -380,7 +377,7 @@ class TestCalculateTokensFromContextUsage:
         assert prompt_source == "unknown"
         assert total_source == "tiktoken"
         print("✓ None percentage handled correctly")
-    
+
     def test_prevents_negative_prompt_tokens(self, mock_model_cache):
         """
         What it does: Prevents negative prompt tokens.
@@ -389,16 +386,16 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Very small context usage with large completion...")
         context_usage_percentage = 0.01  # 0.01% of 200000 = 20 total tokens
         completion_tokens = 100  # More than total!
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
         )
-        
+
         print(f"Comparing prompt_tokens: Expected >= 0, Got {prompt_tokens}")
         assert prompt_tokens >= 0
         print("✓ Negative prompt tokens prevented")
-    
+
     def test_uses_model_specific_max_tokens(self, mock_model_cache):
         """
         What it does: Uses model-specific max input tokens.
@@ -408,20 +405,20 @@ class TestCalculateTokensFromContextUsage:
         mock_model_cache.get_max_input_tokens.return_value = 100000  # Different from default
         context_usage_percentage = 10.0
         completion_tokens = 100
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-haiku-3"
         )
-        
+
         # 10% of 100000 = 10000 total tokens
         print(f"Comparing total_tokens: Expected 10000, Got {total_tokens}")
         assert total_tokens == 10000
-        
+
         # Verify model cache was called with correct model
         mock_model_cache.get_max_input_tokens.assert_called_with("claude-haiku-3")
         print("✓ Model-specific max tokens used correctly")
-    
+
     def test_small_percentage_calculation(self, mock_model_cache):
         """
         What it does: Calculates tokens for small percentage.
@@ -430,12 +427,12 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 0.5%...")
         context_usage_percentage = 0.5
         completion_tokens = 50
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
         )
-        
+
         # 0.5% of 200000 = 1000 total tokens
         # prompt_tokens = 1000 - 50 = 950
         print(f"Comparing total_tokens: Expected 1000, Got {total_tokens}")
@@ -443,7 +440,7 @@ class TestCalculateTokensFromContextUsage:
         print(f"Comparing prompt_tokens: Expected 950, Got {prompt_tokens}")
         assert prompt_tokens == 950
         print("✓ Small percentage calculated correctly")
-    
+
     def test_large_percentage_calculation(self, mock_model_cache):
         """
         What it does: Calculates tokens for large percentage.
@@ -452,12 +449,12 @@ class TestCalculateTokensFromContextUsage:
         print("Setup: Context usage 95%...")
         context_usage_percentage = 95.0
         completion_tokens = 1000
-        
+
         print("Action: Calculating tokens...")
         prompt_tokens, total_tokens, prompt_source, total_source = calculate_tokens_from_context_usage(
             context_usage_percentage, completion_tokens, mock_model_cache, "claude-sonnet-4"
         )
-        
+
         # 95% of 200000 = 190000 total tokens
         # prompt_tokens = 190000 - 1000 = 189000
         print(f"Comparing total_tokens: Expected 190000, Got {total_tokens}")
@@ -471,14 +468,15 @@ class TestCalculateTokensFromContextUsage:
 # Tests for thinking parser integration
 # ==================================================================================================
 
+
 class TestStreamWithFirstTokenRetryCore:
     """
     Tests for stream_with_first_token_retry() generic function.
-    
+
     This function provides automatic retry logic on first token timeout.
     It is used by both OpenAI and Anthropic streaming implementations.
     """
-    
+
     @pytest.mark.asyncio
     async def test_yields_chunks_on_success(self):
         """
@@ -486,35 +484,35 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify normal operation without retries.
         """
         print("Setup: Mock successful request...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         async def mock_stream_processor(response):
             yield "chunk1"
             yield "chunk2"
             yield "chunk3"
-        
+
         print("Action: Streaming with retry wrapper...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
         assert len(chunks) == 3
         assert chunks == ["chunk1", "chunk2", "chunk3"]
         print("✓ Chunks yielded on success")
-    
+
     @pytest.mark.asyncio
     async def test_retries_on_first_token_timeout(self):
         """
@@ -522,9 +520,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify retry logic is triggered.
         """
         print("Setup: Mock request that times out then succeeds...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -532,32 +530,32 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             nonlocal call_count
             if call_count == 1:
                 raise FirstTokenTimeoutError("Timeout on first attempt")
             yield "success_chunk"
-        
+
         print("Action: Streaming with retry on timeout...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"Call count: {call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         assert call_count == 2  # First timeout, second success
         assert len(chunks) == 1
         assert chunks[0] == "success_chunk"
         print("✓ Retry on timeout works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_raises_exception_after_all_retries(self):
         """
@@ -565,9 +563,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify error handling when all retries fail.
         """
         print("Setup: Mock request that always times out...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -575,30 +573,30 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with all retries failing...")
-        
+
         with pytest.raises(Exception) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Call count: {call_count}")
         print(f"Exception: {exc_info.value}")
-        
+
         assert call_count == 3  # Should try exactly 3 times
         assert "30" in str(exc_info.value)  # Timeout value in message
         assert "3" in str(exc_info.value)  # Retry count in message
         print("✓ Exception raised after all retries")
-    
+
     @pytest.mark.asyncio
     async def test_uses_custom_error_callbacks(self):
         """
@@ -606,38 +604,38 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify on_http_error and on_all_retries_failed callbacks.
         """
         print("Setup: Mock request that always times out with custom callbacks...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         def custom_all_retries_failed(max_retries, timeout):
             return ValueError(f"Custom error: {max_retries} retries, {timeout}s timeout")
-        
+
         print("Action: Streaming with custom callback...")
-        
+
         with pytest.raises(ValueError) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=2,
                 first_token_timeout=15,
-                on_all_retries_failed=custom_all_retries_failed
+                on_all_retries_failed=custom_all_retries_failed,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
         assert "Custom error" in str(exc_info.value)
         assert "2 retries" in str(exc_info.value)
         assert "15" in str(exc_info.value)
         print("✓ Custom callback used correctly")
-    
+
     @pytest.mark.asyncio
     async def test_handles_http_error(self):
         """
@@ -645,33 +643,33 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify HTTP errors are handled correctly.
         """
         print("Setup: Mock request that returns HTTP error...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 500
             response.aread = AsyncMock(return_value=b"Internal Server Error")
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             yield "should not reach"
-        
+
         print("Action: Streaming with HTTP error...")
-        
+
         with pytest.raises(Exception) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
         assert "500" in str(exc_info.value)
         assert "Internal Server Error" in str(exc_info.value)
         print("✓ HTTP error handled correctly")
-    
+
     @pytest.mark.asyncio
     async def test_uses_custom_http_error_callback(self):
         """
@@ -679,38 +677,38 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify on_http_error callback is used.
         """
         print("Setup: Mock request with custom HTTP error callback...")
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 429
             response.aread = AsyncMock(return_value=b"Rate limited")
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             yield "should not reach"
-        
+
         def custom_http_error(status_code, error_text):
             return RuntimeError(f"Custom HTTP error: {status_code} - {error_text}")
-        
+
         print("Action: Streaming with custom HTTP error callback...")
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
                 first_token_timeout=30,
-                on_http_error=custom_http_error
+                on_http_error=custom_http_error,
             ):
                 pass
-        
+
         print(f"Exception: {exc_info.value}")
         assert "Custom HTTP error" in str(exc_info.value)
         assert "429" in str(exc_info.value)
         assert "Rate limited" in str(exc_info.value)
         print("✓ Custom HTTP error callback used correctly")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_timeout(self):
         """
@@ -718,42 +716,42 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify response is properly closed after timeout.
         """
         print("Setup: Mock request that times out...")
-        
+
         responses = []
-        
+
         async def mock_make_request():
             response = AsyncMock()
             response.status_code = 200
             response.aclose = AsyncMock()
             responses.append(response)
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with timeout...")
-        
+
         try:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=2,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
         except Exception:
             pass
-        
+
         print(f"Created {len(responses)} responses")
-        
+
         # All responses should have been closed
         for i, response in enumerate(responses):
             print(f"Response {i} aclose called: {response.aclose.called}")
             response.aclose.assert_called()
-        
+
         print("✓ Responses closed on timeout")
-    
+
     @pytest.mark.asyncio
     async def test_propagates_non_timeout_exceptions(self):
         """
@@ -761,9 +759,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify other exceptions are not retried.
         """
         print("Setup: Mock request that raises RuntimeError...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -771,29 +769,29 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise RuntimeError("Not a timeout error")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with non-timeout error...")
-        
+
         with pytest.raises(RuntimeError) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
-        
+
         print(f"Call count: {call_count}")
         print(f"Exception: {exc_info.value}")
-        
+
         assert call_count == 1  # Should NOT retry
         assert "Not a timeout error" in str(exc_info.value)
         print("✓ Non-timeout exceptions propagated without retry")
-    
+
     @pytest.mark.asyncio
     async def test_uses_configured_max_retries(self):
         """
@@ -801,9 +799,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify max_retries parameter is respected.
         """
         print("Setup: Mock request that always times out...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -811,28 +809,28 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming with max_retries=5...")
-        
+
         try:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=5,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
         except Exception:
             pass
-        
+
         print(f"Call count: {call_count}")
         assert call_count == 5  # Should try exactly 5 times
         print("✓ max_retries parameter respected")
-    
+
     @pytest.mark.asyncio
     async def test_multiple_retries_then_success(self):
         """
@@ -840,9 +838,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify recovery after multiple failures.
         """
         print("Setup: Mock request that fails twice then succeeds...")
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
@@ -850,32 +848,32 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             nonlocal call_count
             if call_count < 3:
                 raise FirstTokenTimeoutError(f"Timeout on attempt {call_count}")
             yield "finally_success"
-        
+
         print("Action: Streaming with multiple retries...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             max_retries=5,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"Call count: {call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         assert call_count == 3  # Failed twice, succeeded on third
         assert len(chunks) == 1
         assert chunks[0] == "finally_success"
         print("✓ Multiple retries then success works correctly")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_http_error(self):
         """
@@ -883,35 +881,35 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify response is properly closed after HTTP error.
         """
         print("Setup: Mock request that returns HTTP error...")
-        
+
         response = AsyncMock()
         response.status_code = 503
         response.aread = AsyncMock(return_value=b"Service Unavailable")
         response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return response
-        
+
         async def mock_stream_processor(resp):
             yield "should not reach"
-        
+
         print("Action: Streaming with HTTP error...")
-        
+
         try:
             async for chunk in stream_with_first_token_retry(
                 make_request=mock_make_request,
                 stream_processor=mock_stream_processor,
                 max_retries=3,
-                first_token_timeout=30
+                first_token_timeout=30,
             ):
                 pass
         except Exception:
             pass
-        
+
         print(f"Response aclose called: {response.aclose.called}")
         response.aclose.assert_called()
         print("✓ Response closed on HTTP error")
-    
+
     @pytest.mark.asyncio
     async def test_reuses_initial_response_on_first_attempt(self):
         """
@@ -919,13 +917,13 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify initial_response is used instead of calling make_request.
         """
         print("Setup: Mock initial response...")
-        
+
         initial_response = AsyncMock()
         initial_response.status_code = 200
         initial_response.aclose = AsyncMock()
-        
+
         make_request_called = False
-        
+
         async def mock_make_request():
             nonlocal make_request_called
             make_request_called = True
@@ -933,33 +931,33 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             # Verify we got the initial response
             assert response is initial_response
             yield "chunk_from_initial"
-        
+
         print("Action: Streaming with initial_response...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             initial_response=initial_response,
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"make_request called: {make_request_called}")
         print(f"Received {len(chunks)} chunks")
-        
+
         # make_request should NOT be called on first attempt
         assert not make_request_called
         assert len(chunks) == 1
         assert chunks[0] == "chunk_from_initial"
         print("✓ initial_response reused on first attempt")
-    
+
     @pytest.mark.asyncio
     async def test_calls_make_request_on_retry(self):
         """
@@ -967,13 +965,13 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify make_request is called when retrying after timeout.
         """
         print("Setup: Mock initial response that times out...")
-        
+
         initial_response = AsyncMock()
         initial_response.status_code = 200
         initial_response.aclose = AsyncMock()
-        
+
         make_request_call_count = 0
-        
+
         async def mock_make_request():
             nonlocal make_request_call_count
             make_request_call_count += 1
@@ -982,13 +980,13 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         attempt_count = 0
-        
+
         async def mock_stream_processor(response):
             nonlocal attempt_count
             attempt_count += 1
-            
+
             if attempt_count == 1:
                 # First attempt with initial_response - timeout
                 assert response is initial_response
@@ -997,29 +995,29 @@ class TestStreamWithFirstTokenRetryCore:
                 # Retry attempts - should get response from make_request
                 assert response is not initial_response
                 yield "success_chunk"
-        
+
         print("Action: Streaming with initial_response that times out...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             initial_response=initial_response,
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"make_request call count: {make_request_call_count}")
         print(f"Total attempts: {attempt_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         # make_request should be called once (on retry)
         assert make_request_call_count == 1
         assert attempt_count == 2  # First with initial_response, second with make_request
         assert len(chunks) == 1
         print("✓ make_request called on retry")
-    
+
     @pytest.mark.asyncio
     async def test_initial_response_none_calls_make_request_immediately(self):
         """
@@ -1027,9 +1025,9 @@ class TestStreamWithFirstTokenRetryCore:
         Goal: Verify backward compatibility (old behavior).
         """
         print("Setup: No initial_response (None)...")
-        
+
         make_request_call_count = 0
-        
+
         async def mock_make_request():
             nonlocal make_request_call_count
             make_request_call_count += 1
@@ -1038,25 +1036,25 @@ class TestStreamWithFirstTokenRetryCore:
             response.status_code = 200
             response.aclose = AsyncMock()
             return response
-        
+
         async def mock_stream_processor(response):
             yield "chunk"
-        
+
         print("Action: Streaming without initial_response...")
         chunks = []
-        
+
         async for chunk in stream_with_first_token_retry(
             make_request=mock_make_request,
             stream_processor=mock_stream_processor,
             initial_response=None,  # Explicitly None
             max_retries=3,
-            first_token_timeout=30
+            first_token_timeout=30,
         ):
             chunks.append(chunk)
-        
+
         print(f"make_request call count: {make_request_call_count}")
         print(f"Received {len(chunks)} chunks")
-        
+
         # make_request should be called immediately (old behavior)
         assert make_request_call_count == 1
         assert len(chunks) == 1

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 """
@@ -11,24 +10,23 @@ Tests for:
 - collect_stream_response() function
 """
 
-import pytest
 import json
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from kiro.streaming_openai import (
-    stream_kiro_to_openai,
-    stream_kiro_to_openai_internal,
-    stream_with_first_token_retry,
-    collect_stream_response,
-    FirstTokenTimeoutError,
-)
-from kiro.streaming_core import KiroEvent
+import pytest
 
+from kiro.streaming_core import KiroEvent
+from kiro.streaming_openai import (
+    FirstTokenTimeoutError,
+    collect_stream_response,
+    stream_kiro_to_openai,
+    stream_with_first_token_retry,
+)
 
 # ==================================================================================================
 # Fixtures
 # ==================================================================================================
+
 
 @pytest.fixture
 def mock_model_cache():
@@ -65,9 +63,10 @@ def mock_response():
 # Tests for stream_kiro_to_openai()
 # ==================================================================================================
 
+
 class TestStreamKiroToOpenai:
     """Tests for stream_kiro_to_openai() generator."""
-    
+
     @pytest.mark.asyncio
     async def test_yields_content_chunks(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -75,29 +74,28 @@ class TestStreamKiroToOpenai:
         Goal: Verify content streaming.
         """
         print("Setup: Mock stream with content events...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="content", content=" World")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have content chunks
         content_chunks = [c for c in chunks if "content" in c and '"Hello"' in c or '" World"' in c]
         assert len(content_chunks) >= 2
         print("✓ Content chunks yielded correctly")
-    
+
     @pytest.mark.asyncio
     async def test_first_chunk_has_role(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -105,30 +103,29 @@ class TestStreamKiroToOpenai:
         Goal: Verify OpenAI streaming protocol.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         first_chunk = json.loads(chunks[0].removeprefix("data: "))
         assert first_chunk["choices"][0]["delta"] == {
             "role": "assistant",
             "content": "",
         }
         print("✓ First chunk has a standalone role: assistant delta")
-    
+
     @pytest.mark.asyncio
     async def test_yields_done_at_end(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -136,57 +133,57 @@ class TestStreamKiroToOpenai:
         Goal: Verify stream termination.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Last chunk should be [DONE]
         assert chunks[-1] == "data: [DONE]\n\n"
         print("✓ [DONE] yielded at end")
-    
+
     @pytest.mark.asyncio
-    async def test_yields_final_chunk_with_usage(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_yields_final_chunk_with_usage(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields final chunk with usage info.
         Goal: Verify usage is included.
         """
         print("Setup: Mock stream with content...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have chunk with usage before [DONE]
         usage_chunks = [c for c in chunks if '"usage"' in c]
         assert len(usage_chunks) >= 1
         print("✓ Final chunk with usage yielded")
-    
+
     @pytest.mark.asyncio
     async def test_yields_tool_calls_chunk(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -194,30 +191,29 @@ class TestStreamKiroToOpenai:
         Goal: Verify tool call streaming.
         """
         print("Setup: Mock stream with tool call...")
-        
+
         tool_use_data = {
             "id": "call_123",
             "type": "function",
-            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'}
+            "function": {"name": "get_weather", "arguments": '{"city": "Moscow"}'},
         }
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Let me check")
             yield KiroEvent(type="tool_use", tool_use=tool_use_data)
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have tool_calls chunk
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
@@ -280,9 +276,7 @@ class TestStreamKiroToOpenai:
         assert "I will search the repository." in stream
         assert "call_search" in stream
         assert "call_bash" in stream
-        assert stream.index('"tool_calls"') < stream.index(
-            '"finish_reason": "tool_calls"'
-        )
+        assert stream.index('"tool_calls"') < stream.index('"finish_reason": "tool_calls"')
 
     @pytest.mark.asyncio
     async def test_tool_capable_final_text_preserves_reasoning_block(
@@ -350,7 +344,7 @@ class TestStreamKiroToOpenai:
         assert '"reasoning"' not in stream
         assert "internal" not in stream
         assert "Final answer" in stream
-    
+
     @pytest.mark.asyncio
     async def test_tool_calls_have_index(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -358,34 +352,33 @@ class TestStreamKiroToOpenai:
         Goal: Verify OpenAI streaming spec compliance.
         """
         print("Setup: Mock stream with multiple tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_2", "type": "function",
-                "function": {"name": "func2", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}},
+            )
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_2", "type": "function", "function": {"name": "func2", "arguments": "{}"}},
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Find tool_calls chunk and verify indices
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
-        
+
         # Parse and check indices
         for chunk in tool_chunks:
             if chunk.startswith("data: "):
@@ -397,7 +390,7 @@ class TestStreamKiroToOpenai:
                         if "tool_calls" in delta:
                             for tc in delta["tool_calls"]:
                                 assert "index" in tc
-        
+
         print("✓ Tool calls have index field")
 
     @pytest.mark.asyncio
@@ -441,94 +434,97 @@ class TestStreamKiroToOpenai:
         stream = "".join(chunks)
         assert "call_0" in stream
         assert "call_1" not in stream
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_tool_calls_when_tools_present(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_tool_calls_when_tools_present(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to tool_calls when tools present.
         Goal: Verify correct finish reason.
         """
         print("Setup: Mock stream with tool call...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}},
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk before [DONE] should have finish_reason: tool_calls
         final_chunk = chunks[-2]  # Before [DONE]
         assert '"finish_reason": "tool_calls"' in final_chunk
         print("✓ finish_reason is tool_calls")
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_stop_without_tools(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_stop_without_tools(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to stop without tools.
         Goal: Verify correct finish reason.
         """
         print("Setup: Mock stream without tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="usage", usage={"inputTokenCount": 10, "outputTokenCount": 1})
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk before [DONE] should have finish_reason: stop
         final_chunk = chunks[-2]  # Before [DONE]
         assert '"finish_reason": "stop"' in final_chunk
         print("✓ finish_reason is stop")
-    
+
     @pytest.mark.asyncio
-    async def test_closes_response_on_completion(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_closes_response_on_completion(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Closes response on completion.
         Goal: Verify resource cleanup.
         """
         print("Setup: Mock stream...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
-        
+
         print("Action: Streaming to OpenAI format...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on completion")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_error(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -536,24 +532,23 @@ class TestStreamKiroToOpenai:
         Goal: Verify resource cleanup on error.
         """
         print("Setup: Mock stream that raises error...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to OpenAI format with error...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 try:
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                     ):
                         pass
                 except RuntimeError:
                     pass
-        
+
         print("Check: response.aclose() should be called...")
         mock_response.aclose.assert_called()
         print("✓ Response closed on error")
@@ -563,40 +558,42 @@ class TestStreamKiroToOpenai:
 # Tests for thinking content handling
 # ==================================================================================================
 
+
 class TestStreamingOpenaiNoneProtection:
     """Tests for None protection in tool calls."""
-    
+
     @pytest.mark.asyncio
-    async def test_handles_none_function_name(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_none_function_name(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles None in function.name.
         Goal: Verify None is replaced with empty string.
         """
         print("Setup: Mock stream with None function name...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": None, "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": {"name": None, "arguments": "{}"}},
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should handle None gracefully
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
-        
+
         # Parse and verify name is empty string
         for chunk in tool_chunks:
             if chunk.startswith("data: "):
@@ -608,40 +605,41 @@ class TestStreamingOpenaiNoneProtection:
                         if "tool_calls" in delta:
                             for tc in delta["tool_calls"]:
                                 assert tc["function"]["name"] == ""
-        
+
         print("✓ None function name handled")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_none_function_arguments(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_none_function_arguments(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles None in function.arguments.
         Goal: Verify None is replaced with "{}".
         """
         print("Setup: Mock stream with None arguments...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": None}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": None}},
+            )
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should handle None gracefully
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
-        
+
         # Parse and verify arguments is "{}"
         for chunk in tool_chunks:
             if chunk.startswith("data: "):
@@ -653,36 +651,34 @@ class TestStreamingOpenaiNoneProtection:
                         if "tool_calls" in delta:
                             for tc in delta["tool_calls"]:
                                 assert tc["function"]["arguments"] == "{}"
-        
+
         print("✓ None function arguments handled")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_none_function_object(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_none_function_object(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles None function object.
         Goal: Verify None function is handled.
         """
         print("Setup: Mock stream with None function...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": None
-            })
-        
+            yield KiroEvent(type="tool_use", tool_use={"id": "call_1", "type": "function", "function": None})
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should handle None gracefully without error
         assert len(chunks) > 0
         print("✓ None function object handled")
@@ -692,9 +688,10 @@ class TestStreamingOpenaiNoneProtection:
 # Tests for stream_with_first_token_retry()
 # ==================================================================================================
 
+
 class TestStreamWithFirstTokenRetry:
     """Tests for stream_with_first_token_retry() function."""
-    
+
     @pytest.mark.asyncio
     async def test_retries_on_first_token_timeout(self, mock_http_client, mock_model_cache, mock_auth_manager):
         """
@@ -702,34 +699,34 @@ class TestStreamWithFirstTokenRetry:
         Goal: Verify retry logic.
         """
         print("Setup: Mock make_request that succeeds on second attempt...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
             print(f"make_request called (attempt {call_count})")
             return mock_response
-        
+
         # First call raises timeout, second succeeds
         timeout_raised = False
-        
+
         async def mock_parse_kiro_stream_with_retry(*args, **kwargs):
             nonlocal timeout_raised
             if not timeout_raised:
                 timeout_raised = True
                 raise FirstTokenTimeoutError("Timeout!")
             yield KiroEvent(type="content", content="Success")
-        
+
         print("Action: Running stream_with_first_token_retry...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_with_retry):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_with_retry):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
                     mock_http_client,
@@ -737,17 +734,17 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
         print(f"make_request was called {call_count} times")
-        
+
         assert call_count == 2
         assert len(chunks) > 0
         print("✓ Retry logic worked correctly")
-    
+
     @pytest.mark.asyncio
     async def test_raises_504_after_all_retries_exhausted(self, mock_http_client, mock_model_cache, mock_auth_manager):
         """
@@ -755,29 +752,29 @@ class TestStreamWithFirstTokenRetry:
         Goal: Verify error handling.
         """
         from fastapi import HTTPException
-        
+
         print("Setup: Mock make_request that always times out...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
             return mock_response
-        
+
         async def mock_parse_kiro_stream_always_timeout(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         max_retries = 3
-        
+
         print(f"Action: Running stream_with_first_token_retry with max_retries={max_retries}...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_always_timeout):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_always_timeout):
             with pytest.raises(HTTPException) as exc_info:
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
@@ -786,17 +783,17 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=max_retries,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     pass
-        
+
         print(f"Caught HTTPException: {exc_info.value.status_code}")
         print(f"make_request was called {call_count} times")
-        
+
         assert exc_info.value.status_code == 504
         assert call_count == max_retries
         print("✓ 504 raised after all retries exhausted")
-    
+
     @pytest.mark.asyncio
     async def test_handles_api_error_response(self, mock_http_client, mock_model_cache, mock_auth_manager):
         """
@@ -804,20 +801,20 @@ class TestStreamWithFirstTokenRetry:
         Goal: Verify error response handling.
         """
         from fastapi import HTTPException
-        
+
         print("Setup: Mock make_request that returns error...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 500
         # Use simple error text without curly braces to avoid loguru format issues
-        mock_response.aread = AsyncMock(return_value=b'Internal server error')
+        mock_response.aread = AsyncMock(return_value=b"Internal server error")
         mock_response.aclose = AsyncMock()
-        
+
         async def mock_make_request():
             return mock_response
-        
+
         print("Action: Running stream_with_first_token_retry with error response...")
-        
+
         with pytest.raises(HTTPException) as exc_info:
             async for chunk in stream_with_first_token_retry(
                 mock_make_request,
@@ -826,14 +823,14 @@ class TestStreamWithFirstTokenRetry:
                 mock_model_cache,
                 mock_auth_manager,
                 max_retries=3,
-                first_token_timeout=15
+                first_token_timeout=15,
             ):
                 pass
-        
+
         print(f"Caught HTTPException: {exc_info.value.status_code}")
         assert exc_info.value.status_code == 500
         print("✓ API error response handled")
-    
+
     @pytest.mark.asyncio
     async def test_propagates_non_timeout_errors(self, mock_http_client, mock_model_cache, mock_auth_manager):
         """
@@ -841,25 +838,25 @@ class TestStreamWithFirstTokenRetry:
         Goal: Verify only timeout errors trigger retry.
         """
         print("Setup: Mock make_request that raises RuntimeError...")
-        
+
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.aclose = AsyncMock()
-        
+
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             call_count += 1
             return mock_response
-        
+
         async def mock_parse_kiro_stream_error(*args, **kwargs):
             raise RuntimeError("Test error")
             yield  # Make it a generator
-        
+
         print("Action: Running stream_with_first_token_retry with RuntimeError...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_error):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_error):
             with pytest.raises(RuntimeError) as exc_info:
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
@@ -868,18 +865,18 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     pass
-        
+
         print(f"Caught RuntimeError: {exc_info.value}")
         print(f"make_request was called {call_count} times")
-        
+
         # Should only be called once - no retry for non-timeout errors
         assert call_count == 1
         assert "Test error" in str(exc_info.value)
         print("✓ Non-timeout errors propagated without retry")
-    
+
     @pytest.mark.asyncio
     async def test_closes_response_on_retry(self, mock_http_client, mock_model_cache, mock_auth_manager):
         """
@@ -887,38 +884,38 @@ class TestStreamWithFirstTokenRetry:
         Goal: Verify resource cleanup on retry.
         """
         print("Setup: Mock responses for retry...")
-        
+
         mock_response1 = AsyncMock()
         mock_response1.status_code = 200
         mock_response1.aclose = AsyncMock()
-        
+
         mock_response2 = AsyncMock()
         mock_response2.status_code = 200
         mock_response2.aclose = AsyncMock()
-        
+
         responses = [mock_response1, mock_response2]
         call_count = 0
-        
+
         async def mock_make_request():
             nonlocal call_count
             response = responses[call_count]
             call_count += 1
             return response
-        
+
         # First call raises timeout, second succeeds
         timeout_raised = False
-        
+
         async def mock_parse_kiro_stream_with_retry(*args, **kwargs):
             nonlocal timeout_raised
             if not timeout_raised:
                 timeout_raised = True
                 raise FirstTokenTimeoutError("Timeout!")
             yield KiroEvent(type="content", content="Success")
-        
+
         print("Action: Running stream_with_first_token_retry...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream_with_retry):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream_with_retry):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_with_first_token_retry(
                     mock_make_request,
                     mock_http_client,
@@ -926,10 +923,10 @@ class TestStreamWithFirstTokenRetry:
                     mock_model_cache,
                     mock_auth_manager,
                     max_retries=3,
-                    first_token_timeout=15
+                    first_token_timeout=15,
                 ):
                     pass
-        
+
         print("Check: First response should be closed...")
         mock_response1.aclose.assert_called()
         print("✓ Response closed on retry")
@@ -939,115 +936,120 @@ class TestStreamWithFirstTokenRetry:
 # Tests for collect_stream_response()
 # ==================================================================================================
 
+
 class TestStreamingOpenaiErrorHandling:
     """Tests for error handling in streaming_openai."""
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_first_token_timeout_error(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_propagates_first_token_timeout_error(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates FirstTokenTimeoutError.
         Goal: Verify timeout error is propagated for retry.
         """
         print("Setup: Mock stream that raises timeout...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             raise FirstTokenTimeoutError("Timeout!")
             yield  # Make it a generator
-        
+
         print("Action: Streaming to OpenAI format with timeout...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
             with pytest.raises(FirstTokenTimeoutError):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     pass
-        
+
         print("✓ FirstTokenTimeoutError propagated correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_handles_generator_exit_gracefully(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_handles_generator_exit_gracefully(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Handles GeneratorExit gracefully without re-raising.
         Goal: Verify client disconnect is handled without error.
         """
         print("Setup: Mock stream that raises GeneratorExit...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise GeneratorExit()
-        
+
         print("Action: Streaming to OpenAI format with GeneratorExit...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 # GeneratorExit is caught internally and not re-raised
                 # This is correct behavior - client disconnect should be handled gracefully
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks before disconnect")
         # Response should be closed
         mock_response.aclose.assert_called()
         print("✓ GeneratorExit handled gracefully")
-    
+
     @pytest.mark.asyncio
-    async def test_propagates_other_exceptions(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_propagates_other_exceptions(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Propagates other exceptions.
         Goal: Verify errors are not swallowed.
         """
         print("Setup: Mock stream that raises RuntimeError...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Test error")
-        
+
         print("Action: Streaming to OpenAI format with RuntimeError...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 with pytest.raises(RuntimeError) as exc_info:
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                     ):
                         pass
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Test error" in str(exc_info.value)
         print("✓ RuntimeError propagated correctly")
-    
+
     @pytest.mark.asyncio
-    async def test_aclose_error_does_not_mask_original(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_aclose_error_does_not_mask_original(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: aclose() error doesn't mask original error.
         Goal: Verify original exception is propagated.
         """
         print("Setup: Mock response with error in aclose()...")
-        
+
         mock_response.aclose = AsyncMock(side_effect=ConnectionError("Connection lost"))
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             raise RuntimeError("Original error")
-        
+
         print("Action: Streaming to OpenAI format with error and aclose error...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 with pytest.raises(RuntimeError) as exc_info:
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                     ):
                         pass
-        
+
         print(f"Caught exception: {exc_info.value}")
         assert "Original error" in str(exc_info.value)
         print("✓ Original error not masked by aclose error")
@@ -1057,42 +1059,42 @@ class TestStreamingOpenaiErrorHandling:
 # Tests for bracket tool calls
 # ==================================================================================================
 
+
 class TestStreamingOpenaiBracketToolCalls:
     """Tests for bracket-style tool call handling."""
-    
+
     @pytest.mark.asyncio
-    async def test_detects_bracket_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_detects_bracket_tool_calls(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Detects bracket-style tool calls in content.
         Goal: Verify bracket tool call detection.
         """
         print("Setup: Mock stream with bracket tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="[tool_call: func1]")
-        
-        bracket_tool_calls = [
-            {"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}
-        ]
-        
+
+        bracket_tool_calls = [{"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}]
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=bracket_tool_calls):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=bracket_tool_calls):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Should have tool_calls chunk
         tool_chunks = [c for c in chunks if '"tool_calls"' in c]
         assert len(tool_chunks) >= 1
         print("✓ Bracket tool calls detected")
-    
+
     @pytest.mark.asyncio
     async def test_deduplicates_tool_calls(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
         """
@@ -1100,37 +1102,34 @@ class TestStreamingOpenaiBracketToolCalls:
         Goal: Verify deduplication.
         """
         print("Setup: Mock stream with duplicate tool calls...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="text")
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "func1", "arguments": "{}"}
-            })
-        
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}},
+            )
+
         # Same tool call from bracket detection
-        bracket_tool_calls = [
-            {"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}
-        ]
-        
+        bracket_tool_calls = [{"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}]
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=bracket_tool_calls):
-                with patch('kiro.streaming_openai.deduplicate_tool_calls') as mock_dedup:
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=bracket_tool_calls):
+                with patch("kiro.streaming_openai.deduplicate_tool_calls") as mock_dedup:
                     mock_dedup.return_value = [
                         {"id": "call_1", "type": "function", "function": {"name": "func1", "arguments": "{}"}}
                     ]
                     async for chunk in stream_kiro_to_openai(
-                        mock_http_client, mock_response, "claude-sonnet-4",
-                        mock_model_cache, mock_auth_manager
+                        mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                     ):
                         chunks.append(chunk)
-                    
+
                     # Verify deduplicate was called
                     mock_dedup.assert_called()
-        
+
         print("✓ Tool calls deduplicated")
 
 
@@ -1138,34 +1137,36 @@ class TestStreamingOpenaiBracketToolCalls:
 # Tests for metering data
 # ==================================================================================================
 
+
 class TestStreamingOpenaiMeteringData:
     """Tests for metering data handling."""
-    
+
     @pytest.mark.asyncio
-    async def test_includes_credits_used_in_usage(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_includes_credits_used_in_usage(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Includes credits_used in usage when metering data present.
         Goal: Verify metering data is included.
         """
         print("Setup: Mock stream with metering data...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Hello")
             yield KiroEvent(type="usage", usage={"credits": 0.001})
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk should have credits_used
         final_chunk = chunks[-2]  # Before [DONE]
         assert '"credits_used"' in final_chunk
@@ -1176,129 +1177,134 @@ class TestStreamingOpenaiMeteringData:
 # Tests for truncation detection
 # ==================================================================================================
 
+
 class TestStreamingOpenaiTruncationDetection:
     """Tests for truncation detection in OpenAI streaming."""
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_length_when_truncated(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_length_when_truncated(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to length when content is truncated.
         Goal: Verify truncation detection without completion signals.
         """
         print("Setup: Mock stream without completion signals (truncated)...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="This response was cut off mid-sentence because")
             # No usage event = truncation
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Final chunk before [DONE] should have finish_reason: length
         final_chunk = chunks[-2]  # Before [DONE]
         print(f"Comparing finish_reason: Expected 'length', Got chunk: {final_chunk}")
         assert '"finish_reason": "length"' in final_chunk
         print("✓ finish_reason is length when truncated")
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_tool_calls_even_without_completion_signals(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_tool_calls_even_without_completion_signals(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to tool_calls when tool calls present.
         Goal: Verify tool_calls take priority (not confused with content truncation).
         """
         print("Setup: Mock stream with tool calls but no completion signals...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Let me call a tool")
-            yield KiroEvent(type="tool_use", tool_use={
-                "id": "call_1", "type": "function",
-                "function": {"name": "get_weather", "arguments": "{}"}
-            })
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}},
+            )
             # No usage event, but tool calls present = tool_calls finish_reason
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # Tool calls take priority (not confused with content truncation)
         final_chunk = chunks[-2]  # Before [DONE]
         print(f"Comparing finish_reason: Expected 'tool_calls', Got chunk: {final_chunk}")
         assert '"finish_reason": "tool_calls"' in final_chunk
         print("✓ finish_reason is tool_calls (not confused with content truncation)")
-    
+
     @pytest.mark.asyncio
-    async def test_finish_reason_is_stop_with_completion_signals(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_finish_reason_is_stop_with_completion_signals(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Sets finish_reason to stop when completion signals present.
         Goal: Verify normal completion is detected correctly.
         """
         print("Setup: Mock stream with completion signals (not truncated)...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Complete response")
             yield KiroEvent(type="usage", usage={"inputTokenCount": 10, "outputTokenCount": 5})
-        
+
         print("Action: Streaming to OpenAI format...")
         chunks = []
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 ):
                     chunks.append(chunk)
-        
+
         print(f"Received {len(chunks)} chunks")
-        
+
         # With completion signals, should be stop
         final_chunk = chunks[-2]  # Before [DONE]
         print(f"Comparing finish_reason: Expected 'stop', Got chunk: {final_chunk}")
         assert '"finish_reason": "stop"' in final_chunk
         print("✓ finish_reason is stop with completion signals")
-    
+
     @pytest.mark.asyncio
-    async def test_collect_extracts_finish_reason_from_chunks(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_collect_extracts_finish_reason_from_chunks(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Non-streaming extracts finish_reason from streaming chunks.
         Goal: Verify collect_stream_response correctly extracts finish_reason.
         """
         print("Setup: Mock stream without completion signals...")
-        
+
         async def mock_parse_kiro_stream(*args, **kwargs):
             yield KiroEvent(type="content", content="Truncated")
             # No usage = truncation
-        
+
         print("Action: Collecting stream response...")
-        
-        with patch('kiro.streaming_openai.parse_kiro_stream', mock_parse_kiro_stream):
-            with patch('kiro.streaming_openai.parse_bracket_tool_calls', return_value=[]):
+
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
                 result = await collect_stream_response(
-                    mock_http_client, mock_response, "claude-sonnet-4",
-                    mock_model_cache, mock_auth_manager
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                 )
-        
+
         print(f"Result finish_reason: {result['choices'][0]['finish_reason']}")
-        
+
         # Should extract "length" from streaming chunks
         assert result["choices"][0]["finish_reason"] == "length"
         print("✓ collect_stream_response extracts finish_reason correctly")

--- a/tests/unit/test_tokenizer.py
+++ b/tests/unit/test_tokenizer.py
@@ -12,23 +12,22 @@ Tests:
 - Fallback when tiktoken is unavailable
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from kiro.tokenizer import (
-    count_tokens,
-    count_message_tokens,
-    count_tools_tokens,
-    count_system_tokens,
-    estimate_request_tokens,
     CLAUDE_CORRECTION_FACTOR,
-    _get_encoding
+    _get_encoding,
+    count_message_tokens,
+    count_system_tokens,
+    count_tokens,
+    count_tools_tokens,
+    estimate_request_tokens,
 )
 
 
 class TestCountTokens:
     """Tests for count_tokens function."""
-    
+
     def test_empty_string_returns_zero(self):
         """
         What it does: Checks that empty string returns 0 tokens.
@@ -38,7 +37,7 @@ class TestCountTokens:
         result = count_tokens("")
         print(f"Result: {result}")
         assert result == 0, "Empty string should return 0 tokens"
-    
+
     def test_none_returns_zero(self):
         """
         What it does: Checks that None returns 0 tokens.
@@ -48,7 +47,7 @@ class TestCountTokens:
         result = count_tokens(None)
         print(f"Result: {result}")
         assert result == 0, "None should return 0 tokens"
-    
+
     def test_simple_text_returns_positive(self):
         """
         What it does: Checks that simple text returns positive token count.
@@ -58,7 +57,7 @@ class TestCountTokens:
         result = count_tokens("Hello, world!")
         print(f"Result: {result}")
         assert result > 0, "Simple text should return positive token count"
-    
+
     def test_longer_text_returns_more_tokens(self):
         """
         What it does: Checks that longer text returns more tokens.
@@ -67,15 +66,15 @@ class TestCountTokens:
         print("Test: Comparing long and short text...")
         short_text = "Hello"
         long_text = "Hello, this is a much longer text that should have more tokens"
-        
+
         short_tokens = count_tokens(short_text)
         long_tokens = count_tokens(long_text)
-        
+
         print(f"Short text: {short_tokens} tokens")
         print(f"Long text: {long_tokens} tokens")
-        
+
         assert long_tokens > short_tokens, "Long text should have more tokens"
-    
+
     def test_claude_correction_applied_by_default(self):
         """
         What it does: Checks that Claude correction coefficient is applied by default.
@@ -83,21 +82,21 @@ class TestCountTokens:
         """
         print("Test: Claude correction coefficient...")
         text = "This is a test text for token counting"
-        
+
         with_correction = count_tokens(text, apply_claude_correction=True)
         without_correction = count_tokens(text, apply_claude_correction=False)
-        
+
         print(f"With correction: {with_correction}")
         print(f"Without correction: {without_correction}")
-        
+
         # With correction should be higher (coefficient 1.15)
         assert with_correction > without_correction, "With correction should have more tokens"
-        
+
         # Check approximate ratio
         ratio = with_correction / without_correction
         print(f"Ratio: {ratio}")
         assert 1.1 <= ratio <= 1.2, f"Ratio should be around {CLAUDE_CORRECTION_FACTOR}"
-    
+
     def test_without_claude_correction(self):
         """
         What it does: Checks token counting without correction coefficient.
@@ -105,12 +104,12 @@ class TestCountTokens:
         """
         print("Test: Without correction coefficient...")
         text = "Test text"
-        
+
         result = count_tokens(text, apply_claude_correction=False)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Should return positive token count"
-    
+
     def test_unicode_text(self):
         """
         What it does: Checks token counting for Unicode text.
@@ -118,12 +117,12 @@ class TestCountTokens:
         """
         print("Test: Unicode text...")
         text = "Привет, мир! 你好世界 🌍"
-        
+
         result = count_tokens(text)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Unicode text should return positive token count"
-    
+
     def test_multiline_text(self):
         """
         What it does: Checks token counting for multiline text.
@@ -133,12 +132,12 @@ class TestCountTokens:
         text = """Line 1
         Line 2
         Line 3"""
-        
+
         result = count_tokens(text)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Multiline text should return positive token count"
-    
+
     def test_json_text(self):
         """
         What it does: Checks token counting for JSON string.
@@ -146,45 +145,45 @@ class TestCountTokens:
         """
         print("Test: JSON text...")
         text = '{"name": "test", "value": 123, "nested": {"key": "value"}}'
-        
+
         result = count_tokens(text)
         print(f"Result: {result}")
-        
+
         assert result > 0, "JSON text should return positive token count"
 
 
 class TestCountTokensFallback:
     """Tests for fallback logic when tiktoken is unavailable."""
-    
+
     def test_fallback_when_tiktoken_unavailable(self):
         """
         What it does: Checks fallback counting when tiktoken is unavailable.
         Purpose: Ensure system works without tiktoken.
         """
         print("Test: Fallback without tiktoken...")
-        
+
         # Mock _get_encoding to return None
-        with patch('kiro.tokenizer._get_encoding', return_value=None):
+        with patch("kiro.tokenizer._get_encoding", return_value=None):
             result = count_tokens("Hello world test")
             print(f"Result: {result}")
-            
+
             # Fallback: len(text) // 4 + 1, then * 1.15
             # "Hello world test" = 16 characters
             # 16 // 4 + 1 = 5
             # 5 * 1.15 = 5.75 -> 5
             assert result > 0, "Fallback should return positive number"
-    
+
     def test_fallback_without_correction(self):
         """
         What it does: Checks fallback without correction coefficient.
         Purpose: Ensure fallback works with apply_claude_correction=False.
         """
         print("Test: Fallback without correction...")
-        
-        with patch('kiro.tokenizer._get_encoding', return_value=None):
+
+        with patch("kiro.tokenizer._get_encoding", return_value=None):
             result = count_tokens("Test", apply_claude_correction=False)
             print(f"Result: {result}")
-            
+
             # "Test" = 4 characters
             # 4 // 4 + 1 = 2
             assert result > 0, "Fallback should return positive number"
@@ -192,7 +191,7 @@ class TestCountTokensFallback:
 
 class TestCountMessageTokens:
     """Tests for count_message_tokens function."""
-    
+
     def test_empty_list_returns_zero(self):
         """
         What it does: Checks that empty list returns 0 tokens.
@@ -202,7 +201,7 @@ class TestCountMessageTokens:
         result = count_message_tokens([])
         print(f"Result: {result}")
         assert result == 0, "Empty list should return 0 tokens"
-    
+
     def test_none_returns_zero(self):
         """
         What it does: Checks that None returns 0 tokens.
@@ -212,7 +211,7 @@ class TestCountMessageTokens:
         result = count_message_tokens(None)
         print(f"Result: {result}")
         assert result == 0, "None should return 0 tokens"
-    
+
     def test_single_user_message(self):
         """
         What it does: Checks token counting for single user message.
@@ -220,12 +219,12 @@ class TestCountMessageTokens:
         """
         print("Test: Single user message...")
         messages = [{"role": "user", "content": "Hello, AI!"}]
-        
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Should return positive token count"
-    
+
     def test_multiple_messages(self):
         """
         What it does: Checks token counting for multiple messages.
@@ -236,16 +235,16 @@ class TestCountMessageTokens:
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Hello!"},
             {"role": "assistant", "content": "Hi there! How can I help you?"},
-            {"role": "user", "content": "What is the weather?"}
+            {"role": "user", "content": "What is the weather?"},
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         # More messages = more tokens
         single_message = count_message_tokens([messages[0]])
         assert result > single_message, "Multiple messages should have more tokens"
-    
+
     def test_message_with_tool_calls(self):
         """
         What it does: Checks token counting for message with tool_calls.
@@ -260,39 +259,30 @@ class TestCountMessageTokens:
                     {
                         "id": "call_123",
                         "type": "function",
-                        "function": {
-                            "name": "get_weather",
-                            "arguments": '{"location": "Moscow"}'
-                        }
+                        "function": {"name": "get_weather", "arguments": '{"location": "Moscow"}'},
                     }
-                ]
+                ],
             }
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Message with tool_calls should have tokens"
-    
+
     def test_message_with_tool_call_id(self):
         """
         What it does: Checks token counting for tool response message.
         Purpose: Ensure tool_call_id is counted.
         """
         print("Test: Tool response message...")
-        messages = [
-            {
-                "role": "tool",
-                "content": "The weather in Moscow is sunny, 25°C",
-                "tool_call_id": "call_123"
-            }
-        ]
-        
+        messages = [{"role": "tool", "content": "The weather in Moscow is sunny, 25°C", "tool_call_id": "call_123"}]
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Tool response should have tokens"
-    
+
     def test_message_with_list_content(self):
         """
         What it does: Checks token counting for multimodal content.
@@ -304,16 +294,16 @@ class TestCountMessageTokens:
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "What is in this image?"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
-                ]
+                    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+                ],
             }
         ]
-        
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Multimodal content should have tokens"
-    
+
     def test_without_claude_correction(self):
         """
         What it does: Checks token counting without correction coefficient.
@@ -321,15 +311,15 @@ class TestCountMessageTokens:
         """
         print("Test: Without correction coefficient...")
         messages = [{"role": "user", "content": "Test message"}]
-        
+
         with_correction = count_message_tokens(messages, apply_claude_correction=True)
         without_correction = count_message_tokens(messages, apply_claude_correction=False)
-        
+
         print(f"С коррекцией: {with_correction}")
         print(f"Без коррекции: {without_correction}")
-        
+
         assert with_correction > without_correction, "With correction should be higher"
-    
+
     def test_message_with_empty_content(self):
         """
         What it does: Checks token counting for message with empty content.
@@ -337,13 +327,13 @@ class TestCountMessageTokens:
         """
         print("Test: Empty content...")
         messages = [{"role": "user", "content": ""}]
-        
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         # Should have service tokens (role, separators)
         assert result > 0, "Even empty message should have service tokens"
-    
+
     def test_message_with_none_content(self):
         """
         What it does: Checks token counting for message with None content.
@@ -351,10 +341,10 @@ class TestCountMessageTokens:
         """
         print("Test: None content...")
         messages = [{"role": "assistant", "content": None}]
-        
+
         result = count_message_tokens(messages)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Message with None content should have service tokens"
 
     def test_anthropic_tool_use_and_tool_result_blocks(self):
@@ -366,14 +356,7 @@ class TestCountMessageTokens:
         messages = [
             {
                 "role": "assistant",
-                "content": [
-                    {
-                        "type": "tool_use",
-                        "id": "toolu_123",
-                        "name": "get_weather",
-                        "input": {"city": "Tokyo"}
-                    }
-                ]
+                "content": [{"type": "tool_use", "id": "toolu_123", "name": "get_weather", "input": {"city": "Tokyo"}}],
             },
             {
                 "role": "user",
@@ -382,10 +365,10 @@ class TestCountMessageTokens:
                         "type": "tool_result",
                         "tool_use_id": "toolu_123",
                         "content": [{"type": "text", "text": "晴天 26C"}],
-                        "is_error": False
+                        "is_error": False,
                     }
-                ]
-            }
+                ],
+            },
         ]
 
         result = count_message_tokens(messages, apply_claude_correction=False)
@@ -395,7 +378,7 @@ class TestCountMessageTokens:
 
 class TestCountToolsTokens:
     """Tests for count_tools_tokens function."""
-    
+
     def test_none_returns_zero(self):
         """
         What it does: Checks that None returns 0 tokens.
@@ -405,7 +388,7 @@ class TestCountToolsTokens:
         result = count_tools_tokens(None)
         print(f"Result: {result}")
         assert result == 0, "None should return 0 tokens"
-    
+
     def test_empty_list_returns_zero(self):
         """
         What it does: Checks that empty list returns 0 tokens.
@@ -415,7 +398,7 @@ class TestCountToolsTokens:
         result = count_tools_tokens([])
         print(f"Result: {result}")
         assert result == 0, "Empty list should return 0 tokens"
-    
+
     def test_single_tool(self):
         """
         What it does: Checks token counting for single tool.
@@ -430,20 +413,18 @@ class TestCountToolsTokens:
                     "description": "Get the current weather for a location",
                     "parameters": {
                         "type": "object",
-                        "properties": {
-                            "location": {"type": "string", "description": "City name"}
-                        },
-                        "required": ["location"]
-                    }
-                }
+                        "properties": {"location": {"type": "string", "description": "City name"}},
+                        "required": ["location"],
+                    },
+                },
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Tool should have tokens"
-    
+
     def test_multiple_tools(self):
         """
         What it does: Checks token counting for multiple tools.
@@ -456,27 +437,27 @@ class TestCountToolsTokens:
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             },
             {
                 "type": "function",
                 "function": {
                     "name": "search_web",
                     "description": "Search the web",
-                    "parameters": {"type": "object", "properties": {}}
-                }
-            }
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
         ]
-        
+
         result = count_tools_tokens(tools)
         single_tool = count_tools_tokens([tools[0]])
-        
+
         print(f"Two tools: {result}")
         print(f"One tool: {single_tool}")
-        
+
         assert result > single_tool, "More tools = more tokens"
-    
+
     def test_tool_with_complex_parameters(self):
         """
         What it does: Checks token counting for tool with complex parameters.
@@ -499,25 +480,22 @@ class TestCountToolsTokens:
                                 "properties": {
                                     "street": {"type": "string"},
                                     "city": {"type": "string"},
-                                    "country": {"type": "string"}
-                                }
+                                    "country": {"type": "string"},
+                                },
                             },
-                            "tags": {
-                                "type": "array",
-                                "items": {"type": "string"}
-                            }
+                            "tags": {"type": "array", "items": {"type": "string"}},
                         },
-                        "required": ["name", "age"]
-                    }
-                }
+                        "required": ["name", "age"],
+                    },
+                },
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Complex tool should have tokens"
-    
+
     def test_tool_without_parameters(self):
         """
         What it does: Checks token counting for tool without parameters.
@@ -525,20 +503,14 @@ class TestCountToolsTokens:
         """
         print("Test: Without parameters...")
         tools = [
-            {
-                "type": "function",
-                "function": {
-                    "name": "no_params_func",
-                    "description": "A function without parameters"
-                }
-            }
+            {"type": "function", "function": {"name": "no_params_func", "description": "A function without parameters"}}
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Tool without parameters should have tokens"
-    
+
     def test_tool_with_empty_description(self):
         """
         What it does: Checks token counting for tool with empty description.
@@ -548,38 +520,29 @@ class TestCountToolsTokens:
         tools = [
             {
                 "type": "function",
-                "function": {
-                    "name": "func",
-                    "description": "",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                "function": {"name": "func", "description": "", "parameters": {"type": "object", "properties": {}}},
             }
         ]
-        
+
         result = count_tools_tokens(tools)
         print(f"Result: {result}")
-        
+
         assert result > 0, "Tool with empty description should have tokens"
-    
+
     def test_non_function_tool_type(self):
         """
         What it does: Checks handling of tool with type != "function".
         Purpose: Ensure non-function tools are handled.
         """
         print("Test: Non-function tool...")
-        tools = [
-            {
-                "type": "other_type",
-                "some_field": "value"
-            }
-        ]
-        
+        tools = [{"type": "other_type", "some_field": "value"}]
+
         result = count_tools_tokens(tools)
         print(f"Result: {result}")
-        
+
         # Should have at least service tokens
         assert result >= 0, "Non-function tool shouldn't break counting"
-    
+
     def test_without_claude_correction(self):
         """
         What it does: Checks token counting without correction coefficient.
@@ -592,17 +555,17 @@ class TestCountToolsTokens:
                 "function": {
                     "name": "test_func",
                     "description": "Test function",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             }
         ]
-        
+
         with_correction = count_tools_tokens(tools, apply_claude_correction=True)
         without_correction = count_tools_tokens(tools, apply_claude_correction=False)
-        
+
         print(f"С коррекцией: {with_correction}")
         print(f"Без коррекции: {without_correction}")
-        
+
         assert with_correction > without_correction, "With correction should be higher"
 
     def test_openai_flat_tool_format(self):
@@ -614,11 +577,7 @@ class TestCountToolsTokens:
             {
                 "name": "search_docs",
                 "description": "Search docs by keyword",
-                "input_schema": {
-                    "type": "object",
-                    "properties": {"query": {"type": "string"}},
-                    "required": ["query"]
-                }
+                "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
             }
         ]
 
@@ -634,23 +593,17 @@ class TestCountToolsTokens:
             "type": "object",
             "properties": {
                 "path": {"type": "string"},
-                "recursive": {"type": "boolean", "description": "Recursive search"}
+                "recursive": {"type": "boolean", "description": "Recursive search"},
             },
-            "required": ["path"]
+            "required": ["path"],
         }
-        openai_tools = [{
-            "type": "function",
-            "function": {
-                "name": "search_files",
-                "description": "Search files",
-                "parameters": shared_schema
+        openai_tools = [
+            {
+                "type": "function",
+                "function": {"name": "search_files", "description": "Search files", "parameters": shared_schema},
             }
-        }]
-        anthropic_tools = [{
-            "name": "search_files",
-            "description": "Search files",
-            "input_schema": shared_schema
-        }]
+        ]
+        anthropic_tools = [{"name": "search_files", "description": "Search files", "input_schema": shared_schema}]
 
         openai_tokens = count_tools_tokens(openai_tools, apply_claude_correction=False)
         anthropic_tokens = count_tools_tokens(anthropic_tools, apply_claude_correction=False)
@@ -717,7 +670,7 @@ class TestCountSystemTokens:
 
 class TestEstimateRequestTokens:
     """Tests for estimate_request_tokens function."""
-    
+
     def test_messages_only(self):
         """
         What it does: Checks token estimation for messages only.
@@ -725,20 +678,20 @@ class TestEstimateRequestTokens:
         """
         print("Test: Messages only...")
         messages = [{"role": "user", "content": "Hello!"}]
-        
+
         result = estimate_request_tokens(messages)
         print(f"Result: {result}")
-        
+
         assert "messages_tokens" in result
         assert "tools_tokens" in result
         assert "system_tokens" in result
         assert "total_tokens" in result
-        
+
         assert result["messages_tokens"] > 0
         assert result["tools_tokens"] == 0
         assert result["system_tokens"] == 0
         assert result["total_tokens"] == result["messages_tokens"]
-    
+
     def test_messages_with_tools(self):
         """
         What it does: Checks token estimation for messages with tools.
@@ -752,18 +705,18 @@ class TestEstimateRequestTokens:
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather",
-                    "parameters": {"type": "object", "properties": {}}
-                }
+                    "parameters": {"type": "object", "properties": {}},
+                },
             }
         ]
-        
+
         result = estimate_request_tokens(messages, tools=tools)
         print(f"Result: {result}")
-        
+
         assert result["messages_tokens"] > 0
         assert result["tools_tokens"] > 0
         assert result["total_tokens"] == result["messages_tokens"] + result["tools_tokens"]
-    
+
     def test_messages_with_system_prompt(self):
         """
         What it does: Checks token estimation with separate system prompt.
@@ -772,10 +725,10 @@ class TestEstimateRequestTokens:
         print("Test: With system prompt...")
         messages = [{"role": "user", "content": "Hello!"}]
         system_prompt = "You are a helpful assistant."
-        
+
         result = estimate_request_tokens(messages, system_prompt=system_prompt)
         print(f"Result: {result}")
-        
+
         assert result["messages_tokens"] > 0
         assert result["system_tokens"] > 0
         assert result["total_tokens"] == result["messages_tokens"] + result["system_tokens"]
@@ -797,36 +750,29 @@ class TestEstimateRequestTokens:
 
         assert result["system_tokens"] > 0
         assert result["total_tokens"] == result["messages_tokens"] + result["system_tokens"]
-    
+
     def test_full_request(self):
         """
         What it does: Checks token estimation for full request.
         Purpose: Ensure all components sum correctly.
         """
         print("Test: Full request...")
-        messages = [
-            {"role": "user", "content": "What is the weather in Moscow?"}
-        ]
+        messages = [{"role": "user", "content": "What is the weather in Moscow?"}]
         tools = [
             {
                 "type": "function",
                 "function": {
                     "name": "get_weather",
                     "description": "Get weather for a location",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "location": {"type": "string"}
-                        }
-                    }
-                }
+                    "parameters": {"type": "object", "properties": {"location": {"type": "string"}}},
+                },
             }
         ]
         system_prompt = "You are a weather assistant."
-        
+
         result = estimate_request_tokens(messages, tools=tools, system_prompt=system_prompt)
         print(f"Result: {result}")
-        
+
         expected_total = result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"]
         assert result["total_tokens"] == expected_total, "Total should be sum of components"
 
@@ -835,38 +781,29 @@ class TestEstimateRequestTokens:
         What it does: Simulates Anthropic /v1/messages with tools+system scenario.
         Purpose: Verify estimate_request_tokens no longer undercounts flat tools.
         """
-        messages = [
-            {"role": "user", "content": "请先读取项目结构，再回答。"}
-        ]
+        messages = [{"role": "user", "content": "请先读取项目结构，再回答。"}]
         tools = [
             {
                 "name": "read_file",
                 "description": "Read a file from workspace",
                 "input_schema": {
                     "type": "object",
-                    "properties": {
-                        "path": {"type": "string", "description": "Absolute path"}
-                    },
-                    "required": ["path"]
-                }
+                    "properties": {"path": {"type": "string", "description": "Absolute path"}},
+                    "required": ["path"],
+                },
             }
         ]
         system_prompt = [{"type": "text", "text": "你是代码助手。"}]
 
         result = estimate_request_tokens(
-            messages,
-            tools=tools,
-            system_prompt=system_prompt,
-            apply_claude_correction=False
+            messages, tools=tools, system_prompt=system_prompt, apply_claude_correction=False
         )
 
         assert result["messages_tokens"] > 0
         assert result["tools_tokens"] > 4
         assert result["system_tokens"] > 0
-        assert result["total_tokens"] == (
-            result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"]
-        )
-    
+        assert result["total_tokens"] == (result["messages_tokens"] + result["tools_tokens"] + result["system_tokens"])
+
     def test_empty_messages(self):
         """
         What it does: Checks token estimation for empty message list.
@@ -875,14 +812,14 @@ class TestEstimateRequestTokens:
         print("Test: Empty messages...")
         result = estimate_request_tokens([])
         print(f"Result: {result}")
-        
+
         assert result["messages_tokens"] == 0
         assert result["total_tokens"] == 0
 
 
 class TestClaudeCorrectionFactor:
     """Tests for Claude correction coefficient."""
-    
+
     def test_correction_factor_value(self):
         """
         What it does: Checks correction coefficient value.
@@ -890,7 +827,7 @@ class TestClaudeCorrectionFactor:
         """
         print(f"Correction coefficient: {CLAUDE_CORRECTION_FACTOR}")
         assert CLAUDE_CORRECTION_FACTOR == 1.15, "Coefficient should be 1.15"
-    
+
     def test_correction_increases_token_count(self):
         """
         What it does: Checks that correction increases token count.
@@ -898,81 +835,85 @@ class TestClaudeCorrectionFactor:
         """
         print("Test: Correction increases tokens...")
         text = "This is a test text for checking the correction factor"
-        
+
         with_correction = count_tokens(text, apply_claude_correction=True)
         without_correction = count_tokens(text, apply_claude_correction=False)
-        
+
         print(f"With correction: {with_correction}")
         print(f"Without correction: {without_correction}")
-        
+
         assert with_correction > without_correction
-        
+
         # Check that difference is approximately 15%
         increase_percent = (with_correction - without_correction) / without_correction * 100
         print(f"Increase: {increase_percent:.1f}%")
-        
+
         # Allow rounding error
         assert 10 <= increase_percent <= 20, "Increase should be around 15%"
+
+
 class TestGetEncoding:
     """Tests for _get_encoding function."""
-    
+
     def test_returns_encoding_when_tiktoken_available(self):
         """
         What it does: Checks that _get_encoding returns encoding when tiktoken is available.
         Purpose: Ensure correct tiktoken initialization.
         """
         print("Test: tiktoken available...")
-        
+
         # Reset global variable for clean test
         import kiro.tokenizer as tokenizer_module
+
         original_encoding = tokenizer_module._encoding
         tokenizer_module._encoding = None
-        
+
         try:
             encoding = _get_encoding()
             print(f"Encoding: {encoding}")
-            
+
             # If tiktoken is installed, should return encoding
             if encoding is not None:
-                assert hasattr(encoding, 'encode'), "Encoding should have encode method"
+                assert hasattr(encoding, "encode"), "Encoding should have encode method"
         finally:
             # Restore
             tokenizer_module._encoding = original_encoding
-    
+
     def test_caches_encoding(self):
         """
         What it does: Checks that encoding is cached.
         Purpose: Ensure lazy initialization.
         """
         print("Test: Encoding caching...")
-        
+
         encoding1 = _get_encoding()
         encoding2 = _get_encoding()
-        
+
         print(f"Encoding 1: {encoding1}")
         print(f"Encoding 2: {encoding2}")
-        
+
         # Should return same object
         assert encoding1 is encoding2, "Encoding should be cached"
-    
+
     def test_handles_import_error(self):
         """
         What it does: Checks ImportError handling when tiktoken is missing.
         Purpose: Ensure system works without tiktoken.
         """
         print("Test: ImportError...")
-        
+
         import kiro.tokenizer as tokenizer_module
+
         original_encoding = tokenizer_module._encoding
         tokenizer_module._encoding = None
-        
+
         try:
             # Мокируем import tiktoken чтобы выбросить ImportError
-            with patch.dict('sys.modules', {'tiktoken': None}):
-                with patch('builtins.__import__', side_effect=ImportError("No module named 'tiktoken'")):
+            with patch.dict("sys.modules", {"tiktoken": None}):
+                with patch("builtins.__import__", side_effect=ImportError("No module named 'tiktoken'")):
                     # Сбрасываем кэш
                     tokenizer_module._encoding = None
-                    
+
                     # Должен вернуть None и не упасть
                     # Примечание: из-за кэширования этот тест может не работать идеально
                     # но главное - проверить что код не падает
@@ -983,21 +924,21 @@ class TestGetEncoding:
 
 class TestTokenizerIntegration:
     """Integration tests for tokenizer."""
-    
+
     def test_realistic_chat_request(self):
         """
         What it does: Checks token counting for realistic chat request.
         Purpose: Ensure correct work on real data.
         """
         print("Test: Realistic chat request...")
-        
+
         messages = [
             {"role": "system", "content": "You are a helpful AI assistant. Be concise and accurate."},
             {"role": "user", "content": "What is the capital of France?"},
             {"role": "assistant", "content": "The capital of France is Paris."},
-            {"role": "user", "content": "What is its population?"}
+            {"role": "user", "content": "What is its population?"},
         ]
-        
+
         tools = [
             {
                 "type": "function",
@@ -1006,54 +947,50 @@ class TestTokenizerIntegration:
                     "description": "Search the web for information",
                     "parameters": {
                         "type": "object",
-                        "properties": {
-                            "query": {"type": "string", "description": "Search query"}
-                        },
-                        "required": ["query"]
-                    }
-                }
+                        "properties": {"query": {"type": "string", "description": "Search query"}},
+                        "required": ["query"],
+                    },
+                },
             }
         ]
-        
+
         result = estimate_request_tokens(messages, tools=tools)
         print(f"Result: {result}")
-        
+
         # Check reasonable values
         assert result["messages_tokens"] > 50, "Messages should have > 50 tokens"
         assert result["tools_tokens"] > 20, "Tools should have > 20 tokens"
         assert result["total_tokens"] > 70, "Total should be > 70 tokens"
-    
+
     def test_large_context(self):
         """
         What it does: Checks token counting for large context.
         Purpose: Ensure performance on large data.
         """
         print("Test: Large context...")
-        
+
         # Создаём большой текст
         large_text = "This is a test sentence. " * 1000  # ~5000 слов
-        
+
         messages = [{"role": "user", "content": large_text}]
-        
+
         result = estimate_request_tokens(messages)
         print(f"Токенов в большом тексте: {result['total_tokens']}")
-        
+
         # Should have many tokens
         assert result["total_tokens"] > 1000, "Large text should have > 1000 tokens"
-    
+
     def test_consistency_across_calls(self):
         """
         What it does: Checks consistency of counting on repeated calls.
         Purpose: Ensure results are deterministic.
         """
         print("Test: Consistency...")
-        
+
         text = "This is a test for consistency checking"
-        
+
         results = [count_tokens(text) for _ in range(5)]
         print(f"Результаты: {results}")
-        
+
         # All results should be identical
         assert len(set(results)) == 1, "Results should be consistent"
-    
-    

--- a/tests/unit/test_vpn_proxy.py
+++ b/tests/unit/test_vpn_proxy.py
@@ -8,6 +8,7 @@ for different input formats and scenarios.
 """
 
 import os
+
 import pytest
 
 
@@ -20,7 +21,7 @@ import pytest
             "http://192.168.1.103:2080",
             "http://192.168.1.103:2080",
             "http://192.168.1.103:2080",
-            "127.0.0.1,localhost"
+            "127.0.0.1,localhost",
         ),
         (
             "proxy_with_socks5_scheme",
@@ -28,7 +29,7 @@ import pytest
             "socks5://192.168.1.103:1080",
             "socks5://192.168.1.103:1080",
             "socks5://192.168.1.103:1080",
-            "127.0.0.1,localhost"
+            "127.0.0.1,localhost",
         ),
         (
             "proxy_without_scheme",
@@ -36,7 +37,7 @@ import pytest
             "192.168.1.103:2080",
             "http://192.168.1.103:2080",
             "http://192.168.1.103:2080",
-            "127.0.0.1,localhost"
+            "127.0.0.1,localhost",
         ),
         (
             "proxy_with_auth",
@@ -44,7 +45,7 @@ import pytest
             "http://user:pass@192.168.1.103:2080",
             "http://user:pass@192.168.1.103:2080",
             "http://user:pass@192.168.1.103:2080",
-            "127.0.0.1,localhost"
+            "127.0.0.1,localhost",
         ),
         (
             "proxy_preserves_existing_no_proxy",
@@ -52,30 +53,17 @@ import pytest
             "http://192.168.1.103:2080",
             "http://192.168.1.103:2080",
             "http://192.168.1.103:2080",
-            "internal.corp,*.example.com,127.0.0.1,localhost"
+            "internal.corp,*.example.com,127.0.0.1,localhost",
         ),
-        (
-            "proxy_empty_url",
-            None,
-            "",
-            None,
-            None,
-            None
-        ),
-    ]
+        ("proxy_empty_url", None, "", None, None, None),
+    ],
 )
 def test_vpn_proxy_environment_setup(
-    test_id,
-    initial_no_proxy,
-    vpn_url,
-    expected_http_proxy,
-    expected_https_proxy,
-    expected_no_proxy,
-    monkeypatch
+    test_id, initial_no_proxy, vpn_url, expected_http_proxy, expected_https_proxy, expected_no_proxy, monkeypatch
 ):
     """
     Parametrized test for VPN/Proxy setup via environment variables.
-    
+
     Verifies that:
     - HTTP_PROXY, HTTPS_PROXY, ALL_PROXY are set correctly
     - URL normalization works (adds http:// if no scheme)
@@ -83,45 +71,45 @@ def test_vpn_proxy_environment_setup(
     - Empty URL doesn't set any proxy variables
     """
     print(f"\n--- Running VPN/Proxy test: ID = {test_id} ---")
-    
+
     # Clear proxy environment variables before test
     for key in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"]:
         monkeypatch.delenv(key, raising=False)
-    
+
     # Set initial NO_PROXY if specified
     if initial_no_proxy:
         monkeypatch.setenv("NO_PROXY", initial_no_proxy)
         print(f"Initial NO_PROXY: '{initial_no_proxy}'")
-    
+
     # Simulate VPN_PROXY_URL configuration
     print(f"VPN_PROXY_URL set to: '{vpn_url}'")
-    
+
     # Replicate logic from main.py (lines 175-197)
     if vpn_url:
         proxy_url_with_scheme = vpn_url if "://" in vpn_url else f"http://{vpn_url}"
-        os.environ['HTTP_PROXY'] = proxy_url_with_scheme
-        os.environ['HTTPS_PROXY'] = proxy_url_with_scheme
-        os.environ['ALL_PROXY'] = proxy_url_with_scheme
-        
+        os.environ["HTTP_PROXY"] = proxy_url_with_scheme
+        os.environ["HTTPS_PROXY"] = proxy_url_with_scheme
+        os.environ["ALL_PROXY"] = proxy_url_with_scheme
+
         no_proxy_hosts = os.environ.get("NO_PROXY", "")
         local_hosts = "127.0.0.1,localhost"
         if no_proxy_hosts:
             os.environ["NO_PROXY"] = f"{no_proxy_hosts},{local_hosts}"
         else:
             os.environ["NO_PROXY"] = local_hosts
-    
+
     # --- Assertions ---
     print("\n[Verification]")
-    
+
     if expected_http_proxy:
         actual_http_proxy = os.environ.get("HTTP_PROXY")
         print(f"HTTP_PROXY: Expected '{expected_http_proxy}', Got '{actual_http_proxy}'")
         assert actual_http_proxy == expected_http_proxy, "HTTP_PROXY mismatch!"
-        
+
         actual_https_proxy = os.environ.get("HTTPS_PROXY")
         print(f"HTTPS_PROXY: Expected '{expected_https_proxy}', Got '{actual_https_proxy}'")
         assert actual_https_proxy == expected_https_proxy, "HTTPS_PROXY mismatch!"
-        
+
         actual_all_proxy = os.environ.get("ALL_PROXY")
         print(f"ALL_PROXY: Expected '{expected_http_proxy}', Got '{actual_all_proxy}'")
         assert actual_all_proxy == expected_http_proxy, "ALL_PROXY mismatch!"
@@ -130,19 +118,19 @@ def test_vpn_proxy_environment_setup(
         assert os.environ.get("HTTP_PROXY") is None, "HTTP_PROXY should be None!"
         assert os.environ.get("HTTPS_PROXY") is None, "HTTPS_PROXY should be None!"
         print("Proxy not set (as expected)")
-    
+
     if expected_no_proxy:
         actual_no_proxy = os.environ.get("NO_PROXY")
         print(f"NO_PROXY: Expected '{expected_no_proxy}', Got '{actual_no_proxy}'")
         assert actual_no_proxy == expected_no_proxy, "NO_PROXY mismatch!"
-    
+
     print(f"--- Test '{test_id}' passed successfully ---")
 
 
 def test_proxy_scheme_normalization():
     """
     Verifies that URLs without scheme are correctly normalized to http://.
-    
+
     Tests various input formats:
     - Plain host:port → http://host:port
     - http:// → unchanged
@@ -150,7 +138,7 @@ def test_proxy_scheme_normalization():
     - socks5:// → unchanged
     """
     print("\n--- Test: Proxy scheme normalization ---")
-    
+
     test_cases = [
         ("192.168.1.100:8080", "http://192.168.1.100:8080"),
         ("http://192.168.1.100:8080", "http://192.168.1.100:8080"),
@@ -158,31 +146,31 @@ def test_proxy_scheme_normalization():
         ("socks5://192.168.1.100:8080", "socks5://192.168.1.100:8080"),
         ("127.0.0.1:7890", "http://127.0.0.1:7890"),
     ]
-    
+
     for input_url, expected_url in test_cases:
         print(f"\nInput: '{input_url}'")
-        
+
         # Logic from main.py
         proxy_url_with_scheme = input_url if "://" in input_url else f"http://{input_url}"
-        
+
         print(f"Result: '{proxy_url_with_scheme}'")
         print(f"Expected: '{expected_url}'")
         assert proxy_url_with_scheme == expected_url, f"Normalization failed for '{input_url}'"
-    
+
     print("\n--- Test passed: all schemes normalized correctly ---")
 
 
 def test_no_proxy_list_merging(monkeypatch):
     """
     Verifies correct merging of existing and new NO_PROXY values.
-    
+
     Tests:
     - Empty existing → only localhost
     - Existing values → preserved and localhost added
     - Duplicate localhost → acceptable (not a problem)
     """
     print("\n--- Test: NO_PROXY list merging ---")
-    
+
     test_cases = [
         # (existing, expected_result)
         ("", "127.0.0.1,localhost"),
@@ -190,58 +178,58 @@ def test_no_proxy_list_merging(monkeypatch):
         ("192.168.0.0/16,10.0.0.0/8", "192.168.0.0/16,10.0.0.0/8,127.0.0.1,localhost"),
         ("*.corp.com,localhost", "*.corp.com,localhost,127.0.0.1,localhost"),  # Duplicate localhost - OK
     ]
-    
+
     for existing_value, expected_result in test_cases:
         print(f"\nExisting NO_PROXY: '{existing_value}'")
-        
+
         # Simulate logic
         if existing_value:
             monkeypatch.setenv("NO_PROXY", existing_value)
         else:
             monkeypatch.delenv("NO_PROXY", raising=False)
-        
+
         no_proxy_hosts = os.environ.get("NO_PROXY", "")
         local_hosts = "127.0.0.1,localhost"
         if no_proxy_hosts:
             result = f"{no_proxy_hosts},{local_hosts}"
         else:
             result = local_hosts
-        
+
         print(f"Result: '{result}'")
         print(f"Expected: '{expected_result}'")
         assert result == expected_result, f"Merging failed for '{existing_value}'"
-    
+
     print("\n--- Test passed: lists merged correctly ---")
 
 
 def test_proxy_does_not_affect_local_connections(monkeypatch):
     """
     Verifies that local addresses (127.0.0.1, localhost) are always in NO_PROXY.
-    
+
     This ensures that local tests don't go through VPN/proxy,
     which would be slow and incorrect.
     """
     print("\n--- Test: Local addresses excluded from proxy ---")
-    
+
     # Simulate proxy setup
     vpn_url = "http://vpn.example.com:8080"
-    os.environ['HTTP_PROXY'] = vpn_url
-    os.environ['HTTPS_PROXY'] = vpn_url
-    
+    os.environ["HTTP_PROXY"] = vpn_url
+    os.environ["HTTPS_PROXY"] = vpn_url
+
     no_proxy_hosts = os.environ.get("NO_PROXY", "")
     local_hosts = "127.0.0.1,localhost"
     if no_proxy_hosts:
         os.environ["NO_PROXY"] = f"{no_proxy_hosts},{local_hosts}"
     else:
         os.environ["NO_PROXY"] = local_hosts
-    
+
     no_proxy_value = os.environ.get("NO_PROXY")
     print(f"NO_PROXY set to: '{no_proxy_value}'")
-    
+
     # Assertions
     assert "127.0.0.1" in no_proxy_value, "127.0.0.1 must be in NO_PROXY!"
     assert "localhost" in no_proxy_value, "localhost must be in NO_PROXY!"
-    
+
     print("✅ Local addresses correctly excluded from proxy")
     print("--- Test passed ---")
 
@@ -249,60 +237,60 @@ def test_proxy_does_not_affect_local_connections(monkeypatch):
 def test_proxy_with_special_characters():
     """
     Verifies that proxy URLs with special characters in credentials work correctly.
-    
+
     Tests authentication with:
     - Special characters in password
     - URL encoding (if needed)
     """
     print("\n--- Test: Proxy with special characters in credentials ---")
-    
+
     test_cases = [
         # (input_url, expected_normalized)
         ("http://user:p@ss@proxy.com:8080", "http://user:p@ss@proxy.com:8080"),
         ("http://admin:P@ssw0rd!@192.168.1.1:3128", "http://admin:P@ssw0rd!@192.168.1.1:3128"),
         ("socks5://user123:pass456@localhost:1080", "socks5://user123:pass456@localhost:1080"),
     ]
-    
+
     for input_url, expected_url in test_cases:
         print(f"\nInput: '{input_url}'")
-        
+
         # Normalization logic (should preserve special chars)
         proxy_url_with_scheme = input_url if "://" in input_url else f"http://{input_url}"
-        
+
         print(f"Result: '{proxy_url_with_scheme}'")
         print(f"Expected: '{expected_url}'")
         assert proxy_url_with_scheme == expected_url, f"Special chars handling failed for '{input_url}'"
-    
+
     print("\n--- Test passed: special characters preserved correctly ---")
 
 
 def test_empty_vpn_proxy_url_does_not_set_variables(monkeypatch):
     """
     Verifies that empty VPN_PROXY_URL doesn't set any proxy variables.
-    
+
     This is the default behavior - direct connection without proxy.
     """
     print("\n--- Test: Empty VPN_PROXY_URL (direct connection) ---")
-    
+
     # Clear all proxy variables
     for key in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"]:
         monkeypatch.delenv(key, raising=False)
-    
+
     # Simulate empty VPN_PROXY_URL
     vpn_url = ""
-    
+
     # Logic from main.py - should NOT execute if vpn_url is empty
     if vpn_url:
         proxy_url_with_scheme = vpn_url if "://" in vpn_url else f"http://{vpn_url}"
-        os.environ['HTTP_PROXY'] = proxy_url_with_scheme
-        os.environ['HTTPS_PROXY'] = proxy_url_with_scheme
-        os.environ['ALL_PROXY'] = proxy_url_with_scheme
-    
+        os.environ["HTTP_PROXY"] = proxy_url_with_scheme
+        os.environ["HTTPS_PROXY"] = proxy_url_with_scheme
+        os.environ["ALL_PROXY"] = proxy_url_with_scheme
+
     # Verify no proxy variables are set
     assert os.environ.get("HTTP_PROXY") is None, "HTTP_PROXY should not be set!"
     assert os.environ.get("HTTPS_PROXY") is None, "HTTPS_PROXY should not be set!"
     assert os.environ.get("ALL_PROXY") is None, "ALL_PROXY should not be set!"
-    
+
     print("✅ No proxy variables set (direct connection)")
     print("--- Test passed ---")
 


### PR DESCRIPTION
## Summary

CI had no Python quality gates at all: no ruff, no formatter, no type checker, and no config for any of them. This adds them and makes the tree actually satisfy them, rather than ignoring the findings.

A new `quality` job runs `ruff format --check`, `ruff check`, and `mypy` on the Python tree, plus `eslint` and `tsc` on the dashboard. The docker `build` job now depends on `[test, quality]`, so an image cannot publish while any gate is red.

Baseline before this change: 295 ruff violations, 89 unformatted files, 60 mypy errors.
After: all three gates clean, `1694 passed`.

## Real defects the gates exposed

- `kiro/converters_anthropic.py` had an unreachable `return tool_results` after `return images`, referencing an undefined name.
- Three tests patched names production code never uses, so they could not have failed for the behavior they claimed to cover: `account_manager` owns no httpx client, `main` reads `PROFILE_ARN`/`REGION` via `os.getenv`, and the Anthropic route streams through `stream_with_first_token_retry_anthropic`.
- 20 dead local assignments across `kiro/` and `tests/`.

## Also fixes main CI

CI on main was already red before this branch: 41 tests returned 401 on every authenticated route. `config.PROXY_API_KEY` falls back to a built-in default while the data-plane authenticator reads `PROXY_API_KEY` straight from the environment, so without a local `.env` the two disagreed. The test fixture now pins the variable to whatever config resolved.

## Tested

- `pytest -q` => 1694 passed, both with a local `.env` and in a clean `git archive` checkout without one (the CI condition).
- `ruff check .` => clean; `ruff format --check .` => 96 files formatted; `mypy` => no issues in 40 source files.
- `bun run lint` and `bun run typecheck` => exit 0.

## Notes

- Tool versions are pinned in `requirements-dev.txt` so a tool release cannot turn CI red on its own.
- `E501` is deliberately out of the lint rule set because the formatter owns line length.
- The single `# type: ignore` is Starlette typing exception handlers invariantly as `Exception`, annotated with that reason.
- `UP`/`B` rule families are not enabled; they report 10k+ findings and would be a modernization refactor, not a gate.