### PR TITLE
Suspension detection, registration usage priming, opt-in web_search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,13 +208,13 @@ PROXY_API_KEY="my-super-secret-password-123"
 # WEBSEARCH (MCP Tool Emulation)
 # ===========================================
 
-# Enable web_search tool auto-injection (default: true)
+# Enable web_search tool auto-injection (default: false)
 # When enabled, web_search is automatically added as a tool for MCP emulation (Path B)
 # Model decides whether to use it or not
 #
 # Note: Native Anthropic server-side tools (Path A with "type" field) work ALWAYS,
 # regardless of this setting
-# WEB_SEARCH_ENABLED=true
+# WEB_SEARCH_ENABLED=false
 
 # ===========================================
 # PAYLOAD SIZE GUARD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ kiro-lb-python/
 ├── kiro/                    # Gateway package: 39 modules, 16.5k lines
 │   └── static/              # BUILD OUTPUT of frontend/ — never hand-edit
 ├── frontend/                # Bun + Vite + React 19 dashboard source
-├── tests/                   # pytest, 1725 tests; network-blocked by conftest
+├── tests/                   # pytest, 1768 tests; network-blocked by conftest
 ├── data/                    # Runtime credentials/state/sqlite (gitignored)
 ├── debug_logs/              # Capture output when DEBUG_MODE is on (gitignored)
 ├── pyproject.toml           # ruff + mypy config only; the project is not packaged
@@ -104,6 +104,10 @@ trusting a pin here.
   `ALTER TABLE` migration (`dashboard.py:96`, `:147`), never a destructive rewrite.
 - Proxy env vars are set before any httpx client exists (`main.py:181`); creating
   a client earlier silently ignores the VPN/proxy config.
+- `web_search` auto-injection (Path B) is opt-in and off by default
+  (`config.py:498`): injecting a tool the caller never asked for changes the
+  shape of every request. Native server-side `web_search` (Path A) is driven by
+  the client and works regardless of the flag (`routes_anthropic.py:173`).
 - `pytest.ini`, `kiro/__init__.py`, and legacy comments in `kiro/http_client.py`,
   `kiro/mcp_tools.py` and 5 test modules are Russian; new code, comments, and
   docstrings are English only.
@@ -158,14 +162,18 @@ trusting a pin here.
 
 ```bash
 python main.py --host 127.0.0.1 --port 8000    # run gateway
-pytest -q                                      # full suite (1725 tests, ~6s, no network)
+pytest -q                                      # full suite (1768 tests, ~6s, no network)
 pytest -v --tb=short                           # exactly what CI's test job runs
 pytest --cov=kiro --cov-report=term            # CI coverage step
 ruff format --check --diff . && ruff check .   # CI quality job, python half
 mypy                                           # config in pyproject.toml (kiro + main.py)
 cd frontend && bun run lint && bun run typecheck && bun run build
-docker compose -f docker-compose.homelab.yml up -d --build
+docker compose -p kiro-lb -f docker-compose.homelab.yml up -d --build
 ```
+
+The `-p kiro-lb` is required: the live container was created under that project
+name, so letting compose derive it from the directory (`kiro-lb-python`) fails on
+a `container_name` conflict instead of recreating.
 
 CI (`.github/workflows/docker.yml`) has three jobs: `quality` (ruff format check,
 ruff check, mypy, frontend eslint + tsc), `test` (pytest, then coverage), and

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+import httpx
 from loguru import logger
 
 from kiro.account_errors import ErrorType
@@ -640,20 +641,10 @@ class AccountManager:
                     if response.status_code == 200:
                         data = response.json()
                         models_list = data.get("models", [])
-                    elif is_suspension_error(response.status_code, response.text, _reason_of(response.text)):
-                        # The model listing is the first upstream call an account
-                        # makes, so a suspension surfaces here before a single
-                        # client request is spent on it. Quarantine now instead of
-                        # falling back to the static list, which would leave a
-                        # locked account advertising every model and drawing
+                    elif self._quarantine_if_suspended(account_id, account, response):
+                        # A locked account must not fall back to the static list:
+                        # that is what left it advertising every model and drawing
                         # traffic it can only answer 403 to.
-                        account.suspended_until = time.time() + ACCOUNT_SUSPENSION_QUARANTINE
-                        self._dirty = True
-                        logger.error(
-                            f"Account {account_id} is SUSPENDED upstream (detected while listing models); "
-                            f"excluded from routing for {_format_duration(ACCOUNT_SUSPENSION_QUARANTINE)}. "
-                            f"Kiro support must restore this account."
-                        )
                         models_list = []
                     else:
                         # Shouldn't happen (retry handles non-200), but keep for safety
@@ -705,6 +696,25 @@ class AccountManager:
             logger.error(f"Failed to initialize account {account_id}: {e}")
             return False
 
+    def _quarantine_if_suspended(self, account_id: str, account: "Account", response: httpx.Response) -> bool:
+        """Park an account whose model listing came back as an upstream lock.
+
+        ListAvailableModels is the first upstream call an account makes, so a
+        suspension can be caught here before a client request is spent on it.
+        Returns whether the account was quarantined.
+        """
+        body = response.text
+        if not is_suspension_error(response.status_code, body, _reason_of(body)):
+            return False
+        account.suspended_until = time.time() + ACCOUNT_SUSPENSION_QUARANTINE
+        self._dirty = True
+        logger.error(
+            f"Account {account_id} is SUSPENDED upstream (detected while listing models); "
+            f"excluded from routing for {_format_duration(ACCOUNT_SUSPENSION_QUARANTINE)}. "
+            f"Kiro support must restore this account."
+        )
+        return True
+
     async def _refresh_account_models(self, account_id: str) -> None:
         """
         Refresh model cache for account (TTL refresh).
@@ -747,7 +757,12 @@ class AccountManager:
                 method="GET", url=list_models_url, json_data=None, params=params, stream=False
             )
 
-            if response.status_code == 200:
+            if response.status_code != 200:
+                # A TTL refresh is also an upstream verdict. Without this check a
+                # suspension arriving here was swallowed and the stale cache kept
+                # the locked account advertising models indefinitely.
+                self._quarantine_if_suspended(account_id, account, response)
+            else:
                 data = response.json()
                 models_list = data.get("models", [])
                 await account.model_cache.update(models_list)

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -46,7 +46,7 @@ from kiro.config import (
     STATE_SAVE_INTERVAL_SECONDS,
 )
 from kiro.http_client import KiroHttpClient
-from kiro.kiro_errors import SUSPENSION_REASON
+from kiro.kiro_errors import is_suspension_error
 from kiro.model_resolver import ModelResolver, normalize_model_name
 
 
@@ -142,6 +142,21 @@ def account_routing_state(account: "Account", now: Optional[float] = None) -> Tu
         return ("uninitialized", 0)
 
     return ("available", 0)
+
+
+def _reason_of(body: str) -> Optional[str]:
+    """Pull the reason code out of an upstream error body, if it carries one.
+
+    The runtime host states the verdict in `reason`; the legacy q.* host sends
+    `reason: null` and words it in the message instead. Both callers pass the
+    result to is_suspension_error, which handles either shape.
+    """
+    try:
+        parsed = json.loads(body)
+    except Exception:
+        return None
+    reason = parsed.get("reason") if isinstance(parsed, dict) else None
+    return str(reason) if reason else None
 
 
 def _format_duration(seconds: float) -> str:
@@ -625,6 +640,21 @@ class AccountManager:
                     if response.status_code == 200:
                         data = response.json()
                         models_list = data.get("models", [])
+                    elif is_suspension_error(response.status_code, response.text, _reason_of(response.text)):
+                        # The model listing is the first upstream call an account
+                        # makes, so a suspension surfaces here before a single
+                        # client request is spent on it. Quarantine now instead of
+                        # falling back to the static list, which would leave a
+                        # locked account advertising every model and drawing
+                        # traffic it can only answer 403 to.
+                        account.suspended_until = time.time() + ACCOUNT_SUSPENSION_QUARANTINE
+                        self._dirty = True
+                        logger.error(
+                            f"Account {account_id} is SUSPENDED upstream (detected while listing models); "
+                            f"excluded from routing for {_format_duration(ACCOUNT_SUSPENSION_QUARANTINE)}. "
+                            f"Kiro support must restore this account."
+                        )
+                        models_list = []
                     else:
                         # Shouldn't happen (retry handles non-200), but keep for safety
                         raise Exception(f"HTTP {response.status_code}")
@@ -939,7 +969,13 @@ class AccountManager:
                 pass
 
     async def report_failure(
-        self, account_id: str, model: str, error_type: ErrorType, status_code: int, reason: Optional[str]
+        self,
+        account_id: str,
+        model: str,
+        error_type: ErrorType,
+        status_code: int,
+        reason: Optional[str],
+        message: Optional[str] = None,
     ) -> None:
         """
         Report failed request (update failures, stats, failover).
@@ -950,6 +986,9 @@ class AccountManager:
             error_type: Error classification (FATAL or RECOVERABLE)
             status_code: HTTP status code
             reason: Error reason from Kiro API
+            message: Original upstream message. Required to recognize a
+                suspension on the legacy q.* host, which sends reason=null and
+                states the verdict only in the message.
         """
         async with self._lock:
             account = self._accounts.get(account_id)
@@ -990,7 +1029,13 @@ class AccountManager:
             # quarantine and leave the Circuit Breaker alone - inflating failures
             # would only add an unrelated backoff to an account already fully
             # excluded.
-            if reason == SUSPENSION_REASON:
+            #
+            # The reason field alone is not the test: the runtime host sends
+            # reason=TEMPORARILY_SUSPENDED, but the legacy q.* host sends
+            # reason=null and states the verdict only in the message. Checking
+            # reason only left Builder ID accounts in the rotation, answering 403
+            # to every request forever.
+            if is_suspension_error(status_code, message, reason):
                 account.suspended_until = time.time() + ACCOUNT_SUSPENSION_QUARANTINE
                 account.stats.total_requests += 1
                 account.stats.failed_requests += 1

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -490,12 +490,16 @@ AUTO_TRIM_PAYLOAD: bool = os.getenv("AUTO_TRIM_PAYLOAD", "false").lower() in ("t
 # WebSearch Settings (MCP Tool Emulation)
 # ==================================================================================================
 
-# Enable web_search tool auto-injection (default: true)
+# Enable web_search tool auto-injection (default: false)
 # When enabled, web_search is automatically added as a tool for MCP emulation (Path B)
 # Model decides whether to use it or not
 #
+# Off by default: injecting a tool the caller never asked for changes the shape
+# of every request, and a client with its own search tool then sees two.
+# Opt in with WEB_SEARCH_ENABLED=true.
+#
 # Note: Native Anthropic server-side tools (Path A) work ALWAYS, regardless of this setting
-WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "true").lower() in ("true", "1", "yes")
+WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "false").lower() in ("true", "1", "yes")
 
 # ==================================================================================================
 # Account System Settings

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -428,6 +428,21 @@ async def refresh_account_usage(account: Any) -> dict[str, Any]:
         return {"updatedAt": updated_at, "error": error}
 
 
+async def prime_registered_account_usage(manager: Any, result: dict[str, Any]) -> dict[str, Any]:
+    """Poll quota for a freshly registered account and drop the internal key.
+
+    `register_account` returns the raw account ID (a credential path or token
+    hash) so the caller can find the new pool entry. That key must never reach
+    the client, and every registration route has to poll usage here: the
+    periodic refresh is up to USAGE_REFRESH_INTERVAL_SECONDS away, so without
+    this the new account shows no email, tier, or usage until then.
+    """
+    account = manager._accounts.get(result.pop("accountKey", ""))
+    if account is not None and account.auth_manager is not None:
+        await refresh_account_usage(account)
+    return result
+
+
 async def refresh_all_account_usage(manager: Any) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for account_id, account in list(manager._accounts.items()):
@@ -581,12 +596,7 @@ async def dashboard_register_account(request: Request) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Account registration failed: {exc}") from exc
-    # Populate quota immediately so the new account is not blank in the UI.
-    manager = request.app.state.account_manager
-    account = manager._accounts.get(result.pop("accountKey", ""))
-    if account is not None and account.auth_manager is not None:
-        await refresh_account_usage(account)
-    return result
+    return await prime_registered_account_usage(request.app.state.account_manager, result)
 
 
 @router.post("/api/dashboard/accounts/refresh-usage")
@@ -658,7 +668,7 @@ async def dashboard_register_device_login(flow_id: str, request: Request) -> dic
         discard_flow(flow_id)
 
     result["provider"] = flow.provider
-    return result
+    return await prime_registered_account_usage(request.app.state.account_manager, result)
 
 
 @router.delete("/api/dashboard/accounts/device-login/{flow_id}")

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -401,12 +401,18 @@ async def messages(
 
                     # Extract error reason and save for final return
                     error_reason = None
+                    # The upstream message is kept verbatim: on the legacy q.*
+                    # host a suspension arrives with reason=null and the verdict
+                    # only in the message, so report_failure needs the raw text
+                    # to quarantine the account instead of retrying it forever.
+                    upstream_message = error_text
                     try:
                         error_json = json.loads(error_text)
                         from kiro.kiro_errors import enhance_kiro_error
 
                         error_info = enhance_kiro_error(error_json)
                         error_reason = error_info.reason
+                        upstream_message = error_info.original_message or error_text
                         last_error_message = error_info.user_message
                         last_error_status = response.status_code
                         logger.debug(
@@ -422,7 +428,12 @@ async def messages(
                     if error_type == ErrorType.FATAL:
                         # FATAL - return to client immediately
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type, response.status_code, error_reason
+                            account.id,
+                            request_data.model,
+                            error_type,
+                            response.status_code,
+                            error_reason,
+                            upstream_message,
                         )
 
                         logger.warning(f"HTTP {response.status_code} - POST /v1/messages - {last_error_message[:100]}")
@@ -438,7 +449,12 @@ async def messages(
                     else:  # ErrorType.RECOVERABLE
                         # RECOVERABLE - try next account
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type, response.status_code, error_reason
+                            account.id,
+                            request_data.model,
+                            error_type,
+                            response.status_code,
+                            error_reason,
+                            upstream_message,
                         )
 
                         # Single account - no point in failover, break immediately

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -506,12 +506,18 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
 
                     # Extract error reason and save for final return
                     error_reason = None
+                    # The upstream message is kept verbatim: on the legacy q.*
+                    # host a suspension arrives with reason=null and the verdict
+                    # only in the message, so report_failure needs the raw text
+                    # to quarantine the account instead of retrying it forever.
+                    upstream_message = error_text
                     try:
                         error_json = json.loads(error_text)
                         from kiro.kiro_errors import enhance_kiro_error
 
                         error_info = enhance_kiro_error(error_json)
                         error_reason = error_info.reason
+                        upstream_message = error_info.original_message or error_text
                         last_error_message = error_info.user_message
                         last_error_status = response.status_code
                         logger.debug(
@@ -527,7 +533,12 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                     if error_type == ErrorType.FATAL:
                         # FATAL - return to client immediately
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type, response.status_code, error_reason
+                            account.id,
+                            request_data.model,
+                            error_type,
+                            response.status_code,
+                            error_reason,
+                            upstream_message,
                         )
 
                         logger.warning(
@@ -551,7 +562,12 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                     else:  # ErrorType.RECOVERABLE
                         # RECOVERABLE - try next account
                         await account_manager.report_failure(
-                            account.id, request_data.model, error_type, response.status_code, error_reason
+                            account.id,
+                            request_data.model,
+                            error_type,
+                            response.status_code,
+                            error_reason,
+                            upstream_message,
                         )
 
                         # Single account - no point in failover, break immediately

--- a/tests/unit/test_account_suspension.py
+++ b/tests/unit/test_account_suspension.py
@@ -142,6 +142,80 @@ class TestSuspensionQuarantine:
         assert account.failures == 0
         assert account.stats.failed_requests == 1
 
+    def test_legacy_host_suspension_quarantines_without_a_reason_code(self, manager):
+        """The q.* host sends reason=null and states the verdict in the message.
+
+        Matching on the reason code alone left these accounts in the rotation
+        answering 403 to every request, which is the exact failure the
+        quarantine exists to prevent.
+        """
+        import asyncio
+
+        account = _account()
+        manager._accounts[account.id] = account
+
+        asyncio.run(
+            manager.report_failure(
+                account.id, "claude-sonnet-4.5", ErrorType.RECOVERABLE, 403, None, _SUSPENDED_BODY["message"]
+            )
+        )
+
+        remaining = account.suspended_until - time.time()
+        assert remaining == pytest.approx(ACCOUNT_SUSPENSION_QUARANTINE, abs=5)
+        assert account.failures == 0
+
+    def test_runtime_host_suspension_quarantines_from_the_message_too(self, manager):
+        import asyncio
+
+        account = _account()
+        manager._accounts[account.id] = account
+
+        asyncio.run(
+            manager.report_failure(
+                account.id, "claude-sonnet-4.5", ErrorType.RECOVERABLE, 403, None, _SUSPENDED_BODY_RUNTIME["message"]
+            )
+        )
+
+        assert account.suspended_until > time.time()
+        assert account.failures == 0
+
+    def test_a_plain_403_still_drives_the_circuit_breaker(self, manager):
+        """Only a suspension verdict may quarantine; an ordinary 403 must not."""
+        import asyncio
+
+        account = _account()
+        manager._accounts[account.id] = account
+
+        asyncio.run(
+            manager.report_failure(
+                account.id,
+                "claude-sonnet-4.5",
+                ErrorType.RECOVERABLE,
+                403,
+                None,
+                "The security token included in the request is expired",
+            )
+        )
+
+        assert account.suspended_until == 0.0
+        assert account.failures == 1
+
+    def test_suspension_wording_in_a_non_403_is_not_a_verdict(self, manager):
+        """A 400 echoing the payload says nothing about the account itself."""
+        import asyncio
+
+        account = _account()
+        manager._accounts[account.id] = account
+
+        asyncio.run(
+            manager.report_failure(
+                account.id, "claude-sonnet-4.5", ErrorType.RECOVERABLE, 400, None, _SUSPENDED_BODY["message"]
+            )
+        )
+
+        assert account.suspended_until == 0.0
+        assert account.failures == 1
+
     def test_suspended_account_is_never_selected(self, manager):
         import asyncio
 
@@ -179,6 +253,119 @@ class TestSuspensionQuarantine:
         asyncio.run(manager.report_success(account.id, "claude-sonnet-4.5"))
 
         assert account.suspended_until == 0.0
+
+
+class TestSuspensionDetectedAtInitialization:
+    """A locked account must leave the pool before it costs a client request.
+
+    ListAvailableModels is the first upstream call an account makes. It answers
+    403 for a suspended account, and that non-200 used to be swallowed by the
+    FALLBACK_MODELS path: the account came up advertising all 19 models and
+    collected traffic it could only answer 403 to.
+    """
+
+    @staticmethod
+    def _manager_with_json_account(tmp_path):
+        import json as json_module
+
+        creds = tmp_path / "account.json"
+        # clientId/clientSecret select AWS SSO OIDC, which resolves to the legacy
+        # q.* host. The runtime host skips ListAvailableModels entirely
+        # (_is_runtime_endpoint), so it could never surface a suspension here.
+        creds.write_text(
+            json_module.dumps(
+                {
+                    "refreshToken": "t",
+                    "accessToken": "a",
+                    "expiresAt": "2099-01-01T00:00:00.000Z",
+                    "clientId": "client-id",
+                    "clientSecret": "client-secret",
+                    "region": "us-east-1",
+                }
+            )
+        )
+        pool = tmp_path / "credentials.json"
+        pool.write_text(json_module.dumps([{"type": "json", "path": str(creds)}]))
+        mgr = AccountManager(str(pool), str(tmp_path / "state.json"))
+        mgr._save_state = AsyncMock()
+        return mgr, str(creds.resolve())
+
+    def _initialize_with_response(self, tmp_path, status_code, body):
+        import asyncio
+        import json as json_module
+        from unittest.mock import patch
+
+        manager, account_id = self._manager_with_json_account(tmp_path)
+        asyncio.run(manager.load_credentials())
+
+        response = MagicMock()
+        response.status_code = status_code
+        response.text = json_module.dumps(body)
+        response.json.return_value = body
+
+        with patch("kiro.account_manager.KiroHttpClient") as http_class:
+            client = AsyncMock()
+            client.request_with_retry = AsyncMock(return_value=response)
+            client.close = AsyncMock()
+            http_class.return_value = client
+            ok = asyncio.run(manager._initialize_account(account_id))
+        return manager, account_id, ok
+
+    def test_legacy_host_403_quarantines_instead_of_falling_back(self, tmp_path):
+        manager, account_id, _ = self._initialize_with_response(tmp_path, 403, _SUSPENDED_BODY)
+
+        account = manager._accounts[account_id]
+        remaining = account.suspended_until - time.time()
+        assert remaining == pytest.approx(ACCOUNT_SUSPENSION_QUARANTINE, abs=5)
+
+    def test_runtime_host_403_quarantines_too(self, tmp_path):
+        manager, account_id, _ = self._initialize_with_response(tmp_path, 403, _SUSPENDED_BODY_RUNTIME)
+
+        assert manager._accounts[account_id].suspended_until > time.time()
+
+    def test_a_quarantined_account_advertises_no_models(self, tmp_path):
+        """Falling back to the static list is what made a locked account look healthy."""
+        manager, account_id, _ = self._initialize_with_response(tmp_path, 403, _SUSPENDED_BODY)
+
+        resolver = manager._accounts[account_id].model_resolver
+        advertised = set(resolver.get_available_models()) if resolver else set()
+        assert "claude-opus-5" not in advertised
+
+    def test_a_quarantined_account_is_not_a_routing_target(self, tmp_path):
+        """With a healthy peer present, the locked account must never be picked.
+
+        A second account is required for this assertion: the single-account path
+        deliberately bypasses every exclusion so the operator sees the real
+        upstream error instead of a generic "no account available".
+        """
+        import asyncio
+
+        manager, account_id, _ = self._initialize_with_response(tmp_path, 403, _SUSPENDED_BODY)
+        healthy = _account("/creds/healthy.json")
+        healthy.models_cached_at = time.time()
+        manager._accounts[healthy.id] = healthy
+
+        picks = {asyncio.run(manager.get_next_account("claude-sonnet-4.5")).id for _ in range(50)}
+
+        assert picks == {healthy.id}
+
+    def test_an_unrelated_failure_still_falls_back(self, tmp_path):
+        """Only a suspension may empty the model list; a network blip must not."""
+        import asyncio
+        from unittest.mock import patch
+
+        manager, account_id = self._manager_with_json_account(tmp_path)
+        asyncio.run(manager.load_credentials())
+
+        with patch("kiro.account_manager.KiroHttpClient") as http_class:
+            client = AsyncMock()
+            client.request_with_retry = AsyncMock(side_effect=Exception("Network error"))
+            client.close = AsyncMock()
+            http_class.return_value = client
+            ok = asyncio.run(manager._initialize_account(account_id))
+
+        assert ok is True
+        assert manager._accounts[account_id].suspended_until == 0.0
 
 
 class TestSuspensionPersistence:

--- a/tests/unit/test_account_suspension.py
+++ b/tests/unit/test_account_suspension.py
@@ -368,6 +368,83 @@ class TestSuspensionDetectedAtInitialization:
         assert manager._accounts[account_id].suspended_until == 0.0
 
 
+class TestSuspensionDetectedOnTtlRefresh:
+    """A suspension can also arrive after an account is already healthy.
+
+    The model cache expires on ACCOUNT_CACHE_TTL and _refresh_account_models
+    re-lists. That call answers 403 once the account is locked, and treating any
+    non-200 as "keep the stale cache" left the account advertising every model
+    for as long as the process lived.
+    """
+
+    @staticmethod
+    def _healthy_account(account_id: str = "/creds/locked-later.json") -> Account:
+        from kiro.cache import ModelInfoCache
+        from kiro.model_resolver import ModelResolver
+
+        account = Account(id=account_id)
+        auth = MagicMock()
+        # A plain MagicMock q_host would make _is_runtime_endpoint short-circuit
+        # the refresh, so the legacy host is set explicitly.
+        auth.q_host = "https://q.us-east-1.amazonaws.com"
+        auth.profile_arn = None
+        account.auth_manager = auth
+        account.model_cache = ModelInfoCache()
+        account.model_resolver = ModelResolver(cache=account.model_cache, hidden_models={}, aliases={})
+        account.models_cached_at = time.time()
+        return account
+
+    def _refresh_with_response(self, manager, status_code, body):
+        import asyncio
+        import json as json_module
+        from unittest.mock import patch
+
+        response = MagicMock()
+        response.status_code = status_code
+        response.text = json_module.dumps(body)
+        response.json.return_value = body
+
+        with patch("kiro.account_manager.KiroHttpClient") as http_class:
+            client = AsyncMock()
+            client.request_with_retry = AsyncMock(return_value=response)
+            client.close = AsyncMock()
+            http_class.return_value = client
+            asyncio.run(manager._refresh_account_models(next(iter(manager._accounts))))
+
+    def test_refresh_403_quarantines_the_account(self, manager):
+        account = self._healthy_account()
+        manager._accounts[account.id] = account
+
+        self._refresh_with_response(manager, 403, _SUSPENDED_BODY)
+
+        remaining = account.suspended_until - time.time()
+        assert remaining == pytest.approx(ACCOUNT_SUSPENSION_QUARANTINE, abs=5)
+
+    def test_refresh_403_stops_the_account_being_routed_to(self, manager):
+        import asyncio
+
+        account = self._healthy_account()
+        manager._accounts[account.id] = account
+        self._refresh_with_response(manager, 403, _SUSPENDED_BODY)
+
+        healthy = _account("/creds/healthy.json")
+        healthy.models_cached_at = time.time()
+        manager._accounts[healthy.id] = healthy
+
+        picks = {asyncio.run(manager.get_next_account("claude-sonnet-4.5")).id for _ in range(50)}
+
+        assert picks == {healthy.id}
+
+    def test_an_unrelated_refresh_failure_is_not_a_suspension(self, manager):
+        """A 500 says nothing about the account; the stale cache stays usable."""
+        account = self._healthy_account()
+        manager._accounts[account.id] = account
+
+        self._refresh_with_response(manager, 500, {"message": "internal", "reason": None})
+
+        assert account.suspended_until == 0.0
+
+
 class TestSuspensionPersistence:
     def test_suspension_survives_a_restart(self, tmp_path):
         import asyncio

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -818,10 +818,11 @@ class TestFallbackModelsIntegration:
 class TestWebSearchConfig:
     """Tests for WebSearch configuration (WEB_SEARCH_ENABLED)."""
 
-    def test_web_search_enabled_default_true(self, monkeypatch):
+    def test_web_search_enabled_defaults_to_false(self, monkeypatch):
         """
-        What it does: Verifies WEB_SEARCH_ENABLED defaults to true.
-        Purpose: Ensure auto-injection is enabled by default.
+        What it does: Verifies WEB_SEARCH_ENABLED defaults to false.
+        Purpose: Auto-injection is opt-in; a caller that never asked for a search
+            tool must not have one added to its request.
         """
         print("Setup: Removing WEB_SEARCH_ENABLED from environment...")
         monkeypatch.delenv("WEB_SEARCH_ENABLED", raising=False)
@@ -839,8 +840,8 @@ class TestWebSearchConfig:
         monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **k: False)
         reload(config_module)
 
-        print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")
-        assert config_module.WEB_SEARCH_ENABLED is True
+        print(f"Comparing WEB_SEARCH_ENABLED: Expected False, Got {config_module.WEB_SEARCH_ENABLED}")
+        assert config_module.WEB_SEARCH_ENABLED is False
 
     def test_web_search_enabled_false(self, monkeypatch):
         """

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -829,8 +829,14 @@ class TestWebSearchConfig:
         print("Action: Reloading config module...")
         from importlib import reload
 
+        import dotenv
+
         import kiro.config as config_module
 
+        # reload() re-runs load_dotenv(), so an operator .env that sets
+        # WEB_SEARCH_ENABLED would decide this assertion. Patch dotenv itself,
+        # not the config attribute: reload re-imports the name.
+        monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **k: False)
         reload(config_module)
 
         print(f"Comparing WEB_SEARCH_ENABLED: Expected True, Got {config_module.WEB_SEARCH_ENABLED}")

--- a/tests/unit/test_dashboard_registration_usage.py
+++ b/tests/unit/test_dashboard_registration_usage.py
@@ -1,0 +1,114 @@
+"""Quota priming for freshly registered accounts.
+
+Both registration routes (manual credential entry and browser device login)
+must poll usage before answering. The periodic refresh runs on a
+USAGE_REFRESH_INTERVAL_SECONDS cadence, so an account registered between two
+ticks otherwise sits in the dashboard with no email, tier, or usage until the
+next one. The internal account key that `register_account` hands back for that
+lookup is a credential path, so it must not survive into the response.
+"""
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro.account_manager import Account
+
+_USAGE = {
+    "email": "fresh@example.test",
+    "subscriptionTitle": "KIRO FREE",
+    "subscriptionType": "Q_DEVELOPER_STANDALONE_FREE",
+    "resourceType": "CREDIT",
+    "currentUsage": 0.0,
+    "usageLimit": 50.0,
+    "usagePercent": 0.0,
+    "unit": "INVOCATIONS",
+    "overageStatus": "DISABLED",
+    "overageUsed": 0.0,
+    "overageRate": None,
+    "nextDateReset": 1788220800.0,
+    "daysUntilReset": 3,
+}
+
+_ACCOUNT_KEY = "/data/logins/builder-id-fresh.json"
+
+
+@pytest.fixture
+def dashboard(tmp_path, monkeypatch):
+    monkeypatch.setenv("DASHBOARD_DATA_DIR", str(tmp_path))
+    module = importlib.reload(importlib.import_module("kiro.dashboard"))
+    module.initialize_dashboard_store()
+    return module
+
+
+def _manager_with_registered_account() -> SimpleNamespace:
+    account = Account(id=_ACCOUNT_KEY)
+    account.auth_manager = MagicMock()
+    return SimpleNamespace(_accounts={_ACCOUNT_KEY: account})
+
+
+def _registration_result() -> dict:
+    return {
+        "accountId": "472bf78ae092",
+        "accountKey": _ACCOUNT_KEY,
+        "type": "json",
+        "initialized": True,
+    }
+
+
+def _prime(dashboard, manager, result):
+    with patch.object(dashboard, "fetch_account_usage", AsyncMock(return_value=_USAGE)):
+        return asyncio.run(dashboard.prime_registered_account_usage(manager, result))
+
+
+def test_registration_stores_usage_for_the_new_account(dashboard):
+    manager = _manager_with_registered_account()
+
+    _prime(dashboard, manager, _registration_result())
+
+    view = dashboard._account_view(manager._accounts[_ACCOUNT_KEY])
+    assert view["usage"]["email"] == "fresh@example.test"
+    assert view["usage"]["subscriptionTitle"] == "KIRO FREE"
+    assert view["usage"]["usageLimit"] == 50.0
+
+
+def test_internal_account_key_is_not_returned(dashboard):
+    result = _prime(dashboard, _manager_with_registered_account(), _registration_result())
+
+    assert "accountKey" not in result
+    assert _ACCOUNT_KEY not in str(result)
+    assert result["accountId"] == "472bf78ae092"
+
+
+def test_uninitialized_account_is_not_polled(dashboard):
+    manager = _manager_with_registered_account()
+    manager._accounts[_ACCOUNT_KEY].auth_manager = None
+
+    with patch.object(dashboard, "fetch_account_usage", AsyncMock(return_value=_USAGE)) as fetch:
+        asyncio.run(dashboard.prime_registered_account_usage(manager, _registration_result()))
+
+    fetch.assert_not_awaited()
+    assert dashboard._account_view(manager._accounts[_ACCOUNT_KEY])["usage"] is None
+
+
+def test_a_failed_poll_does_not_fail_the_registration(dashboard):
+    manager = _manager_with_registered_account()
+
+    with patch.object(dashboard, "fetch_account_usage", AsyncMock(side_effect=RuntimeError("upstream 403"))):
+        result = asyncio.run(dashboard.prime_registered_account_usage(manager, _registration_result()))
+
+    assert result["initialized"] is True
+    assert dashboard._account_view(manager._accounts[_ACCOUNT_KEY])["usage"]["error"] == "upstream 403"
+
+
+def test_both_registration_routes_prime_usage():
+    """Neither route may answer without priming; device login used to skip it."""
+    import inspect
+
+    import kiro.dashboard as module
+
+    for route in (module.dashboard_register_account, module.dashboard_register_device_login):
+        assert "prime_registered_account_usage" in inspect.getsource(route)


### PR DESCRIPTION
## Summary

Five commits, from turning off the injected `web_search` tool on the homelab deployment.

**`web_search` auto-injection is now opt-in** (`kiro/config.py`)
`WEB_SEARCH_ENABLED` defaulted to `true`, so every request got a `web_search` tool its caller never asked for; a client carrying its own search tool saw two. Default is now `false`. Native server-side `web_search` (Path A) is driven by what the client sends and is unaffected.

**Suspension detection** (`kiro/account_manager.py`, both routes)
`reason == TEMPORARILY_SUSPENDED` was the only test. The legacy `q.*` host sends `reason: null` and words the verdict in the message, so Builder ID accounts stayed in the rotation answering 403 indefinitely. Both routes now forward the verbatim upstream message to `report_failure`.

Quarantine applies at both model-listing sites via `_quarantine_if_suspended`: `_initialize_account` (the first upstream call an account makes, so a lock is caught before a client request is spent) and `_refresh_account_models`, which previously treated every non-200 as "keep the stale cache" and let an account suspended after coming up healthy advertise all its models for the life of the process.

**Registration usage priming** (`kiro/dashboard.py`)
Manual credential entry primed quota; the device-login route did not, leaving a browser-added account blank in the UI until the next `USAGE_REFRESH_INTERVAL_SECONDS` tick. Both now share `prime_registered_account_usage`, which also strips the internal `accountKey` (a credential path) from the response.

**Test isolation** (`tests/unit/test_config.py`)
The web_search default test reloads `kiro.config`, which re-runs `load_dotenv()`, so a local `.env` decided the assertion. Now patches `dotenv.load_dotenv`.

## Testing

- `pytest -q` — 1768 passed (was 1725 on main)
- `ruff format --check .`, `ruff check .`, `mypy` — clean
- Reverted the refresh-path fix locally to confirm the two new TTL tests fail without it
- Verified on the live homelab deploy: `builder-id-7Oay0539aYPtzTFS` was caught at model listing and quarantined for 1d

`WEB_SEARCH_ENABLED=false` in `.env` is a local deployment change and stays out of this branch (gitignored); the code default now matches it anyway.