### PR TITLE
Tame the legends on the per-model Grafana panels

### DIFF
--- a/deploy/grafana/kiro-lb.json
+++ b/deploy/grafana/kiro-lb.json
@@ -653,14 +653,18 @@
             "mean",
             "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true,
+          "width": 260
         },
         "tooltip": {
-          "hideZeros": false,
+          "hideZeros": true,
           "mode": "multi",
-          "sort": "desc"
+          "sort": "desc",
+          "maxHeight": 320
         }
       },
       "targets": [
@@ -846,14 +850,18 @@
             "mean",
             "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true,
+          "width": 260
         },
         "tooltip": {
-          "hideZeros": false,
+          "hideZeros": true,
           "mode": "multi",
-          "sort": "desc"
+          "sort": "desc",
+          "maxHeight": 320
         }
       },
       "targets": [
@@ -988,7 +996,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Generation throughput: timed output tokens divided by the upstream generation time that produced them. Both counters cover the same requests - dividing kiro_lb_tokens_total instead would mix in requests that were never timed. This is not the request latency on the Traffic row: that stops at first byte for a stream.",
+      "description": "Generation throughput: timed output tokens divided by the upstream generation time that produced them. Both counters cover the same requests - dividing kiro_lb_tokens_total instead would mix in requests that were never timed. This is not the request latency on the Traffic row: that stops at first byte for a stream. Models that have never been measured are filtered out; one with timing in its history keeps its line while idle, so a quiet spell reads as quiet rather than as the model disappearing.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1055,14 +1063,18 @@
             "mean",
             "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true,
+          "width": 260
         },
         "tooltip": {
-          "hideZeros": false,
+          "hideZeros": true,
           "mode": "multi",
-          "sort": "desc"
+          "sort": "desc",
+          "maxHeight": 320
         }
       },
       "targets": [
@@ -1072,7 +1084,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum by (model) (rate(kiro_lb_timed_output_tokens_total{job=\"kiro-lb-usage\"}[5m])) / clamp_min(sum by (model) (rate(kiro_lb_generation_seconds_total{job=\"kiro-lb-usage\"}[5m])), 0.001)",
+          "expr": "(sum by (model) (rate(kiro_lb_timed_output_tokens_total{job=\"kiro-lb-usage\"}[5m])) / clamp_min(sum by (model) (rate(kiro_lb_generation_seconds_total{job=\"kiro-lb-usage\"}[5m])), 0.001))\n  and on (model) (sum by (model) (kiro_lb_generation_seconds_total{job=\"kiro-lb-usage\"}) > 0)",
           "legendFormat": "{{model}}",
           "range": true,
           "refId": "A"
@@ -1369,14 +1381,18 @@
             "mean",
             "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true,
+          "width": 260
         },
         "tooltip": {
-          "hideZeros": false,
+          "hideZeros": true,
           "mode": "multi",
-          "sort": "desc"
+          "sort": "desc",
+          "maxHeight": 320
         }
       },
       "targets": [


### PR DESCRIPTION
## Summary

Twenty of the 21 model series are flat zero at any given moment, so each per-model chart carried 20 anonymous legend rows of noise.

## Two kinds of zero, two fixes

I started by filtering every per-model panel in PromQL, then measured and found that only works for one of them:

```
models with lifetime requests: 21
models active in last 5m:       1   (claude-opus-5)
```

- **`Output tokens per second by model`** genuinely has series that were *never measured* — the counter is new, so most models have no timing at all. Those are filtered in PromQL, keyed on lifetime `kiro_lb_generation_seconds_total` rather than on the rate, so a model that is merely idle keeps its line. 20 series → 2.
- **The other three** (`Requests / min`, `Mean latency`, `Tokens / min`) are a different situation: all 21 models have real history and are simply quiet right now. Filtering those in PromQL would erase a model from the chart the instant it goes quiet, which hides exactly the transition an operator is watching for.

For those, Grafana's own controls do the job without lying about the data: a table legend on the right sorted by **Max descending**, so busy models float to the top and quiet ones are visibly `0` instead of crowding the list, plus `hideZeros` on the tooltip so hovering does not enumerate twenty empty series.

## Verification

Rendered the live dashboard after deploying:

- tok/s legend down to its 2 measured models
- Traffic panels sort `claude-opus-9.2/min` to the top of a compact scrollable table
- All 35 dashboard expressions still return data — zero errors, zero empty
- `pytest -q` 1837 passed (the provisioning tests still hold: every queried metric and label matches the exporter)

Installed via the provisioning reload API, so Grafana was not restarted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tames noisy legends on per-model Grafana panels so active models stand out and quiet ones don’t clutter the UI. Filters never-measured series on the tok/s panel and uses right-side table legends with Max sorting and zero-hiding elsewhere.

- **Bug Fixes**
  - Output tokens/sec: PromQL now keeps idle models but hides never-measured ones using lifetime `kiro_lb_generation_seconds_total`.
  - Requests/min, Mean latency, Tokens/min: switch legend to right-side table (sort by Max desc, width 260) and enable tooltip `hideZeros` with a capped height for cleaner hovers.

<sup>Written for commit 5c5d07245d70b6eb62fa5648db335d9881511806. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

