### PR TITLE
Measure generation throughput and chart tokens/sec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ kiro-lb-python/
 ├── kiro/                    # Gateway package: 39 modules, 16.5k lines
 │   └── static/              # BUILD OUTPUT of frontend/ — never hand-edit
 ├── frontend/                # Bun + Vite + React 19 dashboard source
-├── tests/                   # pytest, 1824 tests; network-blocked by conftest
+├── tests/                   # pytest, 1837 tests; network-blocked by conftest
 ├── data/                    # Runtime credentials/state/sqlite (gitignored)
 ├── deploy/                  # Grafana dashboard + Pushgateway units for /metrics
 ├── debug_logs/              # Capture output when DEBUG_MODE is on (gitignored)
@@ -104,6 +104,17 @@ trusting a pin here.
   (`usage_tracking.py:33`). Callers pass whatever the client sent, so
   `claude-sonnet-4-5`, the dotted form and a dated form are one model; storing
   them raw split a single model's totals across rows nothing could rejoin.
+- Generation throughput divides `timed_completion_tokens` by `generation_ms`,
+  never the full `completion_tokens`. The two counters must cover the same
+  requests: rows predating the timing column hold tokens with no duration, and
+  dividing the full total by a partial duration reported 82,752 tok/s on the live
+  store. The exporter pairs them as `kiro_lb_timed_output_tokens_total` and
+  `kiro_lb_generation_seconds_total`, both keyed by model only.
+- Generation time is measured inside the streaming generators
+  (`streaming_openai.py`, `streaming_anthropic.py`), not by the request-log
+  middleware. The middleware stops when the handler returns, which for a stream
+  is first-byte time: one model averaged 17ms there while generating for seconds,
+  so that latency can never be a throughput denominator.
 - Frontend logic that a panel derives (totals, chart slices) lives in a plain
   module beside the component, not exported from the `.tsx`: eslint's
   `react-refresh/only-export-components` rejects mixed exports, and it is what
@@ -180,7 +191,7 @@ trusting a pin here.
 
 ```bash
 python main.py --host 127.0.0.1 --port 8000    # run gateway
-pytest -q                                      # full suite (1824 tests, ~6s, no network)
+pytest -q                                      # full suite (1837 tests, ~6s, no network)
 pytest -v --tb=short                           # exactly what CI's test job runs
 pytest --cov=kiro --cov-report=term            # CI coverage step
 ruff format --check --diff . && ruff check .   # CI quality job, python half

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -93,6 +93,21 @@ Lands at `/d/kiro-lb/kiro-lb-gateway`.
 summary without quantiles, so `_sum / _count` is all there is. There is
 deliberately no p95 panel implying otherwise.
 
+**Latency is not throughput.** That summary is recorded by the request-log
+middleware, which stops when the handler returns — first-byte time for a stream.
+Throughput has its own pair, measured inside the streaming generators:
+
+```promql
+sum by (model) (rate(kiro_lb_timed_output_tokens_total[5m]))
+  / clamp_min(sum by (model) (rate(kiro_lb_generation_seconds_total[5m])), 0.001)
+```
+
+The numerator is deliberately not `kiro_lb_tokens_total`: that counts every
+request, including ones with no timing, and dividing it by a partial duration
+reported 82,752 tok/s on the live store. `kiro_lb_generation_seconds_total` on its
+own is also useful — as a rate it reads as concurrent generations, since 2 means
+two upstream responses were being produced at once.
+
 Token counts use Grafana's native `short` unit (`1.06 Bil`, `3.88 Mil`). Request
 counts are left unscaled: at four or five digits, `23.1 K` loses more than it
 saves.

--- a/deploy/grafana/kiro-lb.json
+++ b/deploy/grafana/kiro-lb.json
@@ -978,6 +978,226 @@
         "x": 0,
         "y": 24
       },
+      "id": 28,
+      "panels": [],
+      "title": "Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Generation throughput: timed output tokens divided by the upstream generation time that produced them. Both counters cover the same requests - dividing kiro_lb_tokens_total instead would mix in requests that were never timed. This is not the request latency on the Traffic row: that stops at first byte for a stream.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tok / s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "min": 0,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model) (rate(kiro_lb_timed_output_tokens_total{job=\"kiro-lb-usage\"}[5m])) / clamp_min(sum by (model) (rate(kiro_lb_generation_seconds_total{job=\"kiro-lb-usage\"}[5m])), 0.001)",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Output tokens per second by model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "One line is pool-wide throughput. The other is generation-seconds accrued per second, which is how many upstream responses were being produced at once: 2 means two streams were generating in parallel on average.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tok/s  \u00b7  streams",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "min": 0,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kiro_lb_timed_output_tokens_total{job=\"kiro-lb-usage\"}[5m])) / clamp_min(sum(rate(kiro_lb_generation_seconds_total{job=\"kiro-lb-usage\"}[5m])), 0.001)",
+          "legendFormat": "tok/s (all models)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(kiro_lb_generation_seconds_total{job=\"kiro-lb-usage\"}[5m]))",
+          "legendFormat": "concurrent generations",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Pool throughput and concurrency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
       "id": 15,
       "panels": [],
       "title": "Tokens",
@@ -1044,7 +1264,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 35
       },
       "id": 16,
       "options": {
@@ -1140,7 +1360,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 25
+        "y": 35
       },
       "id": 17,
       "options": {
@@ -1202,7 +1422,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 34
+        "y": 44
       },
       "id": 18,
       "options": {
@@ -1274,7 +1494,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 34
+        "y": 44
       },
       "id": 19,
       "options": {
@@ -1380,7 +1600,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 34
+        "y": 44
       },
       "id": 20,
       "options": {
@@ -1473,7 +1693,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 53
       },
       "id": 21,
       "options": {
@@ -1593,7 +1813,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 62
       },
       "id": 22,
       "panels": [],
@@ -1662,7 +1882,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 63
       },
       "id": 23,
       "options": {
@@ -1760,7 +1980,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 53
+        "y": 63
       },
       "id": 24,
       "options": {
@@ -1909,7 +2129,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 72
       },
       "id": 25,
       "options": {
@@ -2149,7 +2369,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 71
+        "y": 81
       },
       "id": 26,
       "options": {
@@ -2247,7 +2467,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 71
+        "y": 81
       },
       "id": 27,
       "options": {

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -128,10 +128,20 @@ def initialize_dashboard_store() -> None:
                 prompt_tokens INTEGER NOT NULL DEFAULT 0,
                 completion_tokens INTEGER NOT NULL DEFAULT 0,
                 requests INTEGER NOT NULL DEFAULT 0,
+                generation_ms INTEGER NOT NULL DEFAULT 0,
+                timed_completion_tokens INTEGER NOT NULL DEFAULT 0,
                 updated_at INTEGER NOT NULL,
                 PRIMARY KEY (key_id, model)
             )"""
         )
+        # Additive migration for stores created before generation time was tracked.
+        # Existing rows keep 0, which reads as "no timing yet" rather than as an
+        # instant response: a throughput consumer has to divide by it, so the
+        # zero must be skipped, not treated as a measurement.
+        usage_columns = {row["name"] for row in conn.execute("PRAGMA table_info(key_model_usage)")}
+        for column in ("generation_ms", "timed_completion_tokens"):
+            if column not in usage_columns:
+                conn.execute(f"ALTER TABLE key_model_usage ADD COLUMN {column} INTEGER NOT NULL DEFAULT 0")
         conn.execute(
             """CREATE TABLE IF NOT EXISTS account_usage (
                 account_id TEXT PRIMARY KEY,
@@ -174,19 +184,22 @@ def _merge_unnormalized_usage_models(conn: sqlite3.Connection) -> int:
     """
     merged = 0
     rows = conn.execute(
-        "SELECT key_id, model, prompt_tokens, completion_tokens, requests, updated_at FROM key_model_usage"
+        "SELECT key_id, model, prompt_tokens, completion_tokens, requests, generation_ms,"
+        " timed_completion_tokens, updated_at FROM key_model_usage"
     ).fetchall()
     for row in rows:
         canonical = normalize_model_name(row["model"]) or row["model"]
         if canonical == row["model"]:
             continue
         conn.execute(
-            """INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            """INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, generation_ms, timed_completion_tokens, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(key_id, model) DO UPDATE SET
                 prompt_tokens = prompt_tokens + excluded.prompt_tokens,
                 completion_tokens = completion_tokens + excluded.completion_tokens,
                 requests = requests + excluded.requests,
+                generation_ms = generation_ms + excluded.generation_ms,
+                timed_completion_tokens = timed_completion_tokens + excluded.timed_completion_tokens,
                 updated_at = MAX(updated_at, excluded.updated_at)""",
             (
                 row["key_id"],
@@ -194,6 +207,8 @@ def _merge_unnormalized_usage_models(conn: sqlite3.Connection) -> int:
                 row["prompt_tokens"],
                 row["completion_tokens"],
                 row["requests"],
+                row["generation_ms"],
+                row["timed_completion_tokens"],
                 row["updated_at"],
             ),
         )
@@ -266,16 +281,18 @@ def flush_key_model_usage() -> int:
     try:
         with _db() as conn:
             conn.executemany(
-                """INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                """INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, generation_ms, timed_completion_tokens, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(key_id, model) DO UPDATE SET
                     prompt_tokens = prompt_tokens + excluded.prompt_tokens,
                     completion_tokens = completion_tokens + excluded.completion_tokens,
                     requests = requests + excluded.requests,
+                    generation_ms = generation_ms + excluded.generation_ms,
+                    timed_completion_tokens = timed_completion_tokens + excluded.timed_completion_tokens,
                     updated_at = excluded.updated_at""",
                 [
-                    (key_id, model, prompt, completion, requests, now)
-                    for key_id, model, prompt, completion, requests in pending
+                    (key_id, model, prompt, completion, requests, generation_ms, timed, now)
+                    for key_id, model, prompt, completion, requests, generation_ms, timed in pending
                 ],
             )
         return len(pending)
@@ -287,20 +304,30 @@ def key_model_usage() -> dict[str, list[dict[str, Any]]]:
     try:
         with _db() as conn:
             rows = conn.execute(
-                "SELECT key_id, model, prompt_tokens, completion_tokens, requests, updated_at"
+                "SELECT key_id, model, prompt_tokens, completion_tokens, requests, generation_ms,"
+                " timed_completion_tokens, updated_at"
                 " FROM key_model_usage ORDER BY prompt_tokens + completion_tokens DESC"
             ).fetchall()
     except Exception:
         return {}
     grouped: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
+        generation_ms = row["generation_ms"] or 0
+        completion = row["completion_tokens"]
+        timed_completion = row["timed_completion_tokens"] or 0
         grouped.setdefault(row["key_id"], []).append(
             {
                 "model": row["model"],
                 "promptTokens": row["prompt_tokens"],
-                "completionTokens": row["completion_tokens"],
-                "totalTokens": row["prompt_tokens"] + row["completion_tokens"],
+                "completionTokens": completion,
+                "totalTokens": row["prompt_tokens"] + completion,
                 "requests": row["requests"],
+                "generationSeconds": generation_ms / 1000,
+                # Only the tokens that were also timed may divide the duration.
+                # Using the full total mixes in rows recorded before timing
+                # existed and reported 82,752 tok/s on the live store. Absent
+                # rather than 0 when nothing has been timed yet.
+                "tokensPerSecond": (timed_completion / (generation_ms / 1000)) if generation_ms > 0 else None,
                 "updatedAt": row["updated_at"],
             }
         )

--- a/kiro/metrics.py
+++ b/kiro/metrics.py
@@ -52,6 +52,16 @@ _FAMILIES: tuple[tuple[str, str, str], ...] = (
     # are emitted, which is valid and keeps the series count flat.
     ("kiro_lb_request_latency_seconds", "summary", "Latency of successful requests by model and protocol."),
     ("kiro_lb_tokens_total", "counter", "Tokens attributed to an API key, by model and direction."),
+    (
+        "kiro_lb_generation_seconds_total",
+        "counter",
+        "Upstream generation time, by model. Denominator for tokens/sec.",
+    ),
+    (
+        "kiro_lb_timed_output_tokens_total",
+        "counter",
+        "Output tokens from requests that were also timed. Numerator for tokens/sec.",
+    ),
     ("kiro_lb_key_requests_total", "counter", "Requests attributed to an API key, by model."),
     ("kiro_lb_accounts", "gauge", "Accounts in the pool by routing state."),
     ("kiro_lb_account_requests_total", "counter", "Upstream requests per account by outcome."),
@@ -166,22 +176,39 @@ def _request_metrics(conn: Any, known: frozenset[str]) -> Iterator[str]:
 
 def _token_metrics(conn: Any, key_names: dict[str, str], known: frozenset[str]) -> Iterator[str]:
     rows = conn.execute(
-        "SELECT key_id, model, prompt_tokens, completion_tokens, requests FROM key_model_usage"
+        "SELECT key_id, model, prompt_tokens, completion_tokens, requests, generation_ms,"
+        " timed_completion_tokens FROM key_model_usage"
     ).fetchall()
     totals: dict[tuple[str, str], tuple[int, int, int]] = {}
+    # Generation time carries no key dimension: throughput is a property of the
+    # model and the upstream, not of who asked. Keying it per model also keeps it
+    # divisible by the token counters without a many-to-one vector match.
+    generation: dict[str, int] = {}
+    timed_output: dict[str, int] = {}
     for row in rows:
-        usage_key = (row["key_id"], _model(row["model"], known))
+        model = _model(row["model"], known)
+        usage_key = (row["key_id"], model)
         previous_usage = totals.get(usage_key, (0, 0, 0))
         totals[usage_key] = (
             previous_usage[0] + row["prompt_tokens"],
             previous_usage[1] + row["completion_tokens"],
             previous_usage[2] + row["requests"],
         )
+        generation[model] = generation.get(model, 0) + (row["generation_ms"] or 0)
+        timed_output[model] = timed_output.get(model, 0) + (row["timed_completion_tokens"] or 0)
     for (key_id, model), (prompt, completion, requests) in totals.items():
         labels = {"key_id": key_id, "key_name": key_names.get(key_id, key_id), "model": model}
         yield _line("kiro_lb_tokens_total", {**labels, "direction": "input"}, prompt)
         yield _line("kiro_lb_tokens_total", {**labels, "direction": "output"}, completion)
         yield _line("kiro_lb_key_requests_total", labels, requests)
+    for model, generation_ms in generation.items():
+        # Emitted even at zero so the series exists from the first scrape; a
+        # consumer has to clamp the denominator anyway.
+        yield _line("kiro_lb_generation_seconds_total", {"model": model}, generation_ms / 1000.0)
+        # Paired with the duration above so tokens/sec divides two counters that
+        # cover the same requests. kiro_lb_tokens_total also includes untimed
+        # requests, so dividing that instead overstates throughput.
+        yield _line("kiro_lb_timed_output_tokens_total", {"model": model}, timed_output.get(model, 0))
 
 
 def _account_metrics(accounts: Iterable[Any], usage_for: Any, label_for: Any, state_for: Any) -> Iterator[str]:

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -37,7 +37,7 @@ from kiro.streaming_core import (
     stream_with_first_token_retry,
 )
 from kiro.tokenizer import count_tokens, estimate_request_tokens
-from kiro.usage_tracking import record_token_usage
+from kiro.usage_tracking import GenerationTimer, record_token_usage
 
 if TYPE_CHECKING:
     from kiro.auth import KiroAuthManager
@@ -151,6 +151,9 @@ async def stream_kiro_to_anthropic(
     output_tokens = 0
     full_content = ""
     full_thinking_content = ""
+    # Timed from inside the generator: the middleware's latency stops when the
+    # handler returns, which for a stream is first-byte time.
+    generation = GenerationTimer()
 
     # NOTE: Anthropic streaming spec requires input_tokens in message_start (beginning),
     # but Kiro API provides accurate context_usage at the end of stream.
@@ -704,7 +707,7 @@ async def stream_kiro_to_anthropic(
             f"tool_blocks={len(tool_blocks)}, stop_reason={stop_reason}"
         )
 
-        record_token_usage(model, input_tokens, output_tokens)
+        record_token_usage(model, input_tokens, output_tokens, generation.elapsed)
 
     except FirstTokenTimeoutError:
         raise
@@ -756,6 +759,9 @@ async def collect_anthropic_response(
         Dictionary with full response in Anthropic Messages format
     """
     message_id = generate_message_id()
+    # The non-streaming path drains the upstream stream before returning, so the
+    # whole call is generation time.
+    generation = GenerationTimer()
 
     # Non-streaming uses the same full-request estimation as streaming
     input_tokens = 0
@@ -873,7 +879,7 @@ async def collect_anthropic_response(
         f"tool_calls={len(result.tool_calls)}, stop_reason={stop_reason}"
     )
 
-    record_token_usage(model, input_tokens, output_tokens)
+    record_token_usage(model, input_tokens, output_tokens, generation.elapsed)
 
     usage_payload: Dict[str, Any] = {"input_tokens": input_tokens, "output_tokens": output_tokens}
     usage_payload.update(upstream_cache_usage)

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -41,7 +41,7 @@ from kiro.streaming_core import (
     stream_with_first_token_retry as stream_with_first_token_retry_core,
 )
 from kiro.tokenizer import count_message_tokens, count_tokens, count_tools_tokens
-from kiro.usage_tracking import record_token_usage
+from kiro.usage_tracking import GenerationTimer, record_token_usage
 from kiro.utils import generate_completion_id
 
 if TYPE_CHECKING:
@@ -142,6 +142,10 @@ async def stream_kiro_to_openai_internal(
     completion_id = generate_completion_id()
     created_time = int(time.time())
     first_chunk = False
+    # Timed from inside the generator: the middleware's latency stops when the
+    # handler returns, which for a stream is first-byte time, so it cannot
+    # measure generation.
+    generation = GenerationTimer()
 
     metering_data = None
     context_usage_percentage = None
@@ -408,7 +412,7 @@ async def stream_kiro_to_openai_internal(
             f"total_tokens={total_tokens} ({total_source})"
         )
 
-        record_token_usage(model, prompt_tokens, completion_tokens)
+        record_token_usage(model, prompt_tokens, completion_tokens, generation.elapsed)
 
         yield _openai_sse(final_chunk)
         yield _openai_done()

--- a/kiro/usage_tracking.py
+++ b/kiro/usage_tracking.py
@@ -11,6 +11,7 @@ write per request while still surviving a restart.
 from __future__ import annotations
 
 import threading
+import time
 from contextvars import ContextVar
 from typing import Dict, List, Tuple
 
@@ -24,36 +25,82 @@ ROOT_KEY_ID = "root"
 
 current_api_key_id: ContextVar[str | None] = ContextVar("current_api_key_id", default=None)
 
-# (key_id, model) -> [prompt_tokens, completion_tokens, requests]
+# (key_id, model) -> [prompt_tokens, completion_tokens, requests, generation_ms,
+#                     timed_completion_tokens]
 _pending: Dict[Tuple[str, str], List[int]] = {}
 _lock = threading.Lock()
 
 
-def record_token_usage(model: str, prompt_tokens: int, completion_tokens: int) -> None:
+def record_token_usage(
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    generation_seconds: float | None = None,
+) -> None:
     """Attribute a finished request's tokens to the key that made it.
 
     The model name is normalized first. Callers pass whatever the client sent,
     and `claude-sonnet-4-5`, `claude-sonnet-4.5` and
     `claude-sonnet-4-5-20251001` are one model: storing them separately splits a
     single model's totals across rows that no consumer can rejoin.
+
+    `generation_seconds` is how long the upstream took to produce this response,
+    measured by the caller because only it knows when the stream actually
+    finished. The request log cannot supply it: its latency is recorded when the
+    handler returns, which for a streaming response is first-byte time, not
+    generation time.
+
+    Output tokens are counted twice: once as the real total, and once restricted
+    to requests that were also timed. Throughput has to divide the second by the
+    duration, because the two are otherwise gathered over different request sets -
+    rows predating this column hold tokens with no time at all, and dividing the
+    full total by a partial duration produced 82,752 tok/s on the live store.
     """
     key_id = current_api_key_id.get()
     if key_id is None or not model:
         return
     model = normalize_model_name(model) or model
+    completion = max(0, int(completion_tokens or 0))
+    timed = generation_seconds is not None and generation_seconds > 0
     try:
         with _lock:
-            entry = _pending.setdefault((key_id, model), [0, 0, 0])
+            entry = _pending.setdefault((key_id, model), [0, 0, 0, 0, 0])
             entry[0] += max(0, int(prompt_tokens or 0))
-            entry[1] += max(0, int(completion_tokens or 0))
+            entry[1] += completion
             entry[2] += 1
+            if timed:
+                # Milliseconds keep the accumulator an int, matching the token
+                # counters and the SQLite columns.
+                entry[3] += int((generation_seconds or 0) * 1000)
+                entry[4] += completion
     except Exception as exc:
         # Accounting must never break the proxy data plane.
         logger.debug("Token usage accounting skipped: {}", exc)
 
 
-def drain_pending_usage() -> List[Tuple[str, str, int, int, int]]:
+class GenerationTimer:
+    """Measure how long an upstream response took to produce.
+
+    A plain `time.perf_counter()` pair would do, except that a streaming
+    generator can be abandoned mid-flight; keeping the start in an object makes
+    the elapsed value available wherever the finally-block ends up.
+    """
+
+    __slots__ = ("_started",)
+
+    def __init__(self) -> None:
+        self._started = time.perf_counter()
+
+    @property
+    def elapsed(self) -> float:
+        return max(0.0, time.perf_counter() - self._started)
+
+
+def drain_pending_usage() -> List[Tuple[str, str, int, int, int, int, int]]:
     with _lock:
-        drained = [(key_id, model, counts[0], counts[1], counts[2]) for (key_id, model), counts in _pending.items()]
+        drained = [
+            (key_id, model, counts[0], counts[1], counts[2], counts[3], counts[4])
+            for (key_id, model), counts in _pending.items()
+        ]
         _pending.clear()
     return drained

--- a/tests/unit/test_key_model_usage.py
+++ b/tests/unit/test_key_model_usage.py
@@ -336,3 +336,125 @@ def test_the_merge_is_idempotent(dashboard):
     # A second startup must not double the totals it already folded.
     assert rows["claude-sonnet-4.5"]["totalTokens"] == 15
     assert rows["claude-sonnet-4.5"]["requests"] == 2
+
+
+def test_generation_time_is_recorded_alongside_the_tokens(dashboard):
+    """Throughput is only meaningful if both halves cover the same requests.
+
+    The request log cannot supply the denominator: its latency stops when the
+    handler returns, which for a streaming response is first-byte time. One
+    Kiro model averaged 17ms there while actually generating for seconds.
+    """
+    current_api_key_id.set(ROOT_KEY_ID)
+    record_token_usage("claude-opus-5", 100, 50, 2.5)
+    record_token_usage("claude-opus-5", 100, 30, 1.5)
+
+    dashboard.flush_key_model_usage()
+    row = {r["model"]: r for r in dashboard.key_model_usage()[ROOT_KEY_ID]}["claude-opus-5"]
+
+    assert row["generationSeconds"] == 4.0
+    # 80 output tokens over 4s of generation.
+    assert row["tokensPerSecond"] == 20.0
+
+
+def test_throughput_is_absent_rather_than_zero_without_timing(dashboard):
+    """A row predating the timing column must not claim the model produces nothing."""
+    current_api_key_id.set(ROOT_KEY_ID)
+    record_token_usage("claude-opus-5", 100, 50)
+
+    dashboard.flush_key_model_usage()
+    row = {r["model"]: r for r in dashboard.key_model_usage()[ROOT_KEY_ID]}["claude-opus-5"]
+
+    assert row["generationSeconds"] == 0.0
+    assert row["tokensPerSecond"] is None
+
+
+def test_a_nonpositive_duration_is_ignored(dashboard):
+    """A clock that did not advance is not a measurement of instant generation."""
+    current_api_key_id.set(ROOT_KEY_ID)
+    record_token_usage("claude-opus-5", 10, 5, 0.0)
+    record_token_usage("claude-opus-5", 10, 5, -1.0)
+
+    dashboard.flush_key_model_usage()
+    row = {r["model"]: r for r in dashboard.key_model_usage()[ROOT_KEY_ID]}["claude-opus-5"]
+
+    assert row["generationSeconds"] == 0.0
+    assert row["tokensPerSecond"] is None
+    # The requests themselves still count.
+    assert row["requests"] == 2
+
+
+def test_generation_time_survives_the_normalization_merge(dashboard):
+    """The merge adds every column, so a folded row keeps its timing."""
+    now = int(time.time())
+    with dashboard._db() as conn:
+        conn.executemany(
+            "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests,"
+            " generation_ms, timed_completion_tokens, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+            [
+                (ROOT_KEY_ID, "claude-sonnet-4.5", 100, 40, 4, 2_000, 40, now - 10),
+                (ROOT_KEY_ID, "claude-sonnet-4-5", 100, 60, 6, 3_000, 60, now),
+            ],
+        )
+
+    dashboard.initialize_dashboard_store()
+
+    rows = {r["model"]: r for r in dashboard.key_model_usage()[ROOT_KEY_ID]}
+    assert "claude-sonnet-4-5" not in rows
+    assert rows["claude-sonnet-4.5"]["generationSeconds"] == 5.0
+    # 100 timed output tokens over the combined 5s.
+    assert rows["claude-sonnet-4.5"]["tokensPerSecond"] == 20.0
+
+
+def test_an_existing_store_gains_the_column_without_losing_rows(dashboard):
+    """The additive migration must not rewrite what is already there."""
+    now = int(time.time())
+    with dashboard._db() as conn:
+        conn.execute("DROP TABLE key_model_usage")
+        # Recreate the pre-timing schema, then seed it.
+        conn.execute(
+            """CREATE TABLE key_model_usage (
+                key_id TEXT NOT NULL,
+                model TEXT NOT NULL,
+                prompt_tokens INTEGER NOT NULL DEFAULT 0,
+                completion_tokens INTEGER NOT NULL DEFAULT 0,
+                requests INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (key_id, model)
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests, updated_at)"
+            " VALUES (?,?,?,?,?,?)",
+            (ROOT_KEY_ID, "claude-opus-5", 500, 100, 7, now),
+        )
+
+    dashboard.initialize_dashboard_store()
+
+    row = {r["model"]: r for r in dashboard.key_model_usage()[ROOT_KEY_ID]}["claude-opus-5"]
+    assert row["totalTokens"] == 600
+    assert row["requests"] == 7
+    # Backfilled to 0, which reads as "not measured" rather than as instant.
+    assert row["tokensPerSecond"] is None
+
+
+def test_untimed_tokens_do_not_inflate_throughput(dashboard):
+    """Only timed requests may divide the duration.
+
+    On the live store, 126,943 output tokens accumulated over 960 requests while
+    the timing column held just 1.5s from two freshly measured ones. Dividing the
+    full total by that partial duration reported 82,752 tok/s.
+    """
+    current_api_key_id.set(ROOT_KEY_ID)
+    # Untimed history, as a store predating the column would hold.
+    record_token_usage("claude-opus-5", 50_000, 40_000)
+    # One measured request: 100 tokens in 4s.
+    record_token_usage("claude-opus-5", 100, 100, 4.0)
+
+    dashboard.flush_key_model_usage()
+    row = {r["model"]: r for r in dashboard.key_model_usage()[ROOT_KEY_ID]}["claude-opus-5"]
+
+    # The real totals still include everything.
+    assert row["completionTokens"] == 40_100
+    # But throughput sees only the measured request.
+    assert row["tokensPerSecond"] == 25.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -399,6 +399,70 @@ class TestTokenMetrics:
         assert series[f'kiro_lb_tokens_total{{{labels},direction="output"}}'] == 250
         assert series[f"kiro_lb_key_requests_total{{{labels}}}"] == 5
 
+    def test_generation_time_is_exposed_per_model(self, dashboard):
+        """The denominator for tokens/sec, keyed by model only.
+
+        Throughput is a property of the model and the upstream, not of who asked,
+        and keying it per model keeps it divisible by the token counters without a
+        many-to-one vector match in PromQL.
+        """
+        with dashboard._db() as conn:
+            conn.executemany(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests,"
+                " generation_ms, timed_completion_tokens, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+                [
+                    ("root", "claude-opus-5", 100, 400, 4, 20_000, 400, int(time.time())),
+                    (_KEY_ID, "claude-opus-5", 100, 100, 1, 5_000, 100, int(time.time())),
+                ],
+            )
+
+        series = _series(_render(dashboard))
+
+        # Summed across keys: 25s of generation for this model.
+        assert series['kiro_lb_generation_seconds_total{model="claude-opus-5"}'] == 25.0
+        # The numerator is the timed subset, not kiro_lb_tokens_total: 500 tokens
+        # over 25s is 20 tok/s.
+        assert series['kiro_lb_timed_output_tokens_total{model="claude-opus-5"}'] == 500
+        assert (
+            series['kiro_lb_timed_output_tokens_total{model="claude-opus-5"}']
+            / series['kiro_lb_generation_seconds_total{model="claude-opus-5"}']
+        ) == 20.0
+
+    def test_the_throughput_numerator_excludes_untimed_requests(self, dashboard):
+        """kiro_lb_tokens_total counts every request; the ratio must not use it.
+
+        Dividing the full output total by a partial duration reported 82,752 tok/s
+        on the live store, where most tokens predate the timing column.
+        """
+        with dashboard._db() as conn:
+            conn.executemany(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests,"
+                " generation_ms, timed_completion_tokens, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+                [
+                    # Untimed history plus one measured request worth 100 tokens in 4s.
+                    ("root", "claude-opus-5", 50_000, 40_000, 900, 4_000, 100, int(time.time())),
+                ],
+            )
+
+        series = _series(_render(dashboard))
+
+        assert series['kiro_lb_timed_output_tokens_total{model="claude-opus-5"}'] == 100
+        assert series['kiro_lb_generation_seconds_total{model="claude-opus-5"}'] == 4.0
+        # 25 tok/s, not 40,000/4 = 10,000.
+        assert 100 / 4.0 == 25.0
+
+    def test_generation_time_carries_no_key_label(self, dashboard):
+        with dashboard._db() as conn:
+            conn.execute(
+                "INSERT INTO key_model_usage(key_id, model, prompt_tokens, completion_tokens, requests,"
+                " generation_ms, timed_completion_tokens, updated_at) VALUES (?,?,?,?,?,?,?,?)",
+                (_KEY_ID, "claude-opus-5", 1, 1, 1, 1_000, 1, int(time.time())),
+            )
+
+        for line in _render(dashboard).splitlines():
+            if line.startswith("kiro_lb_generation_seconds_total"):
+                assert "key_id" not in line and "key_name" not in line
+
     def test_an_unnamed_key_falls_back_to_its_id(self, dashboard):
         with dashboard._db() as conn:
             conn.execute(


### PR DESCRIPTION
## Summary

Adds a real tokens/sec metric and a **Throughput** row to the Grafana dashboard, next to `Mean latency by model`.

## Why the existing latency could not be reused

I checked before building on it. `kiro_lb_request_latency_seconds` comes from the request-log middleware (`main.py:623`), which records when the handler returns — and a streaming handler returns a `StreamingResponse` immediately, so that is first-byte time, not generation time. The live request log makes it obvious:

```
claude-sonnet-4-5   n=1087  min=0ms     avg=17ms     max=2,060ms
claude-opus-5       n=4814  min=1583ms  avg=3,867ms  max=197,633ms
```

A 17ms average with a 0ms floor is not generation. Dividing tokens by it would have overstated throughput by orders of magnitude.

## What was added

The streaming generators time the upstream response themselves (`GenerationTimer`, started inside the generator so it survives the whole stream) and pass the duration to `record_token_usage`. Wired on **both** protocols and **both** streaming and non-streaming paths, per the project rule. Two columns arrive by additive migration; the exporter pairs them as `kiro_lb_generation_seconds_total` and `kiro_lb_timed_output_tokens_total`, keyed by model only — throughput belongs to the model and the upstream, not to the caller, and per-model keys divide cleanly in PromQL without a many-to-one match.

**Output tokens are counted twice on purpose.** Once as the real total, once restricted to timed requests. Only the second may divide the duration. I found this the hard way: after deploying the first version, the cumulative ratio read **82,752 tok/s**, because 126,943 output tokens had accumulated over 960 requests while the timing column held 1.5s from two freshly measured ones. `kiro_lb_tokens_total` still reports every token; the ratio uses the matched subset.

## Verification against live traffic

Two streams, 21.7s wall clock:

```
generation delta: 17.64s, timed output delta: 655 tokens  =>  37.1 tok/s
```

That is a plausible Sonnet-class rate, and it is well under the wall clock as it should be. Prometheus returns the same through the panel's own query (36.1 tok/s at the time of the check). All 35 dashboard expressions verified against live Prometheus — zero errors, zero empty.

New panels: per-model tok/s, and pool-wide tok/s beside generation-seconds-per-second, which reads as concurrent generations (2 means two responses generating in parallel).

## Testing

- `pytest -q` — 1837 passed (9 new, including one that pins the 82,752 tok/s bug)
- `ruff`, `mypy` clean; frontend untouched
- Dashboard installed via the provisioning reload API, so Grafana was not restarted (uptime still 5 days); previous JSON backed up on the host

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real generation throughput (tokens/sec) by timing upstream generation and charting it in Grafana. This makes tokens/sec accurate for streaming and non-streaming requests.

- **New Features**
  - Measure generation time inside the OpenAI and Anthropic generators (streaming and non‑streaming) and pass it to `record_token_usage`.
  - Store `generation_ms` and `timed_completion_tokens` per (key, model); API exposes `generationSeconds` and `tokensPerSecond` (only when timing exists).
  - Export two new Prometheus counters keyed by model: `kiro_lb_generation_seconds_total` (denominator) and `kiro_lb_timed_output_tokens_total` (numerator). This avoids inflating throughput with untimed history.
  - Add a Grafana “Throughput” row: per‑model tok/s, plus pool‑wide tok/s and “concurrent generations”.
  - Clarify in docs that request latency is first‑byte time for streams and cannot be used for throughput.

- **Migration**
  - Additive migration adds `generation_ms` and `timed_completion_tokens` to `key_model_usage`; existing rows default to 0 and are excluded from tok/s.
  - No manual steps. Dashboard updates are provisioned via the reload API.

<sup>Written for commit 7aa709f64e0b0e0dcd7aa87d129a09c217578feb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

