### PR TITLE
Track the Grafana dashboard and Pushgateway units in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 credentials.json
 state.json
 
+# Metrics export credentials; only the .example is tracked.
+deploy/pushgateway/kiro-lb.env
+
 # IDE
 .vscode/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@ kiro-lb-python/
 ├── kiro/                    # Gateway package: 39 modules, 16.5k lines
 │   └── static/              # BUILD OUTPUT of frontend/ — never hand-edit
 ├── frontend/                # Bun + Vite + React 19 dashboard source
-├── tests/                   # pytest, 1768 tests; network-blocked by conftest
+├── tests/                   # pytest, 1822 tests; network-blocked by conftest
 ├── data/                    # Runtime credentials/state/sqlite (gitignored)
+├── deploy/                  # Grafana dashboard + Pushgateway units for /metrics
 ├── debug_logs/              # Capture output when DEBUG_MODE is on (gitignored)
 ├── pyproject.toml           # ruff + mypy config only; the project is not packaged
 ├── docker-compose.yml       # Upstream-style deployment (service kiro-gateway)
@@ -47,6 +48,7 @@ they held are folded into this file; do not link to them.
 | Add an account by browser login | `kiro/device_login.py` | Social + Builder ID device flows |
 | Dashboard API / SQLite store | `kiro/dashboard.py` | 18 routes under `/api/dashboard`, plus `/` and `/metrics` |
 | Prometheus exposition | `kiro/metrics.py` | Pure renderer; the route and its auth live in `dashboard.py` |
+| Grafana dashboard / metrics wiring | `deploy/` | Dashboard JSON is asserted against the exporter by `tests/unit/test_dashboard_provisioning.py` |
 | Per-key token accounting | `kiro/usage_tracking.py` | ContextVar identity, batched flush |
 | Token counting / encodings | `kiro/tokenizer.py` | Per-family encoding + CJK-only correction |
 | Model name handling | `kiro/model_resolver.py` | Never raises; unknown names pass through |
@@ -170,7 +172,7 @@ trusting a pin here.
 
 ```bash
 python main.py --host 127.0.0.1 --port 8000    # run gateway
-pytest -q                                      # full suite (1768 tests, ~6s, no network)
+pytest -q                                      # full suite (1822 tests, ~6s, no network)
 pytest -v --tb=short                           # exactly what CI's test job runs
 pytest --cov=kiro --cov-report=term            # CI coverage step
 ruff format --check --diff . && ruff check .   # CI quality job, python half
@@ -197,8 +199,19 @@ multi-arch images on non-PR runs. Tool versions are pinned in
   credentials, so a workstation timer fetches it with a bearer key and `PUT`s to
   Pushgateway (`job=kiro-lb-usage`, `instance=ws`), which the existing
   `pushgateway` job scrapes with `honor_labels: true`. `job` and `instance` are
-  therefore never set in the exposition itself. Units live in
-  `~/homelab/kiro-lb-probe/`.
+  therefore never set in the exposition itself. The tracked copies of those
+  units, and the Grafana dashboard, live in `deploy/`; the deployed units are
+  symlinked from `~/homelab/kiro-lb-probe/`.
+- The Grafana dashboard is checked in (`deploy/grafana/kiro-lb.json`, uid
+  `kiro-lb`) so a metric rename cannot silently empty a panel:
+  `tests/unit/test_dashboard_provisioning.py` asserts every metric and label it
+  queries against `_FAMILIES`, and pins the two constraints that are invisible in
+  the UI — rate windows must span several 30s pushes, and latency is a summary
+  without quantiles so no p95 panel may claim otherwise. Edit the JSON in the
+  repo and copy it out, never only on the monitoring host.
+- Grafana on `apps` serves 12 unrelated dashboards, so install with the
+  provisioning reload API (`POST /api/admin/provisioning/dashboards/reload`)
+  rather than restarting the container.
 - `/metrics` is not recorded by the request-metrics middleware (`main.py:623`
   filters to `/v1/`), so scraping does not inflate the counters it reports.
 - `main.py` refuses to start when `credentials.json` has no usable account, even

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,108 @@
+# Observability deployment assets
+
+Wiring for `GET /metrics` (`kiro/metrics.py`). These files describe this
+operator's homelab and carry its private addresses; treat them as a worked
+example rather than a drop-in.
+
+## Why the metrics are pushed, not scraped
+
+`/metrics` requires a `/v1` bearer key, and no job in the homelab's
+`prometheus.yml` carries credentials. Rather than make authenticated pull the
+first such job, a workstation timer does the authenticated fetch and republishes
+to Pushgateway, which Prometheus already scrapes with `honor_labels: true`:
+
+```
+kiro-lb GET /metrics          (Authorization: Bearer <key>)
+   |  every 30s, systemd timer
+   v
+PUT http://pushgateway:9091/metrics/job/kiro-lb-usage/instance/ws
+   |
+   v
+Prometheus job_name=pushgateway, honor_labels=true
+   -> series carry job="kiro-lb-usage", instance="ws"
+```
+
+`job` and `instance` are therefore absent from the exposition itself:
+Pushgateway owns them. `PUT` (not `POST`) replaces the whole grouping each run,
+so a model or account that disappears does not leave a stale series behind.
+
+The same layout backs `freerouter-usage-export.*`; keeping both identical means
+one convention to reason about.
+
+## Files
+
+| Path | Goes to |
+|---|---|
+| `pushgateway/export_usage.sh` | anywhere the timer can reach both hosts |
+| `pushgateway/kiro-lb-usage-export.service` | `~/.config/systemd/user/` (symlink) |
+| `pushgateway/kiro-lb-usage-export.timer` | `~/.config/systemd/user/` (symlink) |
+| `pushgateway/kiro-lb.env.example` | copy to `kiro-lb.env`, `chmod 600` |
+| `grafana/kiro-lb.json` | `/opt/monitoring/grafana/dashboards/kiro-lb/` |
+
+## Installing the exporter timer
+
+```bash
+cp deploy/pushgateway/* ~/homelab/kiro-lb-probe/
+cd ~/homelab/kiro-lb-probe
+cp kiro-lb.env.example kiro-lb.env && chmod 600 kiro-lb.env   # then edit
+systemctl --user link  ~/homelab/kiro-lb-probe/kiro-lb-usage-export.service
+systemctl --user link  ~/homelab/kiro-lb-probe/kiro-lb-usage-export.timer
+systemctl --user daemon-reload
+systemctl --user enable --now kiro-lb-usage-export.timer
+```
+
+`EnvironmentFile` in the unit points at an absolute path, so adjust it if the
+directory differs.
+
+## Installing the dashboard
+
+The Grafana container mounts `/opt/monitoring/grafana/dashboards` and its
+provisioning directory, so the dashboard is a file, not an API import. Add a
+provider once:
+
+```yaml
+# /opt/monitoring/grafana/provisioning/dashboards/dashboards.yml
+  - name: kiro-lb
+    orgId: 1
+    folder: kiro-lb
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards/kiro-lb
+```
+
+Then place the JSON and reload. The reload API avoids restarting Grafana, which
+matters because the same instance serves unrelated dashboards:
+
+```bash
+scp deploy/grafana/kiro-lb.json \
+    apps:/opt/monitoring/grafana/dashboards/kiro-lb/kiro-lb.json
+curl -X POST -u admin:admin \
+    http://10.10.10.3:3000/api/admin/provisioning/dashboards/reload
+```
+
+Lands at `/d/kiro-lb/kiro-lb-gateway`.
+
+## Two things the dashboard encodes
+
+**Rate windows are 5m, not `$__rate_interval`.** Pushgateway republishes every
+30s, so a shorter window can fall entirely inside one push and read as zero.
+
+**Latency is a mean, not a quantile.** `kiro_lb_request_latency_seconds` is a
+summary without quantiles, so `_sum / _count` is all there is. There is
+deliberately no p95 panel implying otherwise.
+
+Token counts use Grafana's native `short` unit (`1.06 Bil`, `3.88 Mil`). Request
+counts are left unscaled: at four or five digits, `23.1 K` loses more than it
+saves.
+
+## Coupling to the exporter
+
+`tests/unit/test_dashboard_provisioning.py` asserts every metric the dashboard
+queries is one the exporter actually emits. Renaming a metric without updating
+the JSON fails the suite rather than silently emptying a panel — which is the
+whole reason these files live in the repo instead of only on the monitoring host.
+
+The `datasource.uid` (`PBFA97CFB590B2093`) is this Grafana's Prometheus
+datasource. On another install, either match the uid or rewrite it after import.

--- a/deploy/grafana/kiro-lb.json
+++ b/deploy/grafana/kiro-lb.json
@@ -1,0 +1,2307 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "kiro-lb gateway: traffic, token attribution and account pool health. Metrics arrive via Pushgateway (job=kiro-lb-usage) because /metrics needs a bearer key.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_up{job=\"kiro-lb-usage\"}",
+          "refId": "A",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Gateway",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_uptime_seconds{job=\"kiro-lb-usage\"}",
+          "refId": "B",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_models{job=\"kiro-lb-usage\"}",
+          "refId": "C",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Models served",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_accounts{job=\"kiro-lb-usage\",state=\"available\"}",
+          "refId": "D",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Accounts available",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_accounts{job=\"kiro-lb-usage\",state=\"suspended\"}",
+          "refId": "E",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Suspended",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_accounts{job=\"kiro-lb-usage\",state=\"quota_exhausted\"}",
+          "refId": "F",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Quota exhausted",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kiro_lb_requests_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "G",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Requests / min",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kiro_lb_requests_total{job=\"kiro-lb-usage\",status_class=~\"4xx|5xx\"}[5m])) / clamp_min(sum(rate(kiro_lb_requests_total{job=\"kiro-lb-usage\"}[5m])), 0.0001)",
+          "refId": "H",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Error ratio (5m)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model) (rate(kiro_lb_requests_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "I",
+          "legendFormat": "{{model}}",
+          "range": true
+        }
+      ],
+      "title": "Requests / min by model",
+      "type": "timeseries",
+      "description": "Rate window is 5m: Pushgateway republishes every 30s, so a shorter window can fall inside one push and read as zero."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status_class) (rate(kiro_lb_requests_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "J",
+          "legendFormat": "{{status_class}}",
+          "range": true
+        }
+      ],
+      "title": "Requests / min by status class",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model) (rate(kiro_lb_request_latency_seconds_sum{job=\"kiro-lb-usage\"}[5m])) / clamp_min(sum by (model) (rate(kiro_lb_request_latency_seconds_count{job=\"kiro-lb-usage\"}[5m])), 0.0001)",
+          "refId": "K",
+          "legendFormat": "{{model}}",
+          "range": true
+        }
+      ],
+      "title": "Mean latency by model",
+      "type": "timeseries",
+      "description": "Successful requests only; a rejection's latency says nothing about generation speed. This is a summary without quantiles, so only the mean is available - not p95."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (protocol) (rate(kiro_lb_requests_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "L",
+          "legendFormat": "{{protocol}}",
+          "range": true
+        }
+      ],
+      "title": "Requests / min by protocol",
+      "type": "timeseries",
+      "description": "`other` means a route outside /v1; the raw path is deliberately not a label."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Tokens",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tokens / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (direction) (rate(kiro_lb_tokens_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "M",
+          "legendFormat": "{{direction}}",
+          "range": true
+        }
+      ],
+      "title": "Tokens / min by direction",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tokens / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model) (rate(kiro_lb_tokens_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "N",
+          "legendFormat": "{{model}}",
+          "range": true
+        }
+      ],
+      "title": "Tokens / min by model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      },
+      "id": 18,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model) (kiro_lb_tokens_total{job=\"kiro-lb-usage\"})",
+          "refId": "O",
+          "legendFormat": "{{model}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Token share by model",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 34
+      },
+      "id": 19,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (key_name) (kiro_lb_tokens_total{job=\"kiro-lb-usage\"})",
+          "refId": "P",
+          "legendFormat": "{{key_name}}",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "title": "Token share by API key",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tokens / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (key_name) (rate(kiro_lb_tokens_total{job=\"kiro-lb-usage\"}[5m])) * 60",
+          "refId": "Q",
+          "legendFormat": "{{key_name}}",
+          "range": true
+        }
+      ],
+      "title": "Tokens / min by API key",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Total tokens|Input|Output"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 21,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (key_name, model) (kiro_lb_tokens_total{job=\"kiro-lb-usage\"})",
+          "refId": "R",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (key_name, model) (kiro_lb_tokens_total{job=\"kiro-lb-usage\",direction=\"input\"})",
+          "refId": "S",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (key_name, model) (kiro_lb_tokens_total{job=\"kiro-lb-usage\",direction=\"output\"})",
+          "refId": "T",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (key_name, model) (kiro_lb_key_requests_total{job=\"kiro-lb-usage\"})",
+          "refId": "U",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "title": "Tokens and requests by key and model",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "model",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "key_name 2": true,
+              "key_name 3": true,
+              "key_name 4": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "key_name 1": "API key",
+              "model": "Model",
+              "Value #A": "Total tokens",
+              "Value #B": "Input",
+              "Value #C": "Output",
+              "Value #D": "Requests"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Total tokens"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table",
+      "description": "Cumulative since the store was created, not a rate."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Account pool",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "accounts",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (state) (kiro_lb_accounts{job=\"kiro-lb-usage\"})",
+          "refId": "V",
+          "legendFormat": "{{state}}",
+          "range": true
+        }
+      ],
+      "title": "Accounts by routing state",
+      "type": "timeseries",
+      "description": "Every state is reported even at zero, so a category that empties out reads 0 instead of vanishing from the graph."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "% of allowance",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent",
+          "decimals": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_quota_percent{job=\"kiro-lb-usage\"}",
+          "refId": "W",
+          "legendFormat": "{{account}}",
+          "range": true
+        }
+      ],
+      "title": "Quota consumed per account",
+      "type": "timeseries",
+      "description": "Accounts are identified by the same short digest the kiro-lb dashboard shows; the credential path is never exported."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Quota %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "min",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Eligible in (s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failures"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "text",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 25,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_quota_percent{job=\"kiro-lb-usage\"}",
+          "refId": "X",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_quota_used{job=\"kiro-lb-usage\"}",
+          "refId": "Y",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_quota_limit{job=\"kiro-lb-usage\"}",
+          "refId": "Z",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_failures{job=\"kiro-lb-usage\"}",
+          "refId": "A",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_eligible_in_seconds{job=\"kiro-lb-usage\"}",
+          "refId": "B",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (account) (kiro_lb_account_requests_total{job=\"kiro-lb-usage\",outcome=\"success\"})",
+          "refId": "C",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (account) (kiro_lb_account_requests_total{job=\"kiro-lb-usage\",outcome=\"failure\"})",
+          "refId": "D",
+          "instant": true,
+          "range": false,
+          "format": "table"
+        }
+      ],
+      "title": "Account pool state",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "account",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "Time 7": true,
+              "Time 8": true,
+              "Time": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true,
+              "instance 5": true,
+              "instance 6": true,
+              "instance 7": true,
+              "instance 8": true,
+              "instance": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "job 5": true,
+              "job 6": true,
+              "job 7": true,
+              "job 8": true,
+              "job": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "__name__ 5": true,
+              "__name__ 6": true,
+              "__name__ 7": true,
+              "__name__ 8": true,
+              "__name__": true
+            },
+            "renameByName": {
+              "account": "Account",
+              "Value #A": "Quota %",
+              "Value #B": "Used",
+              "Value #C": "Limit",
+              "Value #D": "Failures",
+              "Value #E": "Eligible in (s)",
+              "Value #F": "Successes",
+              "Value #G": "Failed"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Quota %"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table",
+      "description": "Eligible in (s) is 0 for an account that is serving traffic now. A suspended account shows the remaining quarantine, but only Kiro support can actually lift it."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "failures / min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (account) (rate(kiro_lb_account_requests_total{job=\"kiro-lb-usage\",outcome=\"failure\"}[5m])) * 60",
+          "refId": "E",
+          "legendFormat": "{{account}}",
+          "range": true
+        }
+      ],
+      "title": "Upstream failures / min by account",
+      "type": "timeseries",
+      "description": "A failure here means the upstream request failed and failover moved on, not that the client saw an error."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "consecutive failures",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kiro_lb_account_failures{job=\"kiro-lb-usage\"}",
+          "refId": "F",
+          "legendFormat": "{{account}}",
+          "range": true
+        }
+      ],
+      "title": "Circuit breaker failures per account",
+      "type": "timeseries",
+      "description": "Consecutive failures only. Rate limits, quota exhaustion and suspension deliberately leave this counter untouched, so a fully excluded account can sit at 0."
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "kiro-lb",
+    "kiro",
+    "gateway"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "kiro-lb Gateway",
+  "uid": "kiro-lb",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/pushgateway/export_usage.sh
+++ b/deploy/pushgateway/export_usage.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Fetch the kiro-lb exposition and republish it through Pushgateway.
+#
+# This mirrors freerouter-probe/export_usage.sh deliberately. kiro-lb's /metrics
+# needs a bearer key, and none of the jobs in /opt/monitoring/prometheus.yml
+# carry credentials, so the authenticated fetch happens here and Prometheus only
+# ever scrapes the unauthenticated Pushgateway.
+#
+# PUT, not POST: each run must replace the whole grouping. A POST would merge,
+# leaving series for a model or account that has since disappeared.
+set -eu
+
+: "${KIRO_LB_API_KEY:?KIRO_LB_API_KEY is required}"
+metrics_url="${KIRO_LB_METRICS_URL:-http://10.10.10.10:8000/metrics}"
+pushgateway_url="${PUSHGATEWAY_URL:-http://10.10.10.3:9091}"
+job="${USAGE_JOB:-kiro-lb-usage}"
+instance="${USAGE_INSTANCE:-ws}"
+
+metrics="$(curl --fail --silent --show-error \
+  --connect-timeout 5 \
+  --max-time 15 \
+  --header "Authorization: Bearer $KIRO_LB_API_KEY" \
+  "$metrics_url")"
+
+printf '%s\n' "$metrics" |
+  curl --fail --silent --show-error \
+  --connect-timeout 5 \
+  --max-time 15 \
+  --request PUT \
+  --data-binary @- \
+  "$pushgateway_url/metrics/job/$job/instance/$instance"

--- a/deploy/pushgateway/kiro-lb-usage-export.service
+++ b/deploy/pushgateway/kiro-lb-usage-export.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Export kiro-lb request, token and account metrics to Pushgateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/home/minpeter/homelab/kiro-lb-probe/kiro-lb.env
+ExecStart=/bin/sh /home/minpeter/homelab/kiro-lb-probe/export_usage.sh
+TimeoutStartSec=25

--- a/deploy/pushgateway/kiro-lb-usage-export.timer
+++ b/deploy/pushgateway/kiro-lb-usage-export.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Export kiro-lb metrics every 30 seconds
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=kiro-lb-usage-export.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/pushgateway/kiro-lb.env.example
+++ b/deploy/pushgateway/kiro-lb.env.example
@@ -1,0 +1,13 @@
+# Credentials for the metrics export timer. Copy to kiro-lb.env next to the
+# service unit and chmod 600; the real file is gitignored.
+#
+# Any key /v1 accepts works: the legacy PROXY_API_KEY or a dashboard-issued
+# klb_ key. A dedicated key is preferable, since revoking it then stops the
+# scrape without touching client traffic.
+KIRO_LB_API_KEY=replace-me
+
+# Optional overrides; the defaults match the homelab.
+# KIRO_LB_METRICS_URL=http://10.10.10.10:8000/metrics
+# PUSHGATEWAY_URL=http://10.10.10.3:9091
+# USAGE_JOB=kiro-lb-usage
+# USAGE_INSTANCE=ws

--- a/tests/unit/test_dashboard_provisioning.py
+++ b/tests/unit/test_dashboard_provisioning.py
@@ -1,0 +1,228 @@
+"""The provisioned Grafana dashboard must match what the exporter emits.
+
+`deploy/grafana/kiro-lb.json` is checked in so that renaming a metric cannot
+silently empty a panel. Without these assertions the file would be a copy of
+production with no way to notice it had drifted, which is the only reason to keep
+it in the repo at all.
+
+The exporter has already been through one such rename: latency moved from two
+counters to a summary and the quota reset changed from days to seconds.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from kiro.metrics import _FAMILIES
+
+_REPO = Path(__file__).resolve().parents[2]
+_DASHBOARD = _REPO / "deploy" / "grafana" / "kiro-lb.json"
+_PROBE = _REPO / "deploy" / "pushgateway"
+
+# Pushgateway owns these two labels (honor_labels: true), and the export script
+# sets them in the PUT path.
+_PUSH_JOB = "kiro-lb-usage"
+
+
+@pytest.fixture(scope="module")
+def dashboard() -> dict:
+    return json.loads(_DASHBOARD.read_text())
+
+
+@pytest.fixture(scope="module")
+def exprs(dashboard) -> list[tuple[str, str]]:
+    found = []
+    for panel in dashboard["panels"]:
+        if panel["type"] == "row":
+            continue
+        for target in panel.get("targets", []):
+            if "expr" in target:
+                found.append((panel["title"], target["expr"]))
+    return found
+
+
+def _emitted_series() -> set[str]:
+    """Every series name the exporter can produce, including summary children."""
+    names = set()
+    for name, kind, _ in _FAMILIES:
+        names.add(name)
+        if kind in ("summary", "histogram"):
+            names.update({f"{name}_sum", f"{name}_count"})
+        if kind == "histogram":
+            names.add(f"{name}_bucket")
+    return names
+
+
+class TestMetricNames:
+    def test_every_queried_metric_is_emitted(self, exprs):
+        emitted = _emitted_series()
+        referenced = set()
+        for _, expr in exprs:
+            referenced.update(re.findall(r"\bkiro_lb_[a-z_]+", expr))
+
+        unknown = referenced - emitted
+        assert not unknown, f"dashboard queries metrics the exporter does not emit: {sorted(unknown)}"
+
+    def test_the_dashboard_actually_queries_something(self, exprs):
+        # Guards against a truncated or placeholder file passing the test above.
+        assert len(exprs) > 20
+        assert any("kiro_lb_tokens_total" in expr for _, expr in exprs)
+        assert any("kiro_lb_accounts" in expr for _, expr in exprs)
+
+    def test_no_stale_metric_names_survive(self, exprs):
+        """Names the exporter used before promtool forced a rename."""
+        joined = " ".join(expr for _, expr in exprs)
+
+        assert "kiro_lb_account_quota_reset_days" not in joined
+        # These were counters named _sum/_count; they are now a summary's children,
+        # which is only valid alongside the summary family itself.
+        assert "kiro_lb_request_latency_seconds_total" not in joined
+
+    def test_label_names_match_the_exporter(self, exprs):
+        """A label typo empties a panel just as quietly as a metric typo."""
+        known = {
+            "job",
+            "instance",
+            "model",
+            "protocol",
+            "status_class",
+            "direction",
+            "key_id",
+            "key_name",
+            "account",
+            "state",
+            "outcome",
+            "version",
+        }
+        for title, expr in exprs:
+            for label in re.findall(r"(?:by|without)\s*\(([^)]*)\)", expr):
+                for name in (part.strip() for part in label.split(",")):
+                    if name:
+                        assert name in known, f"{title}: unknown label {name!r}"
+            for name in re.findall(r"[{,]\s*([a-z_]+)\s*=~?\"", expr):
+                assert name in known, f"{title}: unknown label {name!r}"
+
+
+class TestPushgatewayContract:
+    def test_every_query_filters_on_the_push_job(self, exprs):
+        """Without the job filter a panel would also match any future exporter."""
+        for title, expr in exprs:
+            assert f'job="{_PUSH_JOB}"' in expr, f"{title} does not filter on the push job"
+
+    def test_the_export_script_pushes_to_that_job(self):
+        script = (_PROBE / "export_usage.sh").read_text()
+
+        assert f"USAGE_JOB:-{_PUSH_JOB}" in script
+        # PUT replaces the grouping; POST would merge and leave stale series for a
+        # model or account that has since disappeared.
+        assert "--request PUT" in script
+        assert "--request POST" not in script
+
+    def test_the_script_requires_its_key_rather_than_pushing_nothing(self):
+        script = (_PROBE / "export_usage.sh").read_text()
+
+        # `${VAR:?message}` aborts on an unset key. Silently pushing an empty body
+        # would wipe the grouping in Pushgateway.
+        assert "${KIRO_LB_API_KEY:?" in script
+        assert "set -eu" in script
+
+    def test_no_credential_is_committed(self):
+        assert not (_PROBE / "kiro-lb.env").exists() or "kiro-lb.env" in (_REPO / ".gitignore").read_text()
+        example = (_PROBE / "kiro-lb.env.example").read_text()
+        assert "replace-me" in example
+
+    def test_the_timer_interval_is_shorter_than_the_dashboard_rate_window(self):
+        """A rate window must span several pushes or it can read as zero."""
+        timer = (_PROBE / "kiro-lb-usage-export.timer").read_text()
+        seconds = int(re.search(r"OnUnitActiveSec=(\d+)s", timer).group(1))
+
+        assert seconds <= 60
+        # The dashboard uses 5m windows; assert the margin is real, not incidental.
+        assert seconds * 4 <= 5 * 60
+
+
+class TestDashboardShape:
+    def test_uid_and_title_are_stable(self, dashboard):
+        # The URL /d/kiro-lb/... and the README both depend on these.
+        assert dashboard["uid"] == "kiro-lb"
+        assert dashboard["title"] == "kiro-lb Gateway"
+
+    def test_panels_have_unique_ids(self, dashboard):
+        ids = [p["id"] for p in dashboard["panels"]]
+        assert len(ids) == len(set(ids))
+
+    def test_rate_windows_span_several_pushes(self, exprs):
+        """`$__rate_interval` would follow the dashboard's zoom, not the push rate."""
+        for title, expr in exprs:
+            assert "$__rate_interval" not in expr, f"{title} uses $__rate_interval"
+            for window in re.findall(r"\[(\d+)([smh])\]", expr):
+                value, unit = int(window[0]), window[1]
+                as_seconds = value * {"s": 1, "m": 60, "h": 3600}[unit]
+                assert as_seconds >= 120, f"{title}: {value}{unit} window is too short for a 30s push"
+
+    def test_latency_is_a_mean_not_a_fake_quantile(self, exprs):
+        """The summary carries no quantiles, so a p95 panel would be a lie."""
+        joined = " ".join(expr for _, expr in exprs)
+
+        assert "histogram_quantile" not in joined
+        assert 'quantile="' not in joined
+        # The mean is present and divides sum by count.
+        assert any(
+            "kiro_lb_request_latency_seconds_sum" in expr and "kiro_lb_request_latency_seconds_count" in expr
+            for _, expr in exprs
+        )
+
+    def test_divisions_guard_against_a_zero_denominator(self, exprs):
+        for title, expr in exprs:
+            if "/" in expr and "kiro_lb" in expr:
+                assert "clamp_min" in expr, f"{title} divides without clamping the denominator"
+
+    def test_token_panels_use_the_native_short_unit(self, dashboard):
+        """Nine-digit token counts are unreadable raw; `short` renders 1.06 Bil."""
+        checked = 0
+        for panel in dashboard["panels"]:
+            if panel["type"] == "row":
+                continue
+            queries = " ".join(t.get("expr", "") for t in panel.get("targets", []))
+            if "kiro_lb_tokens_total" not in queries:
+                continue
+            checked += 1
+            if panel["type"] == "table":
+                units = [
+                    prop["value"]
+                    for override in panel["fieldConfig"]["overrides"]
+                    for prop in override["properties"]
+                    if prop["id"] == "unit"
+                ]
+                assert "short" in units, panel["title"]
+            else:
+                assert panel["fieldConfig"]["defaults"].get("unit") == "short", panel["title"]
+        assert checked >= 5
+
+    def test_request_counts_stay_unscaled(self, dashboard):
+        """`23.1 K` loses more than it saves at four or five digits."""
+        for panel in dashboard["panels"]:
+            if panel["type"] != "timeseries":
+                continue
+            queries = " ".join(t.get("expr", "") for t in panel.get("targets", []))
+            if "kiro_lb_requests_total" in queries and "tokens" not in queries:
+                assert panel["fieldConfig"]["defaults"].get("unit") != "short", panel["title"]
+
+    def test_no_secret_material_is_embedded(self, dashboard):
+        raw = json.dumps(dashboard)
+
+        for needle in ("Authorization", "Bearer ", "klb_", "PROXY_API_KEY", "password", "refreshToken"):
+            assert needle not in raw, needle
+
+    def test_account_identifiers_are_never_credential_paths(self, dashboard):
+        raw = json.dumps(dashboard)
+
+        # The exporter labels accounts with a short digest; a path or an email
+        # appearing here would mean the exposition leaked one.
+        assert "/data/logins" not in raw
+        assert "builder-id-" not in raw
+        assert "@" not in re.sub(r"https?://[^\"]*", "", raw)


### PR DESCRIPTION
## Summary

The Grafana dashboard and the metrics export timer lived only on the monitoring host (`apps:/opt/monitoring/...`) and this workstation (`~/homelab/kiro-lb-probe/`). Two problems with that: a metric rename in `kiro/metrics.py` could quietly empty a panel with nothing to catch it, and losing either host meant rebuilding 23 panels from memory.

```
deploy/grafana/kiro-lb.json              # dashboard, uid kiro-lb
deploy/pushgateway/export_usage.sh       # authenticated fetch -> Pushgateway PUT
deploy/pushgateway/*.service|.timer      # systemd user units
deploy/pushgateway/kiro-lb.env.example   # the real .env is gitignored
deploy/README.md                         # wiring, and why push instead of pull
```

## The test is the point

`tests/unit/test_dashboard_provisioning.py` (18 tests) is what makes checking these in worth more than a backup. It asserts every metric name and label the dashboard queries against the exporter's own `_FAMILIES`, and pins two constraints that are invisible in the Grafana UI:

- **Rate windows must span several pushes.** Pushgateway republishes every 30s, so a shorter window can fall entirely inside one push and read as zero. `$__rate_interval` is rejected outright since it follows the viewer's zoom, not the push rate.
- **Latency is a mean, not a quantile.** `kiro_lb_request_latency_seconds` is a summary with no quantiles, so a `histogram_quantile` or p95 panel would be fabricating data.

It also checks the timer interval stays well under the rate window, that the script uses `PUT` rather than `POST` (a merge would leave stale series for a model or account that disappeared), that division guards its denominator with `clamp_min`, and that no credential or account path is embedded in the JSON.

Verified by reverting each invariant and watching the right test fail: renaming a metric in the exporter, shortening a rate window to `[30s]`, and adding a fake p95 panel each produce a failure rather than a silently broken dashboard.

## Notes

These files describe this operator's homelab and carry its private addresses and the Grafana datasource uid, so `deploy/README.md` frames them as a worked example rather than a drop-in. There is precedent: `docker-compose.homelab.yml` is already tracked with `10.10.10.10` in it.

Confirmed the tracked dashboard is byte-identical to what Grafana currently serves across every authored key, and that the tracked units match the deployed symlink targets.

## Testing

- `pytest -q` — 1822 passed (18 new)
- `ruff format --check .`, `ruff check .`, `mypy` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track the `kiro-lb` Grafana dashboard and Pushgateway export units in-repo, with tests that lock metric names/labels and enforce safe query rules. This makes the observability setup reproducible and prevents silent panel breakage on metric changes.

- **New Features**
  - Added `deploy/grafana/kiro-lb.json` (uid `kiro-lb`) and docs; provision via file, not API.
  - Added Pushgateway exporter: `deploy/pushgateway/export_usage.sh` and user `.service`/`.timer` (30s).
  - Added `deploy/pushgateway/kiro-lb.env.example`; real `.env` is gitignored; `.gitignore` updated.
  - Added `tests/unit/test_dashboard_provisioning.py` to assert:
    - Only emitted metrics/labels are queried; every query filters `job="kiro-lb-usage"`.
    - Rates use 5m windows (multiple 30s pushes); latency is mean via `_sum/_count` (no quantiles).
    - Denominators are `clamp_min`-guarded; no secrets/paths embedded; unique panel IDs.
    - Export script uses `PUT` (not `POST`) and requires `KIRO_LB_API_KEY`.
  - Added `deploy/README.md` and brief updates in `AGENTS.md`.

- **Migration**
  - Exporter: copy `deploy/pushgateway/*` to your probe dir, set `kiro-lb.env` (chmod 600), link and enable the user timer.
  - Dashboard: copy `deploy/grafana/kiro-lb.json` to the provisioned folder and call `POST /api/admin/provisioning/dashboards/reload`.
  - If your Prometheus datasource uid differs, update it after import.

<sup>Written for commit b0abb6aaa7bd01b23860fdb9c8eb85a455dadeaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

