### PR TITLE
Merge usage rows stored under a client model spelling

### DIFF
--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -20,6 +20,7 @@ from typing import Any, Iterator
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import FileResponse
+from loguru import logger
 
 from kiro.account_manager import account_label, account_routing_state
 from kiro.accounts_admin import register_account
@@ -41,6 +42,7 @@ from kiro.device_login import (
 )
 from kiro.metrics import CONTENT_TYPE as METRICS_CONTENT_TYPE
 from kiro.metrics import render_metrics
+from kiro.model_resolver import normalize_model_name
 from kiro.usage import fetch_account_usage
 from kiro.usage_tracking import ROOT_KEY_ID, drain_pending_usage
 
@@ -154,6 +156,52 @@ def initialize_dashboard_store() -> None:
         for column, ddl in (("overage_status", "TEXT"), ("overage_used", "REAL"), ("email", "TEXT")):
             if column not in existing:
                 conn.execute(f"ALTER TABLE account_usage ADD COLUMN {column} {ddl}")
+
+        _merge_unnormalized_usage_models(conn)
+
+
+def _merge_unnormalized_usage_models(conn: sqlite3.Connection) -> int:
+    """Fold rows stored under a client spelling into the normalized model.
+
+    `record_token_usage` normalizes before writing, but rows recorded before that
+    keep whatever the client sent: `claude-sonnet-4-5` sat beside
+    `claude-sonnet-4.5` as a separate model, so one model's totals were split
+    across two rows and it appeared twice in the dashboard.
+
+    Totals are added, not overwritten. Dropping the old row instead would lose
+    the tokens it accounted for, and taking the larger of the two would silently
+    understate consumption.
+    """
+    merged = 0
+    rows = conn.execute(
+        "SELECT key_id, model, prompt_tokens, completion_tokens, requests, updated_at FROM key_model_usage"
+    ).fetchall()
+    for row in rows:
+        canonical = normalize_model_name(row["model"]) or row["model"]
+        if canonical == row["model"]:
+            continue
+        conn.execute(
+            """INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(key_id, model) DO UPDATE SET
+                prompt_tokens = prompt_tokens + excluded.prompt_tokens,
+                completion_tokens = completion_tokens + excluded.completion_tokens,
+                requests = requests + excluded.requests,
+                updated_at = MAX(updated_at, excluded.updated_at)""",
+            (
+                row["key_id"],
+                canonical,
+                row["prompt_tokens"],
+                row["completion_tokens"],
+                row["requests"],
+                row["updated_at"],
+            ),
+        )
+        conn.execute("DELETE FROM key_model_usage WHERE key_id = ? AND model = ?", (row["key_id"], row["model"]))
+        merged += 1
+    if merged:
+        logger.info("Merged {} usage row(s) stored under a non-normalized model name", merged)
+    return merged
 
 
 def prune_request_logs() -> int:

--- a/tests/unit/test_key_model_usage.py
+++ b/tests/unit/test_key_model_usage.py
@@ -8,6 +8,7 @@ survive a restart.
 
 import asyncio
 import importlib
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -251,3 +252,87 @@ async def test_anthropic_stream_records_usage_for_the_calling_key(dashboard, str
 
     assert row["model"] == "claude-opus-5"
     assert row["requests"] == 1
+
+
+def test_rows_stored_under_a_client_spelling_are_merged_on_startup(dashboard):
+    """Rows written before normalization must be folded, not left as duplicates.
+
+    A store that predates the normalization in record_token_usage holds
+    `claude-sonnet-4-5` beside `claude-sonnet-4.5`, splitting one model's totals
+    across two rows. The live store had exactly one such row, worth 34,658 tokens
+    over 560 requests.
+    """
+    now = int(time.time())
+    with dashboard._db() as conn:
+        conn.executemany(
+            "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+            " VALUES (?,?,?,?,?,?)",
+            [
+                (ROOT_KEY_ID, "claude-sonnet-4.5", 1_000, 100, 10, now - 50),
+                (ROOT_KEY_ID, "claude-sonnet-4-5", 30_000, 4_658, 560, now),
+            ],
+        )
+
+    dashboard.initialize_dashboard_store()
+
+    rows = {row["model"]: row for row in dashboard.key_model_usage()[ROOT_KEY_ID]}
+    assert "claude-sonnet-4-5" not in rows
+    # Added, not replaced: dropping the old row would lose what it accounted for.
+    assert rows["claude-sonnet-4.5"]["promptTokens"] == 31_000
+    assert rows["claude-sonnet-4.5"]["completionTokens"] == 4_758
+    assert rows["claude-sonnet-4.5"]["requests"] == 570
+    assert rows["claude-sonnet-4.5"]["updatedAt"] == now
+
+
+def test_the_merge_creates_the_row_when_no_canonical_one_exists(dashboard):
+    now = int(time.time())
+    with dashboard._db() as conn:
+        conn.execute(
+            "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+            " VALUES (?,?,?,?,?,?)",
+            (ROOT_KEY_ID, "claude-haiku-4-5", 7, 3, 1, now),
+        )
+
+    dashboard.initialize_dashboard_store()
+
+    rows = {row["model"]: row for row in dashboard.key_model_usage()[ROOT_KEY_ID]}
+    assert set(rows) == {"claude-haiku-4.5"}
+    assert rows["claude-haiku-4.5"]["totalTokens"] == 10
+
+
+def test_the_merge_leaves_already_normalized_rows_alone(dashboard):
+    now = int(time.time())
+    with dashboard._db() as conn:
+        conn.executemany(
+            "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+            " VALUES (?,?,?,?,?,?)",
+            [
+                (ROOT_KEY_ID, "claude-opus-5", 100, 50, 5, now),
+                (ROOT_KEY_ID, "some-unknown-model", 1, 1, 1, now),
+            ],
+        )
+
+    dashboard.initialize_dashboard_store()
+
+    rows = {row["model"]: row for row in dashboard.key_model_usage()[ROOT_KEY_ID]}
+    # An unfamiliar name is not a spelling variant; Kiro is the arbiter, so it stays.
+    assert rows["claude-opus-5"]["totalTokens"] == 150
+    assert rows["some-unknown-model"]["totalTokens"] == 2
+
+
+def test_the_merge_is_idempotent(dashboard):
+    now = int(time.time())
+    with dashboard._db() as conn:
+        conn.execute(
+            "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+            " VALUES (?,?,?,?,?,?)",
+            (ROOT_KEY_ID, "claude-sonnet-4-5", 10, 5, 2, now),
+        )
+
+    dashboard.initialize_dashboard_store()
+    dashboard.initialize_dashboard_store()
+
+    rows = {row["model"]: row for row in dashboard.key_model_usage()[ROOT_KEY_ID]}
+    # A second startup must not double the totals it already folded.
+    assert rows["claude-sonnet-4.5"]["totalTokens"] == 15
+    assert rows["claude-sonnet-4.5"]["requests"] == 2


### PR DESCRIPTION
## Summary

Follow-up to #7. `record_token_usage` now normalizes the model name before writing, but rows recorded before that keep whatever the client sent — the live store held `claude-sonnet-4-5` (34,658 tokens, 560 requests) beside `claude-sonnet-4.5`, so one model's totals were split across two rows and it showed up twice in the dashboard and the new donut.

`initialize_dashboard_store` now folds them on startup, alongside the existing additive column migrations.

Totals are **added**, not replaced. Dropping the stale row would lose the tokens it accounted for; taking the larger of the two would silently understate consumption.

## Verification

Ran against a copy of the live store, reconstructed to its pre-merge state:

```
before: 21 rows, 1,167,256,834 tok, 9,059 req | dash=560 req  dot=1,753,010/335
after : 20 rows, 1,167,256,834 tok, 9,059 req | dash=gone     dot=1,787,668/895
```

Row count drops by one, token and request sums are byte-identical, and the dash row's 560 requests land in the canonical row. The merge is idempotent — a second startup does not double what it already folded, which matters because this runs on every boot.

An unrecognized model name is left alone: Kiro is the arbiter of model names, so an unfamiliar one is real traffic, not a spelling variant.

## Testing

- 4 new tests in `test_key_model_usage.py`: the merge itself, creating the canonical row when none exists, leaving normalized and unknown names untouched, and idempotency
- `pytest -q` — 1828 passed; `ruff`/`mypy` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge usage rows stored under client-spelled model names into their normalized model on startup to remove duplicate entries and unify totals in the dashboard/donut. Totals are summed, not replaced, so no usage is lost.

- **Bug Fixes**
  - On startup, `initialize_dashboard_store` normalizes model names in `key_model_usage` via `normalize_model_name` and merges duplicates with an upsert that sums tokens/requests and keeps the latest `updated_at`, then deletes the old row.
  - Unknown/unmapped model names are left untouched; the merge is idempotent and runs on every boot.
  - Tests cover merging, creating the canonical row when missing, leaving normalized/unknown names unchanged, and idempotency.

<sup>Written for commit bcd8bb66d0c221cc3dd3a3e0b60cf830969605ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

