### PR TITLE
fix(auth): persist rotated refresh tokens for social logins

### DIFF
--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -39,6 +39,7 @@ from kiro.device_login import (
     resolve_provider,
     start_device_login,
     write_builder_id_credentials,
+    write_social_credentials,
 )
 from kiro.metrics import CONTENT_TYPE as METRICS_CONTENT_TYPE
 from kiro.metrics import render_metrics
@@ -727,17 +728,19 @@ async def dashboard_register_device_login(flow_id: str, request: Request) -> dic
     if not refresh_token:
         raise HTTPException(status_code=502, detail="Kiro approved the login without a refresh token")
 
+    # Both providers rotate the refresh token on every refresh, so both need a
+    # file the auth manager can write the rotated token back to. An inline
+    # refresh_token entry has none: the account survived one token lifetime and
+    # then answered 401 "Bad credentials" on the next cold init.
     if flow.provider == "BuilderId":
-        # Builder ID refresh needs the client registration, so it is stored as a
-        # JSON credential file next to the pool config rather than inline.
         credential_path = write_builder_id_credentials(flow, _DATA_DIR / "logins")
-        registration = {"type": "json", "path": str(credential_path)}
+        registration: dict[str, Any] = {"type": "json", "path": str(credential_path)}
     else:
-        registration = {
-            "type": "refresh_token",
-            "refreshToken": refresh_token,
-            "profileArn": flow.token.get("profileArn") or "",
-        }
+        credential_path = write_social_credentials(flow, _DATA_DIR / "logins")
+        registration = {"type": "json", "path": str(credential_path)}
+        profile_arn = flow.token.get("profileArn")
+        if profile_arn:
+            registration["profileArn"] = profile_arn
 
     try:
         result = await register_account(request.app.state.account_manager, registration)

--- a/kiro/device_login.py
+++ b/kiro/device_login.py
@@ -11,6 +11,8 @@ the polling logic is deliberately not shared:
 - Social (Google / GitHub) on ``prod.us-east-1.auth.desktop.kiro.dev``. Pending
   is HTTP 200 with a ``status`` field, timings are milliseconds, and the response
   carries ``profileArn``, which routes the account to ``runtime.kiro.dev``.
+  Refreshing rotates the refresh token, so the credentials must live in a file
+  the auth manager can write back to.
 - Builder ID (AWS SSO OIDC) on ``oidc.{region}.amazonaws.com``. Pending is HTTP
   400 with an ``authorization_pending`` code, timings are seconds, and refreshing
   needs the client registration, so the client id and secret are stored with the
@@ -35,6 +37,8 @@ from loguru import logger
 
 AUTH_HOST = "https://prod.us-east-1.auth.desktop.kiro.dev"
 CLIENT_ID = "kiro-cli"
+# The social auth host is pinned to us-east-1, so refreshes resolve there too.
+SOCIAL_REGION = "us-east-1"
 
 BUILDER_ID_START_URL = "https://view.awsapps.com/start"
 BUILDER_ID_REGION = "us-east-1"
@@ -332,29 +336,65 @@ async def await_approval(flow_id: str, timeout_seconds: float) -> DeviceFlow:
     return flow
 
 
+def _write_credential_file(path: Path, document: Dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+    os.chmod(path, 0o600)
+    return path
+
+
+def _expires_at(expires_in: Any) -> str:
+    seconds = float(expires_in or 3600)
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + seconds))
+
+
 def write_builder_id_credentials(flow: DeviceFlow, directory: Path) -> Path:
     """Persist a Builder ID login as a JSON credential file and return its path.
 
-    Builder ID refresh needs the client registration, not just the refresh token,
-    so it cannot use the inline refresh_token entry the social flow uses. The
-    field names are the ones auth.py reads, and clientId/clientSecret are what
+    Builder ID refresh needs the client registration, not just the refresh token.
+    The field names are the ones auth.py reads, and clientId/clientSecret are what
     make it detect AWS SSO OIDC rather than the Kiro Desktop endpoint.
     """
     if not flow.token or not flow.registration:
         raise ValueError("Builder ID login is not approved")
 
-    directory.mkdir(parents=True, exist_ok=True)
-    path = directory / f"builder-id-{flow.id}.json"
-    expires_in = float(flow.token.get("expiresIn") or 3600)
     document = {
         "refreshToken": flow.token.get("refreshToken"),
         "accessToken": flow.token.get("accessToken"),
-        "expiresAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + expires_in)),
+        "expiresAt": _expires_at(flow.token.get("expiresIn")),
         "region": flow.registration["region"],
         "clientId": flow.registration["clientId"],
         "clientSecret": flow.registration["clientSecret"],
         "startUrl": BUILDER_ID_START_URL,
     }
-    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
-    os.chmod(path, 0o600)
-    return path
+    return _write_credential_file(directory / f"builder-id-{flow.id}.json", document)
+
+
+def write_social_credentials(flow: DeviceFlow, directory: Path) -> Path:
+    """Persist a social login as a JSON credential file and return its path.
+
+    The Kiro Desktop refresh endpoint rotates the refresh token and rejects the
+    previous one with 401 "Bad credentials". An inline ``refresh_token`` pool
+    entry has no file to write the rotation back to, so the account worked for one
+    token lifetime and then died on the next cold init. A JSON file gives
+    ``_save_credentials_to_file`` somewhere to persist the rotated token.
+
+    No clientId/clientSecret is written: their absence is what makes auth.py keep
+    using the Kiro Desktop endpoint instead of AWS SSO OIDC.
+    """
+    if not flow.token:
+        raise ValueError(f"{flow.provider} login is not approved")
+
+    document: Dict[str, Any] = {
+        "refreshToken": flow.token.get("refreshToken"),
+        "accessToken": flow.token.get("accessToken"),
+        "expiresAt": _expires_at(flow.token.get("expiresIn")),
+        "region": SOCIAL_REGION,
+    }
+    profile_arn = flow.token.get("profileArn")
+    if profile_arn:
+        document["profileArn"] = profile_arn
+    identity_provider = flow.token.get("identityProvider")
+    if identity_provider:
+        document["identityProvider"] = identity_provider
+    return _write_credential_file(directory / f"social-{flow.provider.lower()}-{flow.id}.json", document)

--- a/tests/unit/test_device_login.py
+++ b/tests/unit/test_device_login.py
@@ -8,6 +8,7 @@ milliseconds, and the poll response carries the profileArn directly.
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -257,9 +258,44 @@ async def test_registering_an_approved_login_adds_the_account(dashboard, tmp_pat
     assert result["provider"] == "Google"
 
     entries = __import__("json").loads((tmp_path / "credentials.json").read_text())
-    assert entries[0]["type"] == "refresh_token"
-    assert entries[0]["refresh_token"] == APPROVED["refreshToken"]
+    # The Kiro Desktop endpoint rotates the refresh token and answers 401 "Bad
+    # credentials" for the previous one, so a social login must be stored as a
+    # JSON file that _save_credentials_to_file can write the rotation back to.
+    assert entries[0]["type"] == "json"
     assert entries[0]["profile_arn"] == APPROVED["profileArn"]
+
+    document = __import__("json").loads(Path(entries[0]["path"]).read_text())
+    assert document["refreshToken"] == APPROVED["refreshToken"]
+    assert document["accessToken"] == APPROVED["accessToken"]
+    assert document["profileArn"] == APPROVED["profileArn"]
+    # No clientId/clientSecret: their absence keeps auth.py on the Kiro Desktop
+    # refresh endpoint instead of AWS SSO OIDC.
+    assert "clientId" not in document
+    assert "clientSecret" not in document
+
+
+@pytest.mark.asyncio
+async def test_a_social_account_persists_its_rotated_refresh_token(dashboard, tmp_path):
+    """The rotation must reach disk, or the account dies on the next cold init."""
+    with patch("kiro.device_login.httpx.AsyncClient", return_value=_client(_Response(AUTHORIZATION))):
+        flow = await start_device_login("Google")
+    with patch("kiro.device_login.httpx.AsyncClient", return_value=_client(_Response(APPROVED))):
+        await poll_device_login(flow.id)
+
+    path = device_login.write_social_credentials(flow, tmp_path / "logins")
+
+    from kiro.auth import AuthType, KiroAuthManager
+
+    manager = KiroAuthManager(creds_file=str(path))
+    assert manager.auth_type is AuthType.KIRO_DESKTOP
+
+    manager._refresh_token = "rotated-refresh-token"
+    manager._access_token = "rotated-access-token"
+    manager._save_credentials_to_file()
+
+    document = __import__("json").loads(path.read_text())
+    assert document["refreshToken"] == "rotated-refresh-token"
+    assert document["accessToken"] == "rotated-access-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약

Kiro Desktop의 `/refreshToken`은 갱신할 때마다 refresh token을 교체하고 이전 토큰을 무효화합니다. 대시보드 소셜 로그인(Google/GitHub)은 계정을 `credentials.json`에 `type: refresh_token`으로 인라인 저장했는데, 그러면 `_save_credentials_to_file`이 쓸 파일이 없어서 그냥 리턴합니다. 결과적으로 교체된 토큰이 메모리에만 남고, 재시작이나 blue/green 플립 후에는 **자기 자신이 무효화시킨 원래 토큰**으로 다시 로그인해서 `401 Bad credentials`가 났습니다.

라이브 풀에서 실제로 확인한 증상:

```
POST https://prod.us-east-1.auth.desktop.kiro.dev/refreshToken
→ 401 {"message":"Bad credentials"}
```

Builder ID가 이 문제를 피한 건 우연입니다. 자체 refresh에 client registration이 필요해서 애초에 JSON 파일로 저장됐고, 덕분에 교체분이 디스크에 남았습니다.

## 변경

- `kiro/device_login.py` — `write_social_credentials()` 추가. `data/logins/social-<provider>-<id>.json`, 권한 0600. `clientId`/`clientSecret`은 의도적으로 생략: 그게 없어야 `_detect_auth_type`이 AWS SSO OIDC 대신 Kiro Desktop 엔드포인트를 유지합니다. 파일 쓰기와 `expiresAt` 계산은 Builder ID 경로와 공유합니다.
- `kiro/dashboard.py` — 소셜 등록을 `type: json`으로 저장. `profileArn`은 풀 엔트리에 그대로 실어서 런타임 호스트 라우팅은 그대로입니다.
- `tests/unit/test_device_login.py` — 등록 결과를 `type: json` + 파일 내용으로 고정하고, `KiroAuthManager._save_credentials_to_file()`을 실제로 돌려 교체된 토큰이 디스크까지 가는지 검증하는 테스트 추가.

## 테스트

- `pytest -q` → 1838 passed
- `ruff format --check`, `ruff check`, `mypy` → 모두 통과
- 홈랩에 blue/green 플립으로 배포 완료. edge/L7 `/health` 200, 요청 유실 없음. 죽은 계정 제거 후 blue가 10개 계정 로드, 401 재시도 루프 멈춤 확인.

## 남은 것 (이 PR 범위 밖)

기존 인라인 엔트리는 소급 적용되지 않습니다. 이미 등록된 소셜 계정은 삭제 후 재로그인해야 파일로 저장됩니다.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist rotated refresh tokens for Google/GitHub logins by storing them as JSON credential files, preventing 401 “Bad credentials” after restarts or blue/green flips. Host routing stays the same and refreshes continue to use the Kiro Desktop endpoint.

- **Bug Fixes**
  - Save social logins as `type: json` files at `data/logins/social-<provider>-<id>.json` (0600) instead of inline `type: refresh_token`.
  - Added `write_social_credentials()`; shares expiry handling with Builder ID and omits `clientId`/`clientSecret` to keep the Kiro Desktop refresh path.
  - Keep `profileArn` on the pool entry; include `profileArn`/`identityProvider` in the file when present.
  - Tests verify JSON storage and that rotated tokens are written back via `_save_credentials_to_file()`.

- **Migration**
  - Existing inline social accounts won’t auto-migrate. Delete and re-login to create the credential file.

<sup>Written for commit a1afa33b5db859bf933182a833412596d9687a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

