### PR TITLE
Expose a Prometheus endpoint at /metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -265,3 +265,18 @@ PROXY_API_KEY="my-super-secret-password-123"
 # DEBUG_CAPTURE_SUCCESS=false
 # DEBUG_CAPTURE_MAX_BYTES=4194304
 # DEBUG_CAPTURE_RETENTION=10
+
+# ===========================================
+# PROMETHEUS METRICS
+# ===========================================
+
+# GET /metrics returns a Prometheus text-format exposition of request counts,
+# per-key token totals, and account routing/quota state. There is no setting to
+# turn it on: it authenticates with the same bearer API key /v1 uses, so it is
+# already closed to anyone without a key, and it reads existing state rather
+# than recording anything new.
+#
+# Dashboard cookie sessions are rejected: a scraper cannot hold a cookie, and
+# the control plane stays separate from the metrics plane.
+#
+#   curl -H "Authorization: Bearer $PROXY_API_KEY" http://127.0.0.1:8000/metrics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ they held are folded into this file; do not link to them.
 | Account failover / rotation | `kiro/account_manager.py` | Circuit breaker, global sticky, lazy init |
 | Credentials + host selection | `kiro/auth.py`, `kiro/config.py` | 4 sources; Builder ID routes to a different host |
 | Add an account by browser login | `kiro/device_login.py` | Social + Builder ID device flows |
-| Dashboard API / SQLite store | `kiro/dashboard.py` | 17 routes under `/api/dashboard`, plus `/` |
+| Dashboard API / SQLite store | `kiro/dashboard.py` | 18 routes under `/api/dashboard`, plus `/` and `/metrics` |
+| Prometheus exposition | `kiro/metrics.py` | Pure renderer; the route and its auth live in `dashboard.py` |
 | Per-key token accounting | `kiro/usage_tracking.py` | ContextVar identity, batched flush |
 | Token counting / encodings | `kiro/tokenizer.py` | Per-family encoding + CJK-only correction |
 | Model name handling | `kiro/model_resolver.py` | Never raises; unknown names pass through |
@@ -98,7 +99,9 @@ trusting a pin here.
   deepseek/qwen/minimax/glm. The correction is a property of the script, not the
   model — it scales by measured CJK ratio and is 1.0 for Latin text.
 - Control and data planes stay separate: dashboard cookie sessions cannot call
-  `/v1`, and `/v1` API keys cannot call `/api/dashboard`.
+  `/v1`, and `/v1` API keys cannot call `/api/dashboard`. `/metrics` is a third
+  plane: it takes a `/v1` bearer key (a scraper cannot hold a cookie) and refuses
+  dashboard sessions.
 - Dashboard SQLite stores metadata only — no prompts, completions, raw keys, or
   refresh tokens. New columns arrive via additive `PRAGMA table_info` +
   `ALTER TABLE` migration (`dashboard.py:96`, `:147`), never a destructive rewrite.
@@ -144,6 +147,11 @@ trusting a pin here.
 - Rejecting unknown model names. Kiro is the arbiter, not this gateway. The
   resolver also never suggests a model from another family
   (`model_resolver.py:405`).
+- Labelling a Prometheus series with a raw model name. The resolver forwards
+  unknown names to Kiro, so `model` is client-controlled: the live store holds 40
+  distinct names including probes like `claude-opus-99`. `kiro/metrics.py`
+  normalizes, then clamps to what the pool serves and collapses the rest into
+  `other`, re-aggregating in Python so no series is emitted twice.
 - Building the upstream host from region alone. A Builder ID account (SSO OIDC
   with no profile ARN) must go to `q.{region}.amazonaws.com`; everything else
   stays on the Kiro host (`kiro/config.py:613`). Absence of a profile alone is
@@ -183,6 +191,16 @@ multi-arch images on non-PR runs. Tool versions are pinned in
 
 ## NOTES
 
+- `/metrics` reads only what the gateway already stores (dashboard SQLite + live
+  pool), so a scrape cannot perturb routing or spend upstream quota. The homelab
+  does not scrape it directly: no job in `/opt/monitoring/prometheus.yml` carries
+  credentials, so a workstation timer fetches it with a bearer key and `PUT`s to
+  Pushgateway (`job=kiro-lb-usage`, `instance=ws`), which the existing
+  `pushgateway` job scrapes with `honor_labels: true`. `job` and `instance` are
+  therefore never set in the exposition itself. Units live in
+  `~/homelab/kiro-lb-probe/`.
+- `/metrics` is not recorded by the request-metrics middleware (`main.py:623`
+  filters to `/v1/`), so scraping does not inflate the counters it reports.
 - `main.py` refuses to start when `credentials.json` has no usable account, even
   with `ACCOUNT_SYSTEM=false`; set `KIRO_CLI_DB_FILE` for a standalone run.
   `validate_configuration` (`main.py:201`) skips legacy `.env` checks entirely

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -24,7 +24,10 @@ from fastapi.responses import FileResponse
 from kiro.account_manager import account_label, account_routing_state
 from kiro.accounts_admin import register_account
 from kiro.config import (
+    APP_VERSION,
     FALLBACK_MODELS,
+    HIDDEN_MODELS,
+    MODEL_ALIASES,
     RATE_OBSERVATION_RETENTION_DAYS,
     REQUEST_LOG_RETENTION_DAYS,
 )
@@ -36,6 +39,8 @@ from kiro.device_login import (
     start_device_login,
     write_builder_id_credentials,
 )
+from kiro.metrics import CONTENT_TYPE as METRICS_CONTENT_TYPE
+from kiro.metrics import render_metrics
 from kiro.usage import fetch_account_usage
 from kiro.usage_tracking import ROOT_KEY_ID, drain_pending_usage
 
@@ -718,6 +723,65 @@ async def dashboard_request_logs(request: Request, limit: int = 25, offset: int 
         "offset": offset,
         "hasMore": offset + len(rows) < total,
     }
+
+
+@router.get("/metrics", include_in_schema=False)
+async def metrics_endpoint(request: Request) -> Response:
+    """Prometheus exposition, authenticated with a data-plane API key.
+
+    This is a third plane: not a dashboard cookie session, and not a `/v1` chat
+    route. It authenticates with the same bearer key `/v1` uses because that is
+    the convention the homelab's other AI gateway already follows, and because a
+    scraper cannot hold a cookie. It is still read-only and must never be
+    reachable unauthenticated: the exposition carries account quota figures and
+    per-key token totals.
+
+    Nothing here is recorded for the scrape's benefit. The numbers come from the
+    dashboard's existing SQLite store and the live pool, so the endpoint cannot
+    perturb routing or spend upstream quota.
+    """
+    auth = request.headers.get("authorization", "")
+    token = auth.removeprefix("Bearer ") if auth.startswith("Bearer ") else ""
+    if not token or not verify_data_api_key(token):
+        # WWW-Authenticate keeps this a well-formed 401 for the scraper rather
+        # than an opaque refusal.
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing API Key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    manager = request.app.state.account_manager
+    # Flush first: token counters batch in memory, so an unflushed scrape would
+    # report totals that lag the traffic by up to one flush interval.
+    await asyncio.to_thread(flush_key_model_usage)
+    key_names = {ROOT_KEY_ID: "root"}
+    try:
+        key_names.update({key["id"]: key["name"] for key in list_data_api_keys()})
+    except Exception:
+        pass
+
+    # The allowlist that bounds the `model` label. Aliases and hidden models are
+    # included because they are genuinely served: `auto-kiro` is the alias every
+    # Cursor client uses, and leaving it out would file real traffic under
+    # `other`.
+    models = set(manager.get_all_available_models() or ())
+    if not models:
+        models = {item["modelId"] if isinstance(item, dict) else item for item in FALLBACK_MODELS}
+    models.update(MODEL_ALIASES)
+    models.update(HIDDEN_MODELS)
+    body = render_metrics(
+        started_at=request.app.state.started_at,
+        version=APP_VERSION,
+        accounts=list(manager._accounts.values()),
+        models=models,
+        connection_factory=_db,
+        usage_for=_cached_usage,
+        label_for=account_label,
+        state_for=account_routing_state,
+        key_names=key_names,
+    )
+    return Response(content=body, media_type=METRICS_CONTENT_TYPE)
 
 
 @router.get("/")

--- a/kiro/metrics.py
+++ b/kiro/metrics.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+"""Prometheus exposition for kiro-lb.
+
+Everything here is derived from state the gateway already keeps: the dashboard
+SQLite store (request logs, per-key token totals, cached account quota) and the
+live AccountManager pool. Nothing new is recorded to serve this endpoint, so
+scraping cannot change the gateway's behaviour.
+
+Three rules shape the output:
+
+- No secrets in labels. Account IDs are credential paths and API keys are
+  hashed, so both are exposed through the same short digest the dashboard shows
+  (`account_label`, the key's public id). Emails and subscription titles stay
+  out entirely.
+- Bounded cardinality. Labels are limited to model, protocol, status class,
+  routing state, and those opaque ids. Nothing derived from request content,
+  error text, or a timestamp becomes a label. The `model` label is especially
+  dangerous: the gateway passes unknown model names straight through to Kiro, so
+  it is client-controlled and a probing client would otherwise mint a new series
+  per name. Only models the pool actually serves are labelled; the rest collapse
+  into `other`.
+- `job` and `instance` are not set here. The homelab pushes this exposition
+  through Pushgateway, which owns those two labels (`honor_labels: true` on the
+  Prometheus side).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Iterable, Iterator
+
+from kiro.model_resolver import normalize_model_name
+
+CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+
+_ROUTE_PROTOCOL = {
+    "/v1/chat/completions": "openai",
+    "/v1/models": "openai",
+    "/v1/messages": "anthropic",
+    "/v1/messages/count_tokens": "anthropic",
+}
+
+# Counters are cumulative for the life of the store; gauges describe right now.
+# Declared here so the HELP/TYPE preamble stays next to the queries that fill it.
+_FAMILIES: tuple[tuple[str, str, str], ...] = (
+    ("kiro_lb_up", "gauge", "Always 1; scrape liveness for the gateway process."),
+    ("kiro_lb_uptime_seconds", "gauge", "Seconds since the gateway process started."),
+    ("kiro_lb_build_info", "gauge", "Gateway version, as a label on a constant 1."),
+    ("kiro_lb_requests_total", "counter", "Data-plane requests by model, protocol and status class."),
+    # A summary, not two counters: the wire names _sum/_count belong to a summary
+    # or histogram, and promtool rejects them on a plain counter. No quantiles
+    # are emitted, which is valid and keeps the series count flat.
+    ("kiro_lb_request_latency_seconds", "summary", "Latency of successful requests by model and protocol."),
+    ("kiro_lb_tokens_total", "counter", "Tokens attributed to an API key, by model and direction."),
+    ("kiro_lb_key_requests_total", "counter", "Requests attributed to an API key, by model."),
+    ("kiro_lb_accounts", "gauge", "Accounts in the pool by routing state."),
+    ("kiro_lb_account_requests_total", "counter", "Upstream requests per account by outcome."),
+    ("kiro_lb_account_failures", "gauge", "Consecutive failures feeding the circuit breaker, per account."),
+    ("kiro_lb_account_eligible_in_seconds", "gauge", "Seconds until an excluded account may serve traffic again."),
+    ("kiro_lb_account_quota_used", "gauge", "Credits consumed this period, per account."),
+    ("kiro_lb_account_quota_limit", "gauge", "Credit allowance for the period, per account."),
+    ("kiro_lb_account_quota_percent", "gauge", "Percentage of the credit allowance consumed, per account."),
+    ("kiro_lb_account_quota_reset_seconds", "gauge", "Seconds until the credit allowance resets, per account."),
+    ("kiro_lb_models", "gauge", "Models the pool can currently serve."),
+)
+
+# Every routing state account_routing_state can return. Emitted even at zero so
+# a state that empties out reads as 0 instead of the series disappearing, which
+# would otherwise make `sum by (state)` silently drop a category.
+_ROUTING_STATES = ("available", "uninitialized", "cooling_down", "rate_limited", "quota_exhausted", "suspended")
+
+
+def _escape(value: str) -> str:
+    """Escape a label value per the Prometheus text format."""
+    return value.replace("\\", r"\\").replace('"', r"\"").replace("\n", r"\n")
+
+
+def _line(name: str, labels: dict[str, str] | None, value: float) -> str:
+    if not labels:
+        return f"{name} {_number(value)}"
+    rendered = ",".join(f'{key}="{_escape(str(val))}"' for key, val in labels.items())
+    return f"{name}{{{rendered}}} {_number(value)}"
+
+
+def _number(value: float) -> str:
+    """Render a value without scientific notation or a pointless .0 tail."""
+    if isinstance(value, int) or float(value).is_integer():
+        return str(int(value))
+    return f"{value:.6f}".rstrip("0")
+
+
+def _status_class(status_code: int) -> str:
+    if status_code <= 0:
+        return "unknown"
+    return f"{status_code // 100}xx"
+
+
+def _protocol(route: str) -> str:
+    return _ROUTE_PROTOCOL.get(route, "other")
+
+
+def _model(value: str | None, known: frozenset[str]) -> str:
+    """Map a logged model name onto a bounded label.
+
+    A null model means the request never got far enough to resolve one. It is
+    still a real request, so it is counted under an explicit placeholder rather
+    than dropped or given an empty label.
+
+    The name is normalized first, because the log stores what the client sent:
+    `claude-sonnet-4-5` and `claude-sonnet-4.5` are the same model and must not
+    become two series (the live store holds 1,324 requests under the dash form
+    alone).
+
+    Anything the pool still does not serve becomes `other`. This matters because
+    the resolver deliberately forwards unknown names to Kiro (it is a gateway,
+    not a gatekeeper), which makes this label client-controlled: without the
+    clamp, a client looping over guesses like `claude-opus-99` would grow the
+    series set forever.
+    """
+    if not value:
+        return "unknown"
+    if value in known:
+        return value
+    normalized = normalize_model_name(value)
+    return normalized if normalized in known else "other"
+
+
+def _preamble() -> Iterator[str]:
+    for name, kind, help_text in _FAMILIES:
+        yield f"# HELP {name} {help_text}"
+        yield f"# TYPE {name} {kind}"
+
+
+def _request_metrics(conn: Any, known: frozenset[str]) -> Iterator[str]:
+    rows = conn.execute(
+        "SELECT route, model, status_code, COUNT(*) AS requests, COALESCE(SUM(latency_ms), 0) AS latency_ms"
+        " FROM request_logs GROUP BY route, model, status_code"
+    ).fetchall()
+    # Re-aggregated in Python rather than SQL: several raw model names collapse
+    # into the same label, and emitting one line per raw name would repeat a
+    # series, which Prometheus rejects as a duplicate.
+    counted: dict[tuple[str, str, str], int] = {}
+    for row in rows:
+        counted_key = (_model(row["model"], known), _protocol(row["route"]), _status_class(row["status_code"]))
+        counted[counted_key] = counted.get(counted_key, 0) + row["requests"]
+    for (model, protocol, status_class), requests in counted.items():
+        labels = {"model": model, "protocol": protocol, "status_class": status_class}
+        yield _line("kiro_lb_requests_total", labels, requests)
+
+    # Latency is summed separately: it has no status_class dimension, because a
+    # rejected request's latency says nothing about generation speed.
+    latency = conn.execute(
+        "SELECT route, model, COUNT(*) AS requests, COALESCE(SUM(latency_ms), 0) AS latency_ms"
+        " FROM request_logs WHERE status_code BETWEEN 200 AND 399 GROUP BY route, model"
+    ).fetchall()
+    timed: dict[tuple[str, str], tuple[int, int]] = {}
+    for row in latency:
+        timed_key = (_model(row["model"], known), _protocol(row["route"]))
+        previous = timed.get(timed_key, (0, 0))
+        timed[timed_key] = (previous[0] + row["latency_ms"], previous[1] + row["requests"])
+    for (model, protocol), (latency_ms, requests) in timed.items():
+        labels = {"model": model, "protocol": protocol}
+        yield _line("kiro_lb_request_latency_seconds_sum", labels, latency_ms / 1000.0)
+        yield _line("kiro_lb_request_latency_seconds_count", labels, requests)
+
+
+def _token_metrics(conn: Any, key_names: dict[str, str], known: frozenset[str]) -> Iterator[str]:
+    rows = conn.execute(
+        "SELECT key_id, model, prompt_tokens, completion_tokens, requests FROM key_model_usage"
+    ).fetchall()
+    totals: dict[tuple[str, str], tuple[int, int, int]] = {}
+    for row in rows:
+        usage_key = (row["key_id"], _model(row["model"], known))
+        previous_usage = totals.get(usage_key, (0, 0, 0))
+        totals[usage_key] = (
+            previous_usage[0] + row["prompt_tokens"],
+            previous_usage[1] + row["completion_tokens"],
+            previous_usage[2] + row["requests"],
+        )
+    for (key_id, model), (prompt, completion, requests) in totals.items():
+        labels = {"key_id": key_id, "key_name": key_names.get(key_id, key_id), "model": model}
+        yield _line("kiro_lb_tokens_total", {**labels, "direction": "input"}, prompt)
+        yield _line("kiro_lb_tokens_total", {**labels, "direction": "output"}, completion)
+        yield _line("kiro_lb_key_requests_total", labels, requests)
+
+
+def _account_metrics(accounts: Iterable[Any], usage_for: Any, label_for: Any, state_for: Any) -> Iterator[str]:
+    counts = dict.fromkeys(_ROUTING_STATES, 0)
+    lines: list[str] = []
+    for account in accounts:
+        state, eligible_in = state_for(account)
+        counts[state] = counts.get(state, 0) + 1
+        label = label_for(account.id)
+        labels = {"account": label}
+
+        lines.append(
+            _line("kiro_lb_account_requests_total", {**labels, "outcome": "success"}, account.stats.successful_requests)
+        )
+        lines.append(
+            _line("kiro_lb_account_requests_total", {**labels, "outcome": "failure"}, account.stats.failed_requests)
+        )
+        lines.append(_line("kiro_lb_account_failures", labels, account.failures))
+        lines.append(_line("kiro_lb_account_eligible_in_seconds", labels, eligible_in))
+
+        # Quota comes from the dashboard's cached getUsageLimits snapshot, so a
+        # scrape never triggers an upstream call. Email and subscription title
+        # are deliberately left out; only the numbers are exported.
+        usage = usage_for(account.id) or {}
+        for metric, field in (
+            ("kiro_lb_account_quota_used", "currentUsage"),
+            ("kiro_lb_account_quota_limit", "usageLimit"),
+            ("kiro_lb_account_quota_percent", "usagePercent"),
+        ):
+            value = usage.get(field)
+            if value is not None:
+                lines.append(_line(metric, labels, float(value)))
+        # Seconds, not the upstream's days: Prometheus convention is base units,
+        # and promtool fails a `_days` suffix outright.
+        reset_days = usage.get("daysUntilReset")
+        if reset_days is not None:
+            lines.append(_line("kiro_lb_account_quota_reset_seconds", labels, float(reset_days) * 86400))
+
+    for state in _ROUTING_STATES:
+        yield _line("kiro_lb_accounts", {"state": state}, counts.get(state, 0))
+    yield from lines
+
+
+def render_metrics(
+    *,
+    started_at: float,
+    version: str,
+    accounts: Iterable[Any],
+    models: Iterable[str],
+    connection_factory: Any,
+    usage_for: Any,
+    label_for: Any,
+    state_for: Any,
+    key_names: dict[str, str],
+) -> str:
+    """Build the full exposition. Dependencies are injected to keep this pure.
+
+    `models` is both the value of kiro_lb_models and the allowlist that bounds
+    the `model` label, so an unknown name a client invented cannot become a new
+    series.
+
+    A failure in any one section must not cost the whole scrape, so the SQLite
+    sections degrade to absent series rather than a 500: a gateway that is
+    serving traffic should still report `kiro_lb_up` even if its metadata store
+    is momentarily locked.
+    """
+    known = frozenset(models)
+    lines: list[str] = list(_preamble())
+    lines.append(_line("kiro_lb_up", None, 1))
+    lines.append(_line("kiro_lb_uptime_seconds", None, int(time.time() - started_at)))
+    lines.append(_line("kiro_lb_build_info", {"version": version}, 1))
+    lines.append(_line("kiro_lb_models", None, len(known)))
+
+    try:
+        with connection_factory() as conn:
+            lines.extend(_request_metrics(conn, known))
+            lines.extend(_token_metrics(conn, key_names, known))
+    except Exception:
+        pass
+
+    try:
+        lines.extend(_account_metrics(accounts, usage_for, label_for, state_for))
+    except Exception:
+        pass
+
+    return "\n".join(lines) + "\n"

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,525 @@
+"""Prometheus exposition contract.
+
+The exporter reads state the gateway already keeps, so the tests that matter are
+about what reaches the wire: valid text format, no secrets in labels, bounded
+cardinality, and an authenticated endpoint. A scrape must also never be able to
+break the data plane, which is why the SQLite sections degrade instead of
+raising.
+"""
+
+import importlib
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro.account_manager import Account, account_label, account_routing_state
+from kiro.metrics import _FAMILIES, CONTENT_TYPE, render_metrics
+
+_ACCOUNT_PATH = "/data/logins/builder-id-7Oay0539aYPtzTFS.json"
+_KEY_ID = "6f1c2d3e4a5b"
+
+
+@pytest.fixture
+def dashboard(tmp_path, monkeypatch):
+    monkeypatch.setenv("DASHBOARD_DATA_DIR", str(tmp_path))
+    module = importlib.reload(importlib.import_module("kiro.dashboard"))
+    module.initialize_dashboard_store()
+    return module
+
+
+def _account(account_id: str = _ACCOUNT_PATH, **state) -> Account:
+    account = Account(id=account_id)
+    account.auth_manager = MagicMock()
+    account.stats.total_requests = 10
+    account.stats.successful_requests = 7
+    account.stats.failed_requests = 3
+    for key, value in state.items():
+        setattr(account, key, value)
+    return account
+
+
+def _render(dashboard, accounts=(), key_names=None, models=("claude-opus-5", "m", "claude-haiku-4.5")) -> str:
+    return render_metrics(
+        started_at=time.time() - 120,
+        version="0.1.0",
+        accounts=list(accounts),
+        models=models,
+        connection_factory=dashboard._db,
+        usage_for=dashboard._cached_usage,
+        label_for=account_label,
+        state_for=account_routing_state,
+        key_names=key_names or {},
+    )
+
+
+def _series(body: str) -> dict[str, float]:
+    """Parse the exposition into {series_line_without_value: value}."""
+    parsed = {}
+    for line in body.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name, _, value = line.rpartition(" ")
+        parsed[name] = float(value)
+    return parsed
+
+
+class TestTextFormat:
+    def test_every_family_declares_help_and_type(self, dashboard):
+        dashboard.record_request("/v1/messages", "claude-opus-5", 200, 10)
+        body = _render(dashboard)
+
+        helps = {line.split()[2] for line in body.splitlines() if line.startswith("# HELP")}
+        types = {line.split()[2] for line in body.splitlines() if line.startswith("# TYPE")}
+        assert helps == types
+        # Every emitted series must belong to a declared family. A summary's
+        # _sum/_count children are part of its family, not families of their own.
+        for series in _series(body):
+            family = series.split("{")[0]
+            base = family.removesuffix("_sum").removesuffix("_count")
+            assert family in helps or base in helps, family
+
+    def test_body_ends_with_a_newline(self, dashboard):
+        # Pushgateway rejects a body whose final line is unterminated.
+        assert _render(dashboard).endswith("\n")
+
+    def test_names_satisfy_promtool_lint_rules(self, dashboard):
+        """`promtool check metrics` is the gate here; these are the rules it applies.
+
+        It rejected an earlier version for exposing latency as two counters named
+        `_sum`/`_count` and for a `_days` suffix, so the constraints are asserted
+        rather than left to a manual run.
+        """
+        declared = [(name, kind) for name, kind, _ in _FAMILIES]
+
+        for name, kind in declared:
+            if kind == "counter":
+                assert name.endswith("_total"), name
+                assert not name.endswith(("_sum", "_count")), name
+            # Base units only: no _days, _ms, _millis.
+            assert not name.endswith(("_days", "_ms", "_millis")), name
+
+        # _sum/_count may only appear as children of a summary or histogram.
+        summaries = {name for name, kind in declared if kind in ("summary", "histogram")}
+        dashboard.record_request("/v1/messages", "claude-opus-5", 200, 10)
+        for series in _series(_render(dashboard)):
+            family = series.split("{")[0]
+            if family.endswith(("_sum", "_count")):
+                base = family.removesuffix("_sum").removesuffix("_count")
+                assert base in summaries, family
+
+    def test_no_scientific_notation_in_values(self, dashboard):
+        with dashboard._db() as conn:
+            conn.execute(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+                " VALUES (?,?,?,?,?,?)",
+                (_KEY_ID, "claude-opus-5", 965355905, 524436, 4468, int(time.time())),
+            )
+
+        body = _render(dashboard)
+
+        # Only the value matters here; a label like "claude-opus-5" legitimately
+        # contains "e-". Prometheus accepts exponents, but a nine-digit token
+        # count rendered as 9.65355905e+08 is unreadable in an alert.
+        for line in body.splitlines():
+            if line and not line.startswith("#"):
+                raw_value = line.rpartition(" ")[2]
+                assert "e" not in raw_value.lower()
+        assert (
+            'kiro_lb_tokens_total{key_id="6f1c2d3e4a5b",key_name="6f1c2d3e4a5b",model="claude-opus-5",direction="input"} 965355905'
+            in body
+        )
+
+    def test_up_and_uptime_are_always_present(self, dashboard):
+        series = _series(_render(dashboard))
+
+        assert series["kiro_lb_up"] == 1
+        assert series["kiro_lb_uptime_seconds"] == pytest.approx(120, abs=2)
+        assert series['kiro_lb_build_info{version="0.1.0"}'] == 1
+
+    def test_label_values_are_escaped(self, dashboard):
+        """Key names are operator-provided free text, so they must be escaped.
+
+        A name containing a quote would otherwise close the label early and
+        corrupt every following series in the scrape.
+        """
+        with dashboard._db() as conn:
+            conn.execute(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+                " VALUES (?,?,?,?,?,?)",
+                (_KEY_ID, "m", 1, 2, 1, int(time.time())),
+            )
+
+        body = _render(dashboard, key_names={_KEY_ID: 'wei"rd\\name'})
+
+        assert r'key_name="wei\"rd\\name"' in body
+
+
+class TestRequestMetrics:
+    def test_requests_are_grouped_by_model_protocol_and_status_class(self, dashboard):
+        dashboard.record_request("/v1/chat/completions", "claude-opus-5", 200, 1200)
+        dashboard.record_request("/v1/chat/completions", "claude-opus-5", 200, 800)
+        dashboard.record_request("/v1/messages", "claude-opus-5", 429, 30)
+
+        series = _series(_render(dashboard))
+
+        assert series['kiro_lb_requests_total{model="claude-opus-5",protocol="openai",status_class="2xx"}'] == 2
+        assert series['kiro_lb_requests_total{model="claude-opus-5",protocol="anthropic",status_class="4xx"}'] == 1
+
+    def test_latency_is_seconds_and_counts_only_successes(self, dashboard):
+        dashboard.record_request("/v1/chat/completions", "m", 200, 1500)
+        dashboard.record_request("/v1/chat/completions", "m", 200, 500)
+        dashboard.record_request("/v1/chat/completions", "m", 500, 90000)
+
+        series = _series(_render(dashboard))
+        labels = '{model="m",protocol="openai"}'
+
+        # A failed request's latency says nothing about generation speed, so the
+        # 90s rejection must not pollute the average.
+        assert series[f"kiro_lb_request_latency_seconds_sum{labels}"] == 2.0
+        assert series[f"kiro_lb_request_latency_seconds_count{labels}"] == 2
+
+    def test_a_request_with_no_model_is_still_counted(self, dashboard):
+        dashboard.record_request("/v1/chat/completions", None, 422, 3)
+
+        series = _series(_render(dashboard))
+
+        assert series['kiro_lb_requests_total{model="unknown",protocol="openai",status_class="4xx"}'] == 1
+
+    def test_an_unknown_route_gets_a_bounded_protocol_label(self, dashboard):
+        # The label must never be the raw path: that would be unbounded.
+        dashboard.record_request("/some/other/path", "m", 200, 5)
+
+        body = _render(dashboard)
+
+        assert 'protocol="other"' in body
+        assert "/some/other/path" not in body
+
+
+class TestModelLabelCardinality:
+    """The model name is client-controlled, so it cannot be labelled verbatim.
+
+    The resolver forwards unknown names to Kiro on purpose (gateway, not
+    gatekeeper), and the live store already holds 40 distinct names including
+    probes like `claude-opus-99`. Labelling those raw would let any client mint
+    series in Prometheus indefinitely.
+    """
+
+    def test_a_model_the_pool_serves_is_labelled_verbatim(self, dashboard):
+        dashboard.record_request("/v1/messages", "claude-opus-5", 200, 10)
+
+        series = _series(_render(dashboard))
+
+        assert series['kiro_lb_requests_total{model="claude-opus-5",protocol="anthropic",status_class="2xx"}'] == 1
+
+    def test_an_invented_model_collapses_into_other(self, dashboard):
+        dashboard.record_request("/v1/messages", "claude-opus-99", 400, 3)
+
+        body = _render(dashboard)
+
+        assert "claude-opus-99" not in body
+        assert _series(body)['kiro_lb_requests_total{model="other",protocol="anthropic",status_class="4xx"}'] == 1
+
+    def test_many_invented_names_produce_exactly_one_series(self, dashboard):
+        for index in range(50):
+            dashboard.record_request("/v1/chat/completions", f"made-up-{index}", 400, 1)
+
+        series = _series(_render(dashboard))
+        matching = [name for name in series if name.startswith("kiro_lb_requests_total")]
+
+        # One series, carrying all 50 requests: this is the whole point.
+        assert matching == ['kiro_lb_requests_total{model="other",protocol="openai",status_class="4xx"}']
+        assert series[matching[0]] == 50
+
+    def test_collapsed_latency_is_summed_not_duplicated(self, dashboard):
+        # Two distinct unknown names both map to `other`; emitting a line each
+        # would repeat a series, which Prometheus rejects as a duplicate.
+        dashboard.record_request("/v1/chat/completions", "nope-a", 200, 1000)
+        dashboard.record_request("/v1/chat/completions", "nope-b", 200, 2000)
+
+        body = _render(dashboard)
+        emitted = [line for line in body.splitlines() if line.startswith("kiro_lb_request_latency_seconds_sum")]
+
+        assert len(emitted) == 1
+        assert _series(body)['kiro_lb_request_latency_seconds_sum{model="other",protocol="openai"}'] == 3.0
+
+    def test_no_series_is_emitted_twice(self, dashboard):
+        for name in ("claude-opus-5", "m", "unknown-1", "unknown-2", None):
+            dashboard.record_request("/v1/chat/completions", name, 200, 10)
+            dashboard.record_request("/v1/messages", name, 500, 10)
+        with dashboard._db() as conn:
+            conn.executemany(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+                " VALUES (?,?,?,?,?,?)",
+                [(_KEY_ID, f"invented-{index}", 5, 5, 1, int(time.time())) for index in range(4)],
+            )
+
+        emitted = [line.rpartition(" ")[0] for line in _render(dashboard).splitlines() if not line.startswith("#")]
+
+        assert len(emitted) == len(set(emitted))
+
+    def test_collapsed_token_totals_are_summed(self, dashboard):
+        with dashboard._db() as conn:
+            conn.executemany(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+                " VALUES (?,?,?,?,?,?)",
+                [
+                    (_KEY_ID, "invented-a", 100, 10, 1, int(time.time())),
+                    (_KEY_ID, "invented-b", 200, 20, 2, int(time.time())),
+                ],
+            )
+
+        series = _series(_render(dashboard))
+        labels = f'key_id="{_KEY_ID}",key_name="{_KEY_ID}",model="other"'
+
+        assert series[f'kiro_lb_tokens_total{{{labels},direction="input"}}'] == 300
+        assert series[f'kiro_lb_tokens_total{{{labels},direction="output"}}'] == 30
+        assert series[f"kiro_lb_key_requests_total{{{labels}}}"] == 3
+
+    def test_a_client_dash_form_merges_into_the_dotted_model(self, dashboard):
+        """The log stores what the client sent, which is often the dash form.
+
+        `claude-sonnet-4-5` and `claude-sonnet-4.5` are one model; splitting them
+        would both double the series and understate each. The live store holds
+        1,324 requests under the dash form alone.
+        """
+        dashboard.record_request("/v1/messages", "claude-sonnet-4-5", 200, 100)
+        dashboard.record_request("/v1/messages", "claude-sonnet-4.5", 200, 100)
+
+        series = _series(_render(dashboard, models=("claude-sonnet-4.5",)))
+
+        assert series['kiro_lb_requests_total{model="claude-sonnet-4.5",protocol="anthropic",status_class="2xx"}'] == 2
+        assert 'kiro_lb_requests_total{model="other",protocol="anthropic",status_class="2xx"}' not in series
+
+    def test_a_dated_client_name_merges_too(self, dashboard):
+        dashboard.record_request("/v1/messages", "claude-sonnet-4-5-20251001", 200, 10)
+
+        series = _series(_render(dashboard, models=("claude-sonnet-4.5",)))
+
+        assert series['kiro_lb_requests_total{model="claude-sonnet-4.5",protocol="anthropic",status_class="2xx"}'] == 1
+
+    def test_models_gauge_counts_what_the_pool_serves(self, dashboard):
+        series = _series(_render(dashboard, models=("a", "b", "c", "d")))
+
+        assert series["kiro_lb_models"] == 4
+
+
+class TestAccountMetrics:
+    def test_account_label_is_a_digest_not_a_credential_path(self, dashboard):
+        body = _render(dashboard, accounts=[_account()])
+
+        assert _ACCOUNT_PATH not in body
+        assert "builder-id-7Oay0539aYPtzTFS" not in body
+        assert f'kiro_lb_account_failures{{account="{account_label(_ACCOUNT_PATH)}"}}' in _series(body)
+
+    def test_every_routing_state_is_emitted_even_at_zero(self, dashboard):
+        series = _series(_render(dashboard, accounts=[_account()]))
+
+        # A state that empties out must read 0 rather than vanish, or
+        # `sum by (state)` silently drops the category.
+        assert series['kiro_lb_accounts{state="available"}'] == 1
+        assert series['kiro_lb_accounts{state="suspended"}'] == 0
+        assert series['kiro_lb_accounts{state="quota_exhausted"}'] == 0
+
+    def test_a_suspended_account_reports_its_state_and_countdown(self, dashboard):
+        suspended = _account(suspended_until=time.time() + 3600)
+
+        series = _series(_render(dashboard, accounts=[suspended]))
+
+        assert series['kiro_lb_accounts{state="suspended"}'] == 1
+        assert series['kiro_lb_accounts{state="available"}'] == 0
+        label = account_label(_ACCOUNT_PATH)
+        assert series[f'kiro_lb_account_eligible_in_seconds{{account="{label}"}}'] == pytest.approx(3600, abs=5)
+
+    def test_account_request_outcomes_are_split(self, dashboard):
+        series = _series(_render(dashboard, accounts=[_account()]))
+        label = account_label(_ACCOUNT_PATH)
+
+        assert series[f'kiro_lb_account_requests_total{{account="{label}",outcome="success"}}'] == 7
+        assert series[f'kiro_lb_account_requests_total{{account="{label}",outcome="failure"}}'] == 3
+
+    def test_quota_numbers_come_from_the_cache_without_an_upstream_call(self, dashboard):
+        usage = {
+            "email": "operator@example.test",
+            "subscriptionTitle": "KIRO PRO",
+            "subscriptionType": "PAID",
+            "resourceType": "CREDIT",
+            "currentUsage": 12.5,
+            "usageLimit": 50.0,
+            "usagePercent": 25.0,
+            "unit": "INVOCATIONS",
+            "nextDateReset": 1788220800.0,
+            "daysUntilReset": 3,
+            "overageStatus": "DISABLED",
+            "overageUsed": 0.0,
+            "overageRate": None,
+        }
+        account = _account()
+        with patch.object(dashboard, "fetch_account_usage", AsyncMock(return_value=usage)):
+            import asyncio
+
+            asyncio.run(dashboard.refresh_account_usage(account))
+
+        body = _render(dashboard, accounts=[account])
+        series = _series(body)
+        label = account_label(_ACCOUNT_PATH)
+
+        assert series[f'kiro_lb_account_quota_used{{account="{label}"}}'] == 12.5
+        assert series[f'kiro_lb_account_quota_limit{{account="{label}"}}'] == 50.0
+        assert series[f'kiro_lb_account_quota_percent{{account="{label}"}}'] == 25.0
+        # Seconds, not days: Prometheus wants base units and promtool rejects a
+        # _days suffix.
+        assert series[f'kiro_lb_account_quota_reset_seconds{{account="{label}"}}'] == 3 * 86400
+        # The identity behind the quota must not travel with it.
+        assert "operator@example.test" not in body
+        assert "KIRO PRO" not in body
+
+    def test_an_account_with_no_cached_quota_omits_those_series(self, dashboard):
+        series = _series(_render(dashboard, accounts=[_account()]))
+        label = account_label(_ACCOUNT_PATH)
+
+        # Absent is correct here: 0 would read as "no quota left".
+        assert f'kiro_lb_account_quota_used{{account="{label}"}}' not in series
+
+
+class TestTokenMetrics:
+    def test_tokens_are_split_by_direction_and_named_key(self, dashboard):
+        with dashboard._db() as conn:
+            conn.execute(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+                " VALUES (?,?,?,?,?,?)",
+                ("root", "claude-opus-5", 1000, 250, 5, int(time.time())),
+            )
+
+        series = _series(_render(dashboard, key_names={"root": "root"}))
+        labels = 'key_id="root",key_name="root",model="claude-opus-5"'
+
+        assert series[f'kiro_lb_tokens_total{{{labels},direction="input"}}'] == 1000
+        assert series[f'kiro_lb_tokens_total{{{labels},direction="output"}}'] == 250
+        assert series[f"kiro_lb_key_requests_total{{{labels}}}"] == 5
+
+    def test_an_unnamed_key_falls_back_to_its_id(self, dashboard):
+        with dashboard._db() as conn:
+            conn.execute(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+                " VALUES (?,?,?,?,?,?)",
+                (_KEY_ID, "m", 1, 2, 1, int(time.time())),
+            )
+
+        body = _render(dashboard)
+
+        assert f'key_id="{_KEY_ID}",key_name="{_KEY_ID}"' in body
+
+
+class TestResilience:
+    def test_a_broken_store_still_reports_liveness(self, dashboard):
+        def explode():
+            raise RuntimeError("database is locked")
+
+        body = render_metrics(
+            started_at=time.time(),
+            version="0.1.0",
+            accounts=[],
+            models=(),
+            connection_factory=explode,
+            usage_for=lambda _: None,
+            label_for=account_label,
+            state_for=account_routing_state,
+            key_names={},
+        )
+
+        # A gateway that is serving traffic must not report itself down just
+        # because its metadata store is momentarily unavailable.
+        assert _series(body)["kiro_lb_up"] == 1
+
+    def test_a_broken_account_does_not_lose_the_request_metrics(self, dashboard):
+        dashboard.record_request("/v1/messages", "m", 200, 10)
+        broken = SimpleNamespace(id="/creds/x.json")  # no .stats, so state_for raises
+
+        series = _series(_render(dashboard, accounts=[broken]))
+
+        assert series['kiro_lb_requests_total{model="m",protocol="anthropic",status_class="2xx"}'] == 1
+
+
+class TestEndpoint:
+    @staticmethod
+    def _client(dashboard, monkeypatch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setenv("PROXY_API_KEY", "test-root-key")
+        app = FastAPI()
+        app.include_router(dashboard.router)
+        app.state.started_at = time.time()
+        app.state.account_manager = SimpleNamespace(
+            _accounts={_ACCOUNT_PATH: _account()},
+            get_all_available_models=lambda: ["claude-opus-5"],
+        )
+        return TestClient(app)
+
+    def test_a_valid_data_plane_key_is_accepted(self, dashboard, monkeypatch):
+        client = self._client(dashboard, monkeypatch)
+
+        response = client.get("/metrics", headers={"Authorization": "Bearer test-root-key"})
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/plain")
+        assert CONTENT_TYPE.startswith("text/plain; version=0.0.4")
+        assert "kiro_lb_up 1" in response.text
+
+    def test_an_unauthenticated_scrape_is_refused(self, dashboard, monkeypatch):
+        client = self._client(dashboard, monkeypatch)
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 401
+        assert response.headers["www-authenticate"] == "Bearer"
+
+    def test_a_wrong_key_is_refused(self, dashboard, monkeypatch):
+        client = self._client(dashboard, monkeypatch)
+
+        response = client.get("/metrics", headers={"Authorization": "Bearer nope"})
+
+        assert response.status_code == 401
+
+    def test_a_dashboard_cookie_cannot_scrape(self, dashboard, monkeypatch):
+        """Control-plane sessions stay out of the metrics plane."""
+        client = self._client(dashboard, monkeypatch)
+        token = "session-token"
+        dashboard._sessions[token] = time.time() + 3600
+        client.cookies.set(dashboard._COOKIE, token)
+
+        response = client.get("/metrics")
+
+        assert response.status_code == 401
+
+    def test_the_exposition_never_carries_the_key_that_fetched_it(self, dashboard, monkeypatch):
+        client = self._client(dashboard, monkeypatch)
+
+        response = client.get("/metrics", headers={"Authorization": "Bearer test-root-key"})
+
+        assert "test-root-key" not in response.text
+
+    def test_an_alias_the_pool_serves_is_not_filed_under_other(self, dashboard, monkeypatch):
+        """`auto-kiro` is the alias Cursor clients use, so it is real traffic.
+
+        get_all_available_models() reports it only once an account has
+        initialized, so the endpoint has to add MODEL_ALIASES itself or genuine
+        requests land in `other`.
+        """
+        dashboard.record_request("/v1/chat/completions", "auto-kiro", 200, 10)
+        client = self._client(dashboard, monkeypatch)
+
+        response = client.get("/metrics", headers={"Authorization": "Bearer test-root-key"})
+
+        assert 'model="auto-kiro"' in response.text
+
+    def test_the_model_gauge_survives_an_uninitialized_pool(self, dashboard, monkeypatch):
+        """With no initialized account the gateway still serves the fallback list."""
+        client = self._client(dashboard, monkeypatch)
+        client.app.state.account_manager.get_all_available_models = lambda: []
+
+        response = client.get("/metrics", headers={"Authorization": "Bearer test-root-key"})
+
+        assert _series(response.text)["kiro_lb_models"] > 0


### PR DESCRIPTION
## Summary

`GET /metrics` returns a Prometheus text-format exposition covering request counts and latency, per-key token totals, and account routing/quota state. `kiro/metrics.py` is a pure renderer; the route and its auth live in `dashboard.py`.

Everything comes from state the gateway already keeps (dashboard SQLite + the live pool). Nothing new is recorded to serve a scrape, so it cannot perturb routing or spend upstream quota. The request-metrics middleware filters to `/v1/`, so scraping does not inflate the counters it reports.

## Auth

A `/v1` bearer key — the same keys the chat routes accept. This is a third plane next to the dashboard cookie session and the data plane: a scraper cannot hold a cookie, and the exposition carries account quota figures and per-key token totals, so leaving it open was not an option. Dashboard cookie sessions are refused, and there is no flag to disable the endpoint because it is already closed to anyone without a key.

## The model label needed clamping

The resolver forwards unknown model names to Kiro on purpose (gateway, not gatekeeper), which makes `model` client-controlled. The live store already held 40 distinct names, including probes like `claude-opus-99` and `claude-does-not-exist-9`. Labelled raw, any client looping over guesses would mint Prometheus series indefinitely.

- Names are normalized first: the log stores what the client sent, and `claude-sonnet-4-5` alone accounted for 1,324 requests that would otherwise have split from `claude-sonnet-4.5`
- Then clamped to what the pool serves, including `MODEL_ALIASES` and `HIDDEN_MODELS` (`auto-kiro` is real traffic); the remainder collapses into `other`
- Aggregation moved from SQL to Python, because a collapse would otherwise emit the same series twice, which Prometheus rejects

Live result: 21 distinct model labels, 240 series, zero duplicates.

## Homelab wiring

Not committed here (it lives in `~/homelab/kiro-lb-probe/`), but for context: no job in `prometheus.yml` carries credentials, so the authenticated fetch happens in a workstation timer that `PUT`s to Pushgateway as `job=kiro-lb-usage`, `instance=ws`, matching the existing freerouter convention. `job` and `instance` are deliberately absent from the exposition.

## Testing

- `pytest -q` — 1804 passed (36 new in `tests/unit/test_metrics.py`)
- `ruff format --check .`, `ruff check .`, `mypy` — clean
- `promtool check metrics` against the live exposition — exit 0. It rejected the first cut for exposing latency as two counters named `_sum`/`_count` and for a `_days` unit suffix; latency is now a summary and quota reset is in seconds. A test asserts those naming rules so it cannot regress silently
- Live checks: 401 unauthenticated, 200 with a key, and grepped the output for the API key, `klb_` prefixes, emails, credential paths, `builder-id`, refresh tokens and subscription titles — all absent
- Confirmed the series reach Prometheus through Pushgateway (`kiro_lb_accounts{state="suspended"} 1` matches the known locked account)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Prometheus endpoint at GET `/metrics` to expose request counts/latency, per-key token totals, and account routing/quota without recording new data. The endpoint authenticates with a `/v1` bearer key and rejects dashboard cookie sessions.

- **New Features**
  - Adds GET `/metrics` in `kiro/dashboard.py` (rendered by `kiro/metrics.py`) returning Prometheus text format.
  - Metrics: requests by model/protocol/status, latency summary (2xx/3xx), per-key tokens and requests, account routing/quota, and a models gauge.
  - Auth: requires `/v1` bearer key; cookies refused; 401 with `WWW-Authenticate`.
  - Bounded labels: model names normalized and clamped to served models (includes `MODEL_ALIASES`, `HIDDEN_MODELS`), others collapse to `other`; aggregation done in Python to avoid duplicate series.
  - Safe/clean output: scraping doesn’t increment counters; no secrets in labels; base units; passes `promtool` naming rules; no `job`/`instance` labels.

<sup>Written for commit dead453a7f1eb94b4db883badfbf7f0277361637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

