### PR TITLE
Unify gateway state in SQLite and harden lifecycle handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@
 # Password to protect YOUR proxy server
 # This is NOT a token from anywhere - YOU make it up!
 # Use this same value as api_key when connecting to your gateway
-# Example: "my-super-secret-password-123" or any secure string
-PROXY_API_KEY="my-super-secret-password-123"
+# Generate one with: openssl rand -hex 32
+PROXY_API_KEY="replace-with-a-long-random-value"
 
 # ===========================================
 # OPTION 1: Kiro IDE credentials (JSON file)
@@ -123,22 +123,18 @@ PROXY_API_KEY="my-super-secret-password-123"
 # 
 # When false (legacy mode):
 #   - Uses single account without failover
-#   - credentials.json is recreated from .env on every startup
+#   - The environment credential replaces the legacy single-account policy
 #   - Simpler for single-account setups
 #
 # When true (multi-account mode):
 #   - Enables full failover loop with Circuit Breaker and sticky behavior
 #   - Works even with single account (unified architecture)
-#   - On first startup: automatically migrates .env → credentials.json (one-time)
-#   - After migration: credentials.json takes priority, .env is ignored
-#   - Manual credential management via credentials.json
+#   - Existing credentials.json/state.json are imported once into SQLite
+#   - After import the private SQLite store is authoritative
 #
 # ACCOUNT_SYSTEM=false
 
-# Path to credentials configuration file
-# Automatically created from .env on first startup (if doesn't exist)
-# After creation, edit this file directly to manage accounts
-# See credentials.json.example for format
+# Legacy credentials/state import paths. Source files are not modified or deleted.
 # ACCOUNTS_CONFIG_FILE="credentials.json"
 
 # Path to runtime state file
@@ -168,7 +164,7 @@ PROXY_API_KEY="my-super-secret-password-123"
 # Cache is refreshed only when account is used (not in background)
 # ACCOUNT_CACHE_TTL=43200
 
-# Interval for periodic state.json saving in seconds
+# Interval for periodic SQLite runtime-state saving in seconds
 # STATE_SAVE_INTERVAL_SECONDS=10
 
 # ===========================================
@@ -200,8 +196,13 @@ PROXY_API_KEY="my-super-secret-password-123"
 # Generate one with: openssl rand -base64 32
 # DASHBOARD_PASSWORD="replace-with-a-unique-secret"
 
-# Metadata-only SQLite request log location. Prompts, responses, API keys, and
-# Kiro credentials are never persisted by the dashboard.
+# Force the dashboard session cookie's Secure flag. When unset, HTTPS is
+# detected from the request scheme or X-Forwarded-Proto.
+# DASHBOARD_SECURE_COOKIE="true"
+
+# Private unified SQLite location. It stores account source policy, runtime
+# state, device-login refresh credentials, and dashboard metadata. It never
+# stores prompts, responses, or raw client API keys.
 # DASHBOARD_DATA_DIR="data"
 
 # ===========================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ kiro-lb-python/
 │   └── static/              # BUILD OUTPUT of frontend/ — never hand-edit
 ├── frontend/                # Bun + Vite + React 19 dashboard source
 ├── tests/                   # pytest, 1837 tests; network-blocked by conftest
-├── data/                    # Runtime credentials/state/sqlite (gitignored)
+├── data/                    # Unified private dashboard.sqlite3 store (gitignored)
 ├── deploy/                  # Grafana dashboard + Pushgateway units for /metrics
 ├── debug_logs/              # Capture output when DEBUG_MODE is on (gitignored)
 ├── pyproject.toml           # ruff + mypy config only; the project is not packaged
@@ -48,7 +48,8 @@ they held are folded into this file; do not link to them.
 | Account failover / rotation | `kiro/account_manager.py` | Circuit breaker, global sticky, lazy init |
 | Credentials + host selection | `kiro/auth.py`, `kiro/config.py` | 4 sources; Builder ID routes to a different host |
 | Add an account by browser login | `kiro/device_login.py` | Social + Builder ID device flows |
-| Dashboard API / SQLite store | `kiro/dashboard.py` | 18 routes under `/api/dashboard`, plus `/` and `/metrics` |
+| Shared SQLite persistence | `kiro/store.py` | Accounts, runtime state, internal login credentials; mode 0600/WAL |
+| Dashboard API | `kiro/dashboard.py` | 18 routes under `/api/dashboard`, plus `/` and `/metrics` |
 | Prometheus exposition | `kiro/metrics.py` | Pure renderer; the route and its auth live in `dashboard.py` |
 | Grafana dashboard / metrics wiring | `deploy/` | Dashboard JSON is asserted against the exporter by `tests/unit/test_dashboard_provisioning.py` |
 | Per-key token accounting | `kiro/usage_tracking.py` | ContextVar identity, batched flush |
@@ -125,8 +126,9 @@ trusting a pin here.
   `/v1`, and `/v1` API keys cannot call `/api/dashboard`. `/metrics` is a third
   plane: it takes a `/v1` bearer key (a scraper cannot hold a cookie) and refuses
   dashboard sessions.
-- Dashboard SQLite stores metadata only — no prompts, completions, raw keys, or
-  refresh tokens. New columns arrive via additive `PRAGMA table_info` +
+- The private SQLite store contains dashboard metadata plus account policy,
+  runtime state, and upstream refresh credentials for internal device logins;
+  it never stores prompts, completions, or raw client API keys. New columns arrive via additive `PRAGMA table_info` +
   `ALTER TABLE` migration (`dashboard.py:96`, `:147`), never a destructive rewrite.
 - Proxy env vars are set before any httpx client exists (`main.py:181`); creating
   a client earlier silently ignores the VPN/proxy config.
@@ -235,11 +237,11 @@ multi-arch images on non-PR runs. Tool versions are pinned in
   rather than restarting the container.
 - `/metrics` is not recorded by the request-metrics middleware (`main.py:623`
   filters to `/v1/`), so scraping does not inflate the counters it reports.
-- `main.py` refuses to start when `credentials.json` has no usable account, even
+- `main.py` refuses to start when the unified store has no usable account, even
   with `ACCOUNT_SYSTEM=false`; set `KIRO_CLI_DB_FILE` for a standalone run.
   `validate_configuration` (`main.py:201`) skips legacy `.env` checks entirely
-  once `credentials.json` exists. Legacy mode always recreates
-  `credentials.json` from `.env` (`main.py:401`).
+  once legacy credentials have been imported. Legacy mode replaces its SQLite
+  account policy from `.env` without writing gateway-owned JSON.
 - The OpenAI `developer` role must be folded into the system prompt
   (`converters_openai.py:149`); dropping it makes Kiro answer `REQUEST_BODY_INVALID`.
 - The oversize rejection is `CONTENT_LENGTH_EXCEEDS_THRESHOLD`, which names

--- a/deploy/bluegreen/deploy.sh
+++ b/deploy/bluegreen/deploy.sh
@@ -4,6 +4,8 @@
 #
 # Flip = render HAProxy cfg for the next slot + soft-reload (USR2).
 # No Runtime API socket (permission / volume pain); persisted cfg is source of truth.
+# Only the active slot may mutate shared runtime state. The idle slot overlaps
+# solely for startup health and is stopped immediately after the cutover proof.
 #
 # Usage:
 #   ./deploy/bluegreen/deploy.sh              # build idle slot, flip, stop old
@@ -56,6 +58,74 @@ write_active() {
   printf '%s\n' "$1" >"$SLOT_FILE"
 }
 
+set_runtime_writer() {
+  local slot=$1
+  local attempt
+  for attempt in $(seq 1 120); do
+    if KIRO_RUNTIME_SLOT="$slot" ROOT="$ROOT" python3 <<'PY'
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+path = Path(os.environ["ROOT"]) / "data" / "dashboard.sqlite3"
+path.parent.mkdir(parents=True, exist_ok=True)
+with sqlite3.connect(path) as conn:
+    conn.execute("BEGIN IMMEDIATE")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS runtime_writer (id INTEGER PRIMARY KEY CHECK (id = 1), slot TEXT NOT NULL)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS credential_refresh_leases "
+        "(account_id TEXT PRIMARY KEY, owner TEXT NOT NULL, expires_at REAL NOT NULL)"
+    )
+    conn.execute("DELETE FROM credential_refresh_leases WHERE expires_at <= ?", (time.time(),))
+    if conn.execute("SELECT 1 FROM credential_refresh_leases LIMIT 1").fetchone():
+        raise SystemExit(75)
+    conn.execute(
+        "INSERT INTO runtime_writer(id, slot) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET slot=excluded.slot",
+        (os.environ["KIRO_RUNTIME_SLOT"],),
+    )
+PY
+    then
+      log "runtime-state writer=$slot"
+      return
+    fi
+    [[ "$attempt" -eq 120 ]] && die "timed out waiting for credential refresh leases before writer handoff"
+    sleep 0.25
+  done
+}
+
+ensure_handoff_secret() {
+  if [[ -n "${HANDOFF_SECRET:-}" ]]; then
+    export HANDOFF_SECRET
+    return
+  fi
+  HANDOFF_SECRET="$(ROOT="$ROOT" python3 <<'PY'
+import os
+import secrets
+import sqlite3
+from pathlib import Path
+
+path = Path(os.environ["ROOT"]) / "data" / "dashboard.sqlite3"
+path.parent.mkdir(parents=True, exist_ok=True)
+with sqlite3.connect(path) as conn:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS deployment_control "
+        "(id INTEGER PRIMARY KEY CHECK (id = 1), handoff_secret TEXT NOT NULL)"
+    )
+    row = conn.execute("SELECT handoff_secret FROM deployment_control WHERE id = 1").fetchone()
+    if row is None:
+        value = secrets.token_urlsafe(32)
+        conn.execute("INSERT INTO deployment_control(id, handoff_secret) VALUES (1, ?)", (value,))
+    else:
+        value = row[0]
+print(value)
+PY
+)"
+  export HANDOFF_SECRET
+}
+
 render_haproxy_cfg() {
   local active=$1
   local blue_state green_state
@@ -96,6 +166,30 @@ wait_http() {
     sleep 1
   done
   return 1
+}
+
+handoff_post() {
+  local port=$1 action=$2
+  curl -fsS -m 120 -X POST -H "X-Handoff-Secret: $HANDOFF_SECRET" \
+    "http://127.0.0.1:${port}/_internal/handoff/${action}" >/dev/null
+}
+
+wait_handoff_ready() {
+  local port=$1 tries=${2:-60} i
+  for i in $(seq 1 "$tries"); do
+    if curl -fsS -m 2 -H "X-Handoff-Secret: $HANDOFF_SECRET" \
+      "http://127.0.0.1:${port}/_internal/handoff/ready" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+handoff_status() {
+  local port=$1
+  curl -sS -m 2 -o /dev/null -w '%{http_code}' -H "X-Handoff-Secret: $HANDOFF_SECRET" \
+    "http://127.0.0.1:${port}/_internal/handoff/ready" 2>/dev/null || true
 }
 
 edge_slot_header() {
@@ -149,8 +243,10 @@ prove_slot() {
 }
 
 cmd_init() {
+  ensure_handoff_secret
   log "init: render cfg active=blue"
   write_active blue
+  set_runtime_writer blue
   render_haproxy_cfg blue
 
   log "init: build image"
@@ -179,10 +275,12 @@ cmd_init() {
 }
 
 cmd_boot() {
+  ensure_handoff_secret
   local active svc
   active="$(read_active)"
   svc="$(slot_service "$active")"
   log "boot: active=$active"
+  set_runtime_writer "$active"
   render_haproxy_cfg "$active"
   "${COMPOSE[@]}" up -d --no-build "$svc" edge
   wait_http http://10.10.10.10:8000/health 60 || die "boot edge health failed"
@@ -191,6 +289,7 @@ cmd_boot() {
 }
 
 cmd_deploy() {
+  ensure_handoff_secret
   local no_build=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -199,21 +298,80 @@ cmd_deploy() {
     esac
   done
 
-  local current next cur_svc next_svc next_port
+  local current next cur_svc next_svc current_port next_port
   current="$(read_active)"
   next="$(other_slot "$current")"
   cur_svc="$(slot_service "$current")"
   next_svc="$(slot_service "$next")"
+  current_port="$(slot_port "$current")"
   next_port="$(slot_port "$next")"
+
+  local deploy_succeeded=0 legacy_point_of_no_return=0
+  rollback_deploy() {
+    local status=$?
+    [[ "$deploy_succeeded" -eq 1 ]] && return "$status"
+    trap - EXIT
+    if [[ "$legacy_point_of_no_return" -eq 1 ]]; then
+      log "legacy migration passed its credential-rotation point of no return; leaving the old image stopped"
+      log "fix the new slot forward, then rerun this deploy command"
+      return "$status"
+    fi
+    log "deploy failed: restoring writer, HAProxy, and active slot to $current"
+    set +e
+    "${COMPOSE[@]}" up -d --no-build "$cur_svc" >/dev/null
+    set_runtime_writer "$current"
+    handoff_post "$current_port" activate >/dev/null 2>&1 || true
+    render_haproxy_cfg "$current"
+    soft_reload_edge
+    write_active "$current"
+    set -e
+    return "$status"
+  }
+  trap rollback_deploy EXIT
 
   [[ -f "$GENERATED" ]] || render_haproxy_cfg "$current"
 
   log "deploy: active=$current → next=$next"
+  set_runtime_writer "$current"
 
   if [[ "$no_build" -eq 0 ]]; then
     log "build $next_svc (traffic stays on $current)"
     "${COMPOSE[@]}" build "$next_svc"
   fi
+
+  # The release that introduced SQLite handoff cannot quiesce an older active
+  # image. For that one transition, stop it gracefully before the new image
+  # imports its final credentials.json/state.json snapshot. Later releases use
+  # the zero-downtime handoff path below.
+  local current_handoff_status
+  current_handoff_status="$(handoff_status "$current_port")"
+  case "$current_handoff_status" in
+    200) ;;
+    404)
+      log "legacy active slot detected; performing one-time graceful migration cutover"
+      "${COMPOSE[@]}" stop "$cur_svc" >/dev/null
+      # Once the new image can refresh credentials, rolling back to an image
+      # that cannot read SQLite overlays could invalidate authentication.
+      legacy_point_of_no_return=1
+      set_runtime_writer "$next"
+      "${COMPOSE[@]}" up -d --no-build --force-recreate "$next_svc"
+      wait_http "http://127.0.0.1:${next_port}/health" 90 || die "$next slot health failed"
+      wait_handoff_ready "$next_port" 30 || die "new slot readiness failed"
+      render_haproxy_cfg "$next"
+      soft_reload_edge
+      prove_slot "$next"
+      write_active "$next"
+      wait_http http://kiro.minpeter.internal/health 15 || die "post-migration L7 failed"
+      show_status
+      deploy_succeeded=1
+      trap - EXIT
+      log "deploy OK (legacy migration cutover)"
+      return
+      ;;
+    403) die "active slot rejected the handoff secret; refusing to treat it as legacy" ;;
+    503) die "active slot has handoff support but is not active; inspect slot ownership before deploying" ;;
+    *) die "could not verify active-slot handoff support (HTTP ${current_handoff_status:-000})" ;;
+  esac
 
   log "start $next_svc"
   "${COMPOSE[@]}" up -d --no-build --force-recreate "$next_svc"
@@ -224,11 +382,18 @@ cmd_deploy() {
   ensure_edge
   wait_http http://10.10.10.10:8000/health 30 || die "edge unhealthy before flip"
 
-  log "flip: render active=$next + soft-reload"
-  write_active "$next"
+  # Drain the old writer before changing ownership. The standby started
+  # quiesced, then reloads this final snapshot before it can receive traffic.
+  log "quiesce $current and persist final runtime state"
+  handoff_post "$current_port" quiesce || die "old slot handoff drain failed"
+  log "handoff writer=$next; reload standby"
+  set_runtime_writer "$next"
+  handoff_post "$next_port" activate || die "new slot activation failed"
+  wait_handoff_ready "$next_port" 30 || die "new slot handoff readiness failed"
   render_haproxy_cfg "$next"
   soft_reload_edge
   prove_slot "$next"
+  write_active "$next"
 
   log "stop old $cur_svc"
   "${COMPOSE[@]}" stop "$cur_svc" >/dev/null || true
@@ -237,6 +402,8 @@ cmd_deploy() {
   wait_http http://kiro.minpeter.internal/health 15 || die "post-stop L7 failed"
   prove_slot "$next"
   show_status
+  deploy_succeeded=1
+  trap - EXIT
   log "deploy OK"
 }
 

--- a/docker-compose.homelab.yml
+++ b/docker-compose.homelab.yml
@@ -14,6 +14,22 @@
 
 name: kiro-lb
 
+x-kiro-environment: &kiro-environment
+  SERVER_HOST: "0.0.0.0"
+  SERVER_PORT: "8000"
+  ACCOUNT_SYSTEM: "true"
+  ACCOUNTS_CONFIG_FILE: /app/data/credentials.json
+  ACCOUNTS_STATE_FILE: /app/data/state.json
+  DASHBOARD_DATA_DIR: /app/data
+  SQLITE_READONLY: ${SQLITE_READONLY:-true}
+  HOME: /tmp
+  DEBUG_MODE: ${DEBUG_MODE:-off}
+  DEBUG_CAPTURE_CONTENT: ${DEBUG_CAPTURE_CONTENT:-false}
+  DEBUG_CAPTURE_SUCCESS: ${DEBUG_CAPTURE_SUCCESS:-false}
+  DEBUG_CAPTURE_MAX_BYTES: ${DEBUG_CAPTURE_MAX_BYTES:-4194304}
+  DEBUG_CAPTURE_RETENTION: ${DEBUG_CAPTURE_RETENTION:-10}
+  HANDOFF_SECRET: ${HANDOFF_SECRET:?HANDOFF_SECRET must be set for safe blue/green deploys}
+
 x-kiro-app: &kiro-app
   image: kiro-lb:local
   build:
@@ -23,20 +39,7 @@ x-kiro-app: &kiro-app
   user: "1000:1000"
   env_file:
     - .env
-  environment:
-    SERVER_HOST: "0.0.0.0"
-    SERVER_PORT: "8000"
-    ACCOUNT_SYSTEM: "true"
-    ACCOUNTS_CONFIG_FILE: /app/data/credentials.json
-    ACCOUNTS_STATE_FILE: /app/data/state.json
-    DASHBOARD_DATA_DIR: /app/data
-    SQLITE_READONLY: ${SQLITE_READONLY:-true}
-    HOME: /tmp
-    DEBUG_MODE: ${DEBUG_MODE:-off}
-    DEBUG_CAPTURE_CONTENT: ${DEBUG_CAPTURE_CONTENT:-false}
-    DEBUG_CAPTURE_SUCCESS: ${DEBUG_CAPTURE_SUCCESS:-false}
-    DEBUG_CAPTURE_MAX_BYTES: ${DEBUG_CAPTURE_MAX_BYTES:-4194304}
-    DEBUG_CAPTURE_RETENTION: ${DEBUG_CAPTURE_RETENTION:-10}
+  environment: *kiro-environment
   volumes:
     # Shared data: only the ACTIVE slot should receive traffic (see deploy.sh).
     - ./data:/app/data
@@ -78,12 +81,18 @@ services:
   kiro-blue:
     <<: *kiro-app
     container_name: kiro-lb-blue
+    environment:
+      <<: *kiro-environment
+      KIRO_SLOT: blue
     ports:
       - "127.0.0.1:8001:8000"
 
   kiro-green:
     <<: *kiro-app
     container_name: kiro-lb-green
+    environment:
+      <<: *kiro-environment
+      KIRO_SLOT: green
     ports:
       - "127.0.0.1:8002:8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       
       # Required: Set your proxy API key
       # You can also use .env file (see env_file below)
-      - PROXY_API_KEY=${PROXY_API_KEY:-my-super-secret-password-123}
+      - PROXY_API_KEY=${PROXY_API_KEY:?Set PROXY_API_KEY in .env}
       
       # Authentication (choose one method)
       # Option 1: Refresh token
@@ -53,6 +53,8 @@ services:
       
       # Mount debug logs directory (optional, for debugging)
       - ./debug_logs:/app/debug_logs
+      # Unified private SQLite store (dashboard.sqlite3, mode 0600).
+      - ./data:/app/data
     
     restart: unless-stopped
     

--- a/frontend/src/features/dashboard/types.ts
+++ b/frontend/src/features/dashboard/types.ts
@@ -100,6 +100,8 @@ export type KeyModelUsage = {
   completionTokens: number;
   totalTokens: number;
   requests: number;
+  generationSeconds: number;
+  tokensPerSecond: number | null;
   updatedAt: number;
 };
 

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -293,11 +293,11 @@ class AccountManager:
     Manages multiple Kiro accounts with intelligent failover.
 
     Responsibilities:
-    - Load credentials from credentials.json
+    - Load account sources from the private SQLite store
     - Lazy initialization of accounts
     - Select next available account (Circuit Breaker + Sticky)
     - Track statistics and failures
-    - Persist state to state.json
+    - Persist runtime state to the private SQLite store
 
     Example:
         >>> manager = AccountManager("credentials.json", "state.json")
@@ -311,15 +311,36 @@ class AccountManager:
         """
         Initialize AccountManager.
 
+        Direct construction remains backwards compatible with the legacy JSON
+        files. The one-time import also checks the account-deletion recovery
+        record before completing its marker, so an interrupted deletion cannot
+        be mistaken for the source of truth.
+
         Args:
-            credentials_file: Path to credentials.json
-            state_file: Path to state.json
+            credentials_file: Legacy credentials.json import path
+            state_file: Legacy state.json import path
         """
+        from kiro.store import import_legacy_files
+
+        credentials_path = Path(credentials_file).expanduser()
+        recovery_file = str(credentials_path.with_name(f"{credentials_path.name}.account-deletion-recovery"))
+        try:
+            import_legacy_files(credentials_file, state_file, recovery_file)
+        except Exception as e:
+            # Preserve the old manager contract for malformed optional files.
+            # The import transaction rolls back, leaving its marker incomplete
+            # so corrected files (or a recovery record) can be retried later.
+            logger.error(f"Failed to import legacy account files: {e}")
+
         self._credentials_file = credentials_file
         self._state_file = state_file
         self._accounts: Dict[str, Account] = {}
         self._model_to_accounts: Dict[str, ModelAccountList] = {}
         self._lock = asyncio.Lock()
+        # Slow credential/model I/O must never hold the routing lock.  Tasks are
+        # per account so concurrent selectors share one initialization/refresh.
+        self._initializations: Dict[str, asyncio.Task[bool]] = {}
+        self._model_refreshes: Dict[str, asyncio.Task[None]] = {}
         self._dirty = False
         self._credentials_config: List[Dict] = []
         self._current_account_index: int = 0  # GLOBAL sticky index for all models
@@ -331,29 +352,21 @@ class AccountManager:
 
     async def load_credentials(self) -> None:
         """Load credentials while serializing durable rollback recovery."""
-        from kiro.accounts_admin import recover_pending_account_deletion_files
-
         async with self._lock:
-            recover_pending_account_deletion_files(self)
             await self._load_credentials_unlocked()
 
     async def _load_credentials_unlocked(self) -> None:
         """
-        Load credentials from credentials.json.
+        Load account sources from the private SQLite store.
 
         The caller must hold ``_lock``. Validates each entry and creates
         Account objects; invalid entries are skipped with warnings and folders
         are scanned for credential files.
         """
-        creds_path = Path(self._credentials_file).expanduser()
-
-        if not creds_path.exists():
-            logger.warning(f"Credentials file not found: {self._credentials_file}")
-            return
-
         try:
-            with open(creds_path, "r", encoding="utf-8") as f:
-                self._credentials_config = json.load(f)
+            from kiro.store import load_account_sources
+
+            self._credentials_config = load_account_sources()
         except Exception as e:
             logger.error(f"Failed to load credentials: {e}")
             return
@@ -391,6 +404,12 @@ class AccountManager:
                 self._accounts[account_id] = Account(id=account_id)
                 logger.debug(f"Added account: {account_id}")
                 continue  # Skip path processing for refresh_token
+
+            if cred_type == "internal":
+                account_id = str(entry.get("id", ""))
+                if account_id:
+                    self._accounts[account_id] = Account(id=account_id)
+                continue
 
             # Handle folder scanning for json/sqlite types
             assert path is not None
@@ -454,20 +473,18 @@ class AccountManager:
 
     async def load_state(self) -> None:
         """
-        Load runtime state from state.json.
+        Load runtime state from the private SQLite store.
 
         Restores model_to_accounts mapping and account runtime state.
         Creates empty state if file doesn't exist.
         """
-        state_path = Path(self._state_file)
-
-        if not state_path.exists():
-            logger.debug("State file not found, starting with empty state")
-            return
-
         try:
-            with open(state_path, "r", encoding="utf-8") as f:
-                state_data = json.load(f)
+            from kiro.store import load_runtime_state
+
+            state_data = load_runtime_state()
+            if state_data is None:
+                logger.debug("No persisted account runtime state")
+                return
             # Restore global current_account_index
             self._current_account_index = state_data.get("current_account_index", 0)
 
@@ -497,15 +514,54 @@ class AccountManager:
         except Exception as e:
             logger.error(f"Failed to load state: {e}")
 
+    async def reload_durable_state(self) -> None:
+        """Replace the live pool with the latest durable handoff snapshot."""
+        async with self._lock:
+            self._accounts.clear()
+            self._model_to_accounts.clear()
+            self._current_account_index = 0
+            await self._load_credentials_unlocked()
+            await self.load_state()
+
+    async def flush_for_handoff(self) -> None:
+        """Persist a final routing snapshot while account selection is stopped."""
+        async with self._lock:
+            await self._save_state(raise_errors=True)
+
     async def _save_state(self, *, raise_errors: bool = False) -> bool:
         """
-        Save runtime state to state.json atomically.
+        Save runtime state transactionally in SQLite.
 
         Uses tmp file + rename for atomic write. Background callers keep the
         best-effort default; destructive operations can require an observable
         failure with ``raise_errors=True``.
         """
-        state_data = {
+        state_data = self._state_document()
+
+        try:
+            from kiro.store import save_runtime_state
+
+            written = save_runtime_state(state_data)
+            # Older store implementations returned None after writing. False is
+            # the explicit signal that this process does not own runtime writes.
+            if written is False:
+                message = "Runtime state write skipped: this process is not the active writer"
+                logger.debug(message)
+                if raise_errors:
+                    raise RuntimeError(message)
+                return False
+            logger.debug("State saved successfully")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to save state: {e}")
+            if raise_errors:
+                raise
+            return False
+
+    def _state_document(self) -> Dict:
+        """Return the complete durable runtime state document."""
+        return {
             "current_account_index": self._current_account_index,
             "accounts": {
                 account_id: {
@@ -524,29 +580,6 @@ class AccountManager:
             },
             "model_to_accounts": {model: {"accounts": mal.accounts} for model, mal in self._model_to_accounts.items()},
         }
-
-        state_path = Path(self._state_file)
-        tmp_path = state_path.with_suffix(".json.tmp")
-
-        try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                json.dump(state_data, f, indent=2, ensure_ascii=False)
-
-            # Atomic rename
-            tmp_path.replace(state_path)
-            logger.debug("State saved successfully")
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to save state: {e}")
-            try:
-                if tmp_path.exists():
-                    tmp_path.unlink()
-            except OSError as cleanup_error:
-                logger.error(f"Failed to clean up state temp file: {cleanup_error}")
-            if raise_errors:
-                raise
-            return False
 
     def _remove_account_state(self, account_id: str) -> None:
         """Remove one account from live routing and all persisted runtime state.
@@ -611,30 +644,13 @@ class AccountManager:
         Returns:
             True if successful, False otherwise
         """
-        account = self._accounts.get(account_id)
+        async with self._lock:
+            account = self._accounts.get(account_id)
+            creds_config = self._credentials_for_account(account_id)
         if not account:
             return False
 
         try:
-            # Find credentials config for this account
-            creds_config = None
-            for entry in self._credentials_config:
-                path = entry.get("path", "")
-                expanded_path = Path(path).expanduser()
-
-                if entry.get("type") == "refresh_token":
-                    # Match by deterministic hash for refresh_token type
-                    token = entry.get("refresh_token", "")
-                    token_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
-                    if account_id == f"refresh_token_{token_hash}":
-                        creds_config = entry
-                        break
-                elif str(expanded_path.resolve()) == account_id or (
-                    expanded_path.is_dir() and account_id.startswith(str(expanded_path.resolve()) + os.sep)
-                ):
-                    creds_config = entry
-                    break
-
             if not creds_config:
                 logger.error(f"No credentials config found for account: {account_id}")
                 return False
@@ -662,12 +678,19 @@ class AccountManager:
                     region=creds_config.get("region", "us-east-1"),
                     api_region=creds_config.get("api_region"),
                 )
+            elif cred_type == "internal":
+                auth_manager = KiroAuthManager(
+                    internal_account_id=account_id,
+                    profile_arn=creds_config.get("profile_arn"),
+                    region=creds_config.get("region", "us-east-1"),
+                    api_region=creds_config.get("api_region"),
+                )
             else:
                 logger.error(f"Unknown credential type: {cred_type}")
                 return False
 
             # Get token to verify credentials
-            token = await auth_manager.get_access_token()
+            await auth_manager.get_access_token()
 
             # Determine if we should fetch models or use static list
             if _is_runtime_endpoint(auth_manager):
@@ -728,27 +751,94 @@ class AccountManager:
                 cache=model_cache, hidden_models=HIDDEN_MODELS, aliases=MODEL_ALIASES, hidden_from_list=HIDDEN_FROM_LIST
             )
 
-            # Update account
-            account.auth_manager = auth_manager
-            account.model_cache = model_cache
-            account.model_resolver = model_resolver
-            account.models_cached_at = time.time()
-
-            # Update model_to_accounts mapping
             available_models = model_resolver.get_available_models()
-            for model in available_models:
-                if model not in self._model_to_accounts:
-                    self._model_to_accounts[model] = ModelAccountList()
-                if account_id not in self._model_to_accounts[model].accounts:
-                    self._model_to_accounts[model].accounts.append(account_id)
+            async with self._lock:
+                # Deletion or source replacement may happen while token/model I/O
+                # is in flight. Never resurrect or initialize the wrong source.
+                if (
+                    self._accounts.get(account_id) is not account
+                    or self._credentials_for_account(account_id) is not creds_config
+                ):
+                    return False
+                account.auth_manager = auth_manager
+                account.model_cache = model_cache
+                account.model_resolver = model_resolver
+                account.models_cached_at = time.time()
+                for model in available_models:
+                    if model not in self._model_to_accounts:
+                        self._model_to_accounts[model] = ModelAccountList()
+                    if account_id not in self._model_to_accounts[model].accounts:
+                        self._model_to_accounts[model].accounts.append(account_id)
+                self._dirty = True
 
             logger.info(f"Initialized account: {account_id} ({len(available_models)} models)")
-            self._dirty = True
             return True
 
         except Exception as e:
             logger.error(f"Failed to initialize account {account_id}: {e}")
             return False
+
+    def _credentials_for_account(self, account_id: str) -> Optional[Dict]:
+        """Find the source that explicitly owns ``account_id``.
+
+        Only file-backed source types participate in path matching; this avoids
+        an internal source with no path resolving to the current directory and
+        accidentally claiming unrelated accounts.
+        """
+        for entry in self._credentials_config:
+            cred_type = entry.get("type")
+            if cred_type == "internal":
+                if str(entry.get("id", "")) == account_id:
+                    return entry
+                continue
+            if cred_type == "refresh_token":
+                token = entry.get("refresh_token")
+                if not isinstance(token, str) or not token:
+                    continue
+                token_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
+                if account_id == f"refresh_token_{token_hash}":
+                    return entry
+                continue
+            if cred_type not in ("json", "sqlite") or not entry.get("path"):
+                continue
+            expanded_path = Path(str(entry["path"])).expanduser()
+            resolved = str(expanded_path.resolve())
+            if resolved == account_id or (expanded_path.is_dir() and account_id.startswith(resolved + os.sep)):
+                return entry
+        return None
+
+    async def initialize_account(self, account_id: str) -> bool:
+        """Initialize an account outside the global lock with per-account single-flight."""
+        async with self._lock:
+            account = self._accounts.get(account_id)
+            if account is None:
+                return False
+            if account.auth_manager is not None:
+                return True
+            task = self._initializations.get(account_id)
+            if task is None:
+                task = asyncio.create_task(self._initialize_account(account_id))
+                self._initializations[account_id] = task
+        try:
+            return await asyncio.shield(task)
+        finally:
+            async with self._lock:
+                if self._initializations.get(account_id) is task and task.done():
+                    self._initializations.pop(account_id, None)
+
+    async def _refresh_account_models_singleflight(self, account_id: str) -> None:
+        """Refresh one account outside the routing lock, sharing concurrent work."""
+        async with self._lock:
+            task = self._model_refreshes.get(account_id)
+            if task is None:
+                task = asyncio.create_task(self._refresh_account_models(account_id))
+                self._model_refreshes[account_id] = task
+        try:
+            await asyncio.shield(task)
+        finally:
+            async with self._lock:
+                if self._model_refreshes.get(account_id) is task and task.done():
+                    self._model_refreshes.pop(account_id, None)
 
     def _quarantine_if_suspended(self, account_id: str, account: "Account", response: httpx.Response) -> bool:
         """Park an account whose model listing came back as an upstream lock.
@@ -776,36 +866,41 @@ class AccountManager:
         Args:
             account_id: Account ID to refresh
         """
-        account = self._accounts.get(account_id)
-        if not account or not account.auth_manager:
-            return
-
-        # These dependencies are initialized atomically with the auth manager.
-        assert account.model_cache is not None
-        assert account.model_resolver is not None
+        async with self._lock:
+            account = self._accounts.get(account_id)
+            if not account or not account.auth_manager:
+                return
+            auth_manager = account.auth_manager
+            model_cache = account.model_cache
+            model_resolver = account.model_resolver
+        assert model_cache is not None
+        assert model_resolver is not None
 
         # Check if using runtime endpoint (no dynamic model list available)
-        if _is_runtime_endpoint(account.auth_manager):
+        if _is_runtime_endpoint(auth_manager):
             # Runtime endpoint does not provide /ListAvailableModels
             # Use static list and update cache timestamp
             logger.debug(
                 f"Account {account_id}: Skipping model refresh for runtime.kiro.dev endpoint (using static list)"
             )
-            await account.model_cache.update(FALLBACK_MODELS)
-            account.models_cached_at = time.time()
-            self._dirty = True
+            async with self._lock:
+                if self._accounts.get(account_id) is not account or account.auth_manager is not auth_manager:
+                    return
+                await model_cache.update(FALLBACK_MODELS)
+                account.models_cached_at = time.time()
+                self._dirty = True
             return
 
         # Old endpoint - attempt to fetch dynamic model list
         # Use KiroHttpClient for retry logic
-        http_client = KiroHttpClient(account.auth_manager, shared_client=None)
+        http_client = KiroHttpClient(auth_manager, shared_client=None)
 
         try:
             params = {"origin": "AI_EDITOR"}
-            if account.auth_manager.auth_type == AuthType.KIRO_DESKTOP and account.auth_manager.profile_arn:
-                params["profileArn"] = account.auth_manager.profile_arn
+            if auth_manager.auth_type == AuthType.KIRO_DESKTOP and auth_manager.profile_arn:
+                params["profileArn"] = auth_manager.profile_arn
 
-            list_models_url = f"{account.auth_manager.q_host}/ListAvailableModels"
+            list_models_url = f"{auth_manager.q_host}/ListAvailableModels"
 
             response = await http_client.request_with_retry(
                 method="GET", url=list_models_url, json_data=None, params=params, stream=False
@@ -815,23 +910,24 @@ class AccountManager:
                 # A TTL refresh is also an upstream verdict. Without this check a
                 # suspension arriving here was swallowed and the stale cache kept
                 # the locked account advertising models indefinitely.
-                self._quarantine_if_suspended(account_id, account, response)
+                async with self._lock:
+                    if self._accounts.get(account_id) is account and account.auth_manager is auth_manager:
+                        self._quarantine_if_suspended(account_id, account, response)
             else:
                 data = response.json()
                 models_list = data.get("models", [])
-                await account.model_cache.update(models_list)
-                account.models_cached_at = time.time()
-
-                # Update model_to_accounts mapping (new models may have appeared)
-                available_models = account.model_resolver.get_available_models()
-                for model in available_models:
-                    if model not in self._model_to_accounts:
-                        self._model_to_accounts[model] = ModelAccountList()
-                    if account_id not in self._model_to_accounts[model].accounts:
-                        self._model_to_accounts[model].accounts.append(account_id)
-
-                logger.debug(f"Refreshed models for {account_id}")
-                self._dirty = True
+                async with self._lock:
+                    if self._accounts.get(account_id) is not account or account.auth_manager is not auth_manager:
+                        return
+                    await model_cache.update(models_list)
+                    account.models_cached_at = time.time()
+                    for model in model_resolver.get_available_models():
+                        if model not in self._model_to_accounts:
+                            self._model_to_accounts[model] = ModelAccountList()
+                        if account_id not in self._model_to_accounts[model].accounts:
+                            self._model_to_accounts[model].accounts.append(account_id)
+                    self._dirty = True
+                    logger.debug(f"Refreshed models for {account_id}")
 
         except Exception as e:
             # All retries exhausted - keep using stale cache
@@ -861,126 +957,95 @@ class AccountManager:
             Account object or None if no accounts available
         """
         async with self._lock:
-            # Special case: single account - bypass Circuit Breaker
-            # Circuit Breaker is meaningless for single account - user should see real Kiro API errors
-            # instead of generic "Account unavailable" after cooldown kicks in
-            if len(self._accounts) == 1:
-                account_id = list(self._accounts.keys())[0]
-                account = self._accounts[account_id]
-
-                # Skip if already tried in current failover loop
-                if exclude_accounts and account_id in exclude_accounts:
-                    return None
-
-                # Lazy initialization if needed
-                if account.auth_manager is None:
-                    success = await self._initialize_account(account_id)
-                    if not success:
-                        return None
-
-                # Check TTL and refresh if needed
-                if account.models_cached_at > 0:
-                    age = time.time() - account.models_cached_at
-                    if age > ACCOUNT_CACHE_TTL:
-                        try:
-                            await self._refresh_account_models(account_id)
-                        except Exception as e:
-                            logger.warning(f"Failed to refresh models for {account_id}: {e}")
-                # # Validate model availability
-                # if account.model_resolver:
-                #     normalized_model = normalize_model_name(model)
-                #     available_models = account.model_resolver.get_available_models()
-                #     if normalized_model not in available_models:
-                #         return None
-
-                # Always return single account (ignore cooldown/failures)
-                # No model validation - let Kiro API decide (gateway, not gatekeeper)
-                return account
-
-            # Multi-account logic: GLOBAL sticky
-            # ALWAYS start from GLOBAL index (one current account for ALL models)
+            all_account_ids = list(self._accounts)
             start_index = self._current_account_index
+            single_account = len(all_account_ids) == 1
 
-            # ALWAYS iterate over ALL accounts
-            all_account_ids = list(self._accounts.keys())
-
-            for i in range(len(all_account_ids)):
-                current_index = (start_index + i) % len(all_account_ids)
-                account_id = all_account_ids[current_index]
-                account = self._accounts[account_id]
+        for i in range(len(all_account_ids)):
+            account_id = all_account_ids[(start_index + i) % len(all_account_ids)]
+            async with self._lock:
+                account = self._accounts.get(account_id)
+                if account is None:
+                    continue
 
                 # Skip accounts already tried in current failover loop
                 if exclude_accounts and account_id in exclude_accounts:
                     continue
 
-                # An upstream suspension takes the account out of the rotation
-                # completely. No probabilistic retry: the lock is lifted by Kiro
-                # support, never by another request, and each attempt still costs
-                # a full retry storm plus a user-visible failure.
-                if account.suspended_until > time.time():
-                    continue
-
-                # Skip accounts that cannot serve any request. A quota-exhausted
-                # account is out of the rotation entirely until its quarantine
-                # expires: no probabilistic retry, because there is nothing to
-                # discover before the quota resets.
-                if account.quota_exhausted_until > time.time():
-                    continue
-
-                # Skip accounts inside their rate-limit window. This is checked
-                # before the Circuit Breaker and has no probabilistic retry:
-                # retrying a rate-limited account only earns another 429.
-                if account.rate_limited_until > time.time():
-                    continue
-
-                # Check Circuit Breaker (Half-Open state with exponential backoff)
-                if account.failures > 0:
-                    time_since_failure = time.time() - account.last_failure_time
-
-                    # Exponential backoff: base * 2^(failures - 1), capped at MAX_MULTIPLIER
-                    # 1 failure: 60s, 2: 120s, 3: 240s, ..., 12+: 86400s (1 day cap)
-                    backoff_multiplier = min(2 ** (account.failures - 1), ACCOUNT_MAX_BACKOFF_MULTIPLIER)
-                    effective_timeout = ACCOUNT_RECOVERY_TIMEOUT * backoff_multiplier
-
-                    if time_since_failure < effective_timeout:
-                        # Probabilistic retry (10% chance)
-                        if random.random() > ACCOUNT_PROBABILISTIC_RETRY_CHANCE:
-                            continue
-                        else:
-                            logger.info(f"Probabilistic retry for broken account {account_id}")
-                    else:
-                        # Half-Open: recovery timeout passed
-                        logger.info(
-                            f"Half-Open state for {account_id} (recovery timeout passed, effective={effective_timeout}s)"
-                        )
-
-                # Lazy initialization
-                if account.auth_manager is None:
-                    success = await self._initialize_account(account_id)
-                    if not success:
-                        account.failures += 1
-                        self._dirty = True
+                # A sole account bypasses health policy so callers see the real
+                # upstream error rather than a generic unavailable response.
+                if not single_account:
+                    # An upstream suspension takes the account out of the rotation
+                    # completely. No probabilistic retry: the lock is lifted by Kiro
+                    # support, never by another request, and each attempt still costs
+                    # a full retry storm plus a user-visible failure.
+                    if account.suspended_until > time.time():
                         continue
 
-                # Check TTL and refresh if needed
-                if account.models_cached_at > 0:
-                    age = time.time() - account.models_cached_at
-                    if age > ACCOUNT_CACHE_TTL:
-                        try:
-                            await self._refresh_account_models(account_id)
-                        except Exception as e:
-                            logger.warning(f"Failed to refresh models for {account_id}: {e}")
-                # # Check if model is available on this account
-                # available_models = account.model_resolver.get_available_models()
-                # if normalized_model not in available_models:
-                #     continue
+                    # Skip accounts that cannot serve any request. A quota-exhausted
+                    # account is out of the rotation entirely until its quarantine
+                    # expires: no probabilistic retry, because there is nothing to
+                    # discover before the quota resets.
+                    if account.quota_exhausted_until > time.time():
+                        continue
 
-                # No model validation - let Kiro API decide (gateway, not gatekeeper)
-                # Account is suitable!
-                return account
+                    # Skip accounts inside their rate-limit window. This is checked
+                    # before the Circuit Breaker and has no probabilistic retry:
+                    # retrying a rate-limited account only earns another 429.
+                    if account.rate_limited_until > time.time():
+                        continue
 
-            # All accounts unavailable
-            return None
+                    # Check Circuit Breaker (Half-Open state with exponential backoff)
+                    if account.failures > 0:
+                        time_since_failure = time.time() - account.last_failure_time
+
+                        # Exponential backoff: base * 2^(failures - 1), capped at MAX_MULTIPLIER
+                        # 1 failure: 60s, 2: 120s, 3: 240s, ..., 12+: 86400s (1 day cap)
+                        backoff_multiplier = min(2 ** (account.failures - 1), ACCOUNT_MAX_BACKOFF_MULTIPLIER)
+                        effective_timeout = ACCOUNT_RECOVERY_TIMEOUT * backoff_multiplier
+
+                        if time_since_failure < effective_timeout:
+                            # Probabilistic retry (10% chance)
+                            if random.random() > ACCOUNT_PROBABILISTIC_RETRY_CHANCE:
+                                continue
+                            logger.info(f"Probabilistic retry for broken account {account_id}")
+                        else:
+                            # Half-Open: recovery timeout passed
+                            logger.info(
+                                f"Half-Open state for {account_id} (recovery timeout passed, effective={effective_timeout}s)"
+                            )
+
+                needs_initialization = account.auth_manager is None
+                needs_refresh = (
+                    not needs_initialization
+                    and account.models_cached_at > 0
+                    and time.time() - account.models_cached_at > ACCOUNT_CACHE_TTL
+                )
+
+            if needs_initialization:
+                if not await self.initialize_account(account_id):
+                    async with self._lock:
+                        current = self._accounts.get(account_id)
+                        if current is account:
+                            current.failures += 1
+                            self._dirty = True
+                    continue
+
+            if needs_refresh:
+                try:
+                    await self._refresh_account_models_singleflight(account_id)
+                except Exception as e:
+                    logger.warning(f"Failed to refresh models for {account_id}: {e}")
+
+            # Any await above allowed deletion or replacement. Revalidate the
+            # exact object before exposing it to a route.
+            async with self._lock:
+                current = self._accounts.get(account_id)
+                if current is not account or current.auth_manager is None:
+                    continue
+                return current
+
+        return None
 
     async def report_success(self, account_id: str, model: str) -> None:
         """
@@ -1190,6 +1255,14 @@ class AccountManager:
         pending = self._unsaved_rate_observations
         self._unsaved_rate_observations = []
         return [(item.account_id, item.at, item.rpm, int(item.rejected), item.outcome) for item in pending]
+
+    def restore_unsaved_rate_observations(self, rows: List[Tuple[str, float, int, int, str]]) -> None:
+        """Restore a failed persistence batch ahead of newer observations."""
+        restored = [
+            RateObservation(account_id=account_id, at=at, rpm=rpm, rejected=bool(rejected), outcome=outcome)
+            for account_id, at, rpm, rejected, outcome in rows
+        ]
+        self._unsaved_rate_observations = restored + self._unsaved_rate_observations
 
     def load_rate_observations(self, rows: List[Tuple[str, float, int, int, str]]) -> None:
         """Restore persisted rate observations after a restart."""

--- a/kiro/accounts_admin.py
+++ b/kiro/accounts_admin.py
@@ -1,26 +1,17 @@
 # -*- coding: utf-8 -*-
-"""Dashboard-driven Kiro account registration.
-
-Credential material is written to the account-pool credentials file and is
-never returned by the control-plane API. Registration validates the source
-before persisting so an unusable entry cannot silently break failover.
-"""
+"""Transactional dashboard-driven Kiro account registration."""
 
 from __future__ import annotations
 
-import base64
 import hashlib
 import json
-import os
 import sqlite3
-import tempfile
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from loguru import logger
 
-_ALLOWED_TYPES = {"sqlite", "json", "refresh_token"}
-_RECOVERY_VERSION = 1
+_ALLOWED_TYPES = {"sqlite", "json", "refresh_token", "internal"}
 
 
 class AccountNotFoundError(ValueError):
@@ -39,89 +30,10 @@ class DirectoryBackedAccountError(AccountConflictError):
     """The account comes from a directory-scanning credentials entry."""
 
 
-class AccountDeletionRecoveryError(RuntimeError):
-    """An account deletion failed and its rollback needs a retry."""
-
-
-def _credentials_path(manager: Any) -> Path:
-    return Path(manager._credentials_file).expanduser()
-
-
 def _load_entries(manager: Any) -> list[dict[str, Any]]:
-    path = _credentials_path(manager)
-    if not path.exists():
-        return []
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return [entry for entry in data if isinstance(entry, dict)] if isinstance(data, list) else []
-    except Exception as exc:
-        raise RuntimeError(f"Existing credentials file is unreadable: {exc}") from exc
+    from kiro.store import load_account_sources
 
-
-def _write_entries(manager: Any, entries: list[dict[str, Any]]) -> None:
-    path = _credentials_path(manager)
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(entries, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    os.chmod(tmp, 0o600)
-    tmp.replace(path)
-
-
-def _recovery_path(manager: Any) -> Path:
-    credentials_path = _credentials_path(manager)
-    return credentials_path.with_name(f"{credentials_path.name}.account-deletion-recovery")
-
-
-def _persist_removal_recovery(manager: Any, entries: list[dict[str, Any]], snapshot: dict[str, Any]) -> None:
-    path = _recovery_path(manager)
-    state_contents = snapshot["state_file"]
-    payload = {
-        "version": _RECOVERY_VERSION,
-        "credentials_entries": entries,
-        "state_file": None if state_contents is None else base64.b64encode(state_contents).decode("ascii"),
-    }
-    descriptor, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    tmp = Path(tmp_name)
-    try:
-        stream = os.fdopen(descriptor, "w", encoding="utf-8")
-        descriptor = -1
-        with stream:
-            json.dump(payload, stream, indent=2, ensure_ascii=False)
-            stream.write("\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-        tmp.replace(path)
-    except Exception as exc:
-        if descriptor >= 0:
-            os.close(descriptor)
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError as cleanup_error:
-            raise RuntimeError(f"Failed to clean up account deletion recovery temp file: {cleanup_error}") from exc
-        raise
-
-
-def _load_removal_recovery(manager: Any) -> tuple[list[dict[str, Any]], bytes | None] | None:
-    path = _recovery_path(manager)
-    if not path.exists():
-        return None
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(payload, dict) or payload.get("version") != _RECOVERY_VERSION:
-            raise ValueError("unsupported recovery record")
-        entries = payload.get("credentials_entries")
-        if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
-            raise ValueError("invalid credentials snapshot")
-        encoded_state = payload.get("state_file")
-        if encoded_state is not None and not isinstance(encoded_state, str):
-            raise ValueError("invalid state snapshot")
-        state_contents = None if encoded_state is None else base64.b64decode(encoded_state, validate=True)
-    except Exception as exc:
-        raise AccountDeletionRecoveryError(f"Account deletion recovery record is unreadable: {exc}") from exc
-    return entries, state_contents
-
-
-def _clear_removal_recovery(manager: Any) -> None:
-    _recovery_path(manager).unlink(missing_ok=True)
+    return load_account_sources()
 
 
 def _validate_sqlite(path: Path) -> None:
@@ -148,6 +60,8 @@ def _validate_json(path: Path) -> None:
 
 
 def account_id_for_entry(entry: dict[str, Any]) -> str:
+    if entry.get("type") == "internal":
+        return str(entry.get("id", ""))
     if entry.get("type") == "refresh_token":
         digest = hashlib.sha256(entry.get("refresh_token", "").encode()).hexdigest()[:16]
         return f"refresh_token_{digest}"
@@ -162,7 +76,7 @@ def is_account_deletable(manager: Any, account_id: str) -> bool:
     direct_matches = 0
     for entry in manager._credentials_config:
         source_type = entry.get("type")
-        if source_type == "refresh_token":
+        if source_type in {"refresh_token", "internal"}:
             direct_matches += account_id_for_entry(entry) == account_id
             continue
         if source_type not in {"json", "sqlite"}:
@@ -179,17 +93,28 @@ def is_account_deletable(manager: Any, account_id: str) -> bool:
 
 
 def build_entry(payload: dict[str, Any]) -> dict[str, Any]:
-    """Validate a registration request and return a credentials-file entry."""
+    """Validate a registration request and return an account-source entry."""
     source = str(payload.get("type", "")).strip()
     if source not in _ALLOWED_TYPES:
         raise ValueError(f"type must be one of: {', '.join(sorted(_ALLOWED_TYPES))}")
 
     entry: dict[str, Any] = {"type": source}
-    if source == "refresh_token":
+    if source == "internal":
+        account_id = str(payload.get("id", "")).strip()
+        credential = payload.get("credential")
+        if not account_id or not isinstance(credential, dict) or not credential.get("refreshToken"):
+            raise ValueError("internal credentials are incomplete")
+        entry.update(id=account_id, credential=credential)
+    elif source == "refresh_token":
         token = str(payload.get("refreshToken", "")).strip()
         if len(token) < 20:
             raise ValueError("refreshToken is required")
-        entry["refresh_token"] = token
+        digest = hashlib.sha256(token.encode()).hexdigest()[:16]
+        entry = {
+            "type": "internal",
+            "id": f"refresh_token_{digest}",
+            "credential": {"refreshToken": token},
+        }
     else:
         raw_path = str(payload.get("path", "")).strip()
         if not raw_path:
@@ -220,25 +145,7 @@ def _snapshot_manager_state(manager: Any) -> dict[str, Any]:
         "rate_observations": manager._rate_observations,
         "unsaved_rate_observations": manager._unsaved_rate_observations,
         "dirty": manager._dirty,
-        "state_file": _state_file_snapshot(manager),
     }
-
-
-def _state_file_snapshot(manager: Any) -> bytes | None:
-    state_path = Path(manager._state_file)
-    return state_path.read_bytes() if state_path.exists() else None
-
-
-def _restore_state_contents(manager: Any, state_contents: bytes | None) -> None:
-    state_path = Path(manager._state_file)
-    if state_contents is None:
-        state_path.unlink(missing_ok=True)
-    else:
-        state_path.write_bytes(state_contents)
-
-
-def _restore_state_file(manager: Any, snapshot: dict[str, Any]) -> None:
-    _restore_state_contents(manager, snapshot["state_file"])
 
 
 def _restore_manager_state(manager: Any, snapshot: dict[str, Any]) -> None:
@@ -255,117 +162,21 @@ def _restore_manager_state(manager: Any, snapshot: dict[str, Any]) -> None:
     manager._dirty = snapshot["dirty"]
 
 
-async def _rollback_removal(
-    manager: Any,
-    entries: list[dict[str, Any]],
-    snapshot: dict[str, Any],
-    *,
-    restore_state_file: bool,
-) -> None:
-    _restore_manager_state(manager, snapshot)
-    failures: list[str] = []
-    try:
-        _write_entries(manager, entries)
-    except Exception as exc:
-        failures.append(f"credentials.json remains changed ({exc})")
-    if restore_state_file:
-        try:
-            _restore_state_file(manager, snapshot)
-        except Exception as exc:
-            failures.append(f"state.json remains changed ({exc})")
-
-    if not failures:
-        try:
-            _clear_removal_recovery(manager)
-        except Exception as exc:
-            failures.append(f"recovery barrier remains ({exc})")
-
-    if failures:
-        try:
-            _persist_removal_recovery(manager, entries, snapshot)
-        except Exception as exc:
-            failures.append(f"recovery barrier could not be created ({exc})")
-        manager._account_deletion_recovery = (entries, snapshot, restore_state_file)
-        manager._dirty = True
-        invariant = "; ".join(failures)
-        raise AccountDeletionRecoveryError(
-            f"Account deletion rollback is incomplete: live state is restored, but {invariant}. "
-            "Retry deletion to run recovery before another mutation."
-        )
-
-    manager.__dict__.pop("_account_deletion_recovery", None)
-    manager._dirty = snapshot["dirty"]
-
-
-def recover_pending_account_deletion_files(manager: Any) -> bool:
-    """Restore durable rollback snapshots before credentials are loaded or mutated."""
-    persisted = _load_removal_recovery(manager)
-    if persisted is None:
-        return False
-    entries, state_contents = persisted
-    failures: list[str] = []
-    try:
-        _write_entries(manager, entries)
-    except Exception as exc:
-        failures.append(f"credentials.json remains changed ({exc})")
-    try:
-        _restore_state_contents(manager, state_contents)
-    except Exception as exc:
-        failures.append(f"state.json remains changed ({exc})")
-    if not failures:
-        try:
-            _clear_removal_recovery(manager)
-        except Exception as exc:
-            failures.append(f"recovery barrier remains ({exc})")
-    if failures:
-        manager._dirty = True
-        invariant = "; ".join(failures)
-        raise AccountDeletionRecoveryError(f"Account deletion recovery is incomplete: {invariant}")
-    return True
-
-
-async def _recover_pending_removal(manager: Any) -> None:
-    pending = getattr(manager, "_account_deletion_recovery", None)
-    if pending is not None:
-        entries, snapshot, restore_state_file = pending
-        await _rollback_removal(
-            manager,
-            entries,
-            snapshot,
-            restore_state_file=restore_state_file,
-        )
-        return
-
-    if not recover_pending_account_deletion_files(manager):
-        return
-
-    existing = dict(manager._accounts)
-    manager._accounts.clear()
-    await manager._load_credentials_unlocked()
-    for account_id, account in existing.items():
-        if account_id in manager._accounts:
-            manager._accounts[account_id] = account
-    await manager.load_state()
-
-
 async def remove_account(
     manager: Any,
     label: str,
-    *,
-    finalize: Callable[[str], None] | None = None,
 ) -> str:
     """Remove a directly registered account by its public opaque label."""
     from kiro.account_manager import account_label
 
     async with manager._lock:
-        await _recover_pending_removal(manager)
         entries = _load_entries(manager)
         direct_entries: dict[str, list[int]] = {}
         directory_paths: list[Path] = []
 
         for index, entry in enumerate(entries):
             source_type = entry.get("type")
-            if source_type == "refresh_token":
+            if source_type in {"refresh_token", "internal"}:
                 direct_entries.setdefault(account_id_for_entry(entry), []).append(index)
                 continue
             if source_type not in {"json", "sqlite"}:
@@ -404,22 +215,18 @@ async def remove_account(
 
         snapshot = _snapshot_manager_state(manager)
         try:
-            _write_entries(manager, remaining_entries)
+            from kiro.store import connection, replace_account_sources, save_runtime_state
+
             manager._credentials_config = remaining_entries
             manager._remove_account_state(account_id)
-            await manager._save_state(raise_errors=True)
-            if finalize is not None:
-                finalize(account_id)
-        except Exception as exc:
-            try:
-                await _rollback_removal(
-                    manager,
-                    entries,
-                    snapshot,
-                    restore_state_file=True,
-                )
-            except AccountDeletionRecoveryError as recovery_error:
-                raise recovery_error from exc
+            state_data = manager._state_document()
+            with connection() as conn:
+                replace_account_sources(remaining_entries, conn)
+                save_runtime_state(state_data, conn, require_write=True)
+                conn.execute("DELETE FROM account_usage WHERE account_id = ?", (account_id,))
+                conn.execute("DELETE FROM rate_observations WHERE account_id = ?", (account_id,))
+        except Exception:
+            _restore_manager_state(manager, snapshot)
             raise
 
         manager._dirty = False
@@ -428,35 +235,44 @@ async def remove_account(
 
 async def register_account(manager: Any, payload: dict[str, Any]) -> dict[str, Any]:
     """Persist a validated credential source and initialize it in the live pool."""
+    requested_type = str(payload.get("type", "")).strip()
     entry = build_entry(payload)
     account_id = account_id_for_entry(entry)
 
     async with manager._lock:
-        await _recover_pending_removal(manager)
         if account_id in manager._accounts:
             raise ValueError("This credential source is already registered")
 
         entries = _load_entries(manager)
+        snapshot = _snapshot_manager_state(manager)
         entries.append(entry)
-        _write_entries(manager, entries)
+        from kiro.account_manager import Account
+        from kiro.store import connection, replace_account_sources, save_runtime_state
 
-        # Reload so the manager owns the same config it would see on restart, but
-        # keep already-initialized accounts so registration never resets the pool.
-        existing = dict(manager._accounts)
-        await manager._load_credentials_unlocked()
-        for known_id, known_account in existing.items():
-            if known_id in manager._accounts:
-                manager._accounts[known_id] = known_account
-        if account_id not in manager._accounts:
-            raise RuntimeError("Credential source was saved but produced no usable account")
+        try:
+            # Mutate the live pool while the proposed source/runtime transaction
+            # is uncommitted. A failed ownership check rolls both back together.
+            with connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                replace_account_sources(entries, conn)
+                manager._credentials_config = entries
+                manager._accounts[account_id] = Account(id=account_id)
+                save_runtime_state(manager._state_document(), conn, require_write=True)
+        except Exception:
+            _restore_manager_state(manager, snapshot)
+            raise
 
-        initialized = await manager._initialize_account(account_id)
-        if not initialized:
-            logger.warning("Registered account {} could not be initialized yet", account_id)
-        await manager._save_state()
-        return {
-            "accountId": hashlib.sha256(account_id.encode()).hexdigest()[:12],
-            "accountKey": account_id,
-            "type": entry["type"],
-            "initialized": initialized,
-        }
+    # Registration is a control-plane operation, but it must not stall routing
+    # while token/model discovery waits on the network.
+    initialized = await manager.initialize_account(account_id)
+    if not initialized:
+        logger.warning("Registered account {} could not be initialized yet", account_id)
+    async with manager._lock:
+        with connection() as conn:
+            save_runtime_state(manager._state_document(), conn, require_write=True)
+    return {
+        "accountId": hashlib.sha256(account_id.encode()).hexdigest()[:12],
+        "accountKey": account_id,
+        "type": requested_type,
+        "initialized": initialized,
+    }

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -23,7 +23,6 @@ import httpx
 from loguru import logger
 
 from kiro.config import (
-    SQLITE_READONLY,
     TOKEN_REFRESH_THRESHOLD,
     get_aws_sso_oidc_url,
     get_kiro_api_host,
@@ -108,6 +107,7 @@ class KiroAuthManager:
         client_secret: Optional[str] = None,
         sqlite_db: Optional[str] = None,
         api_region: Optional[str] = None,
+        internal_account_id: Optional[str] = None,
     ):
         """
         Initializes the authentication manager.
@@ -129,6 +129,7 @@ class KiroAuthManager:
         self._region = region
         self._creds_file = creds_file
         self._sqlite_db = sqlite_db
+        self._internal_account_id = internal_account_id
 
         # AWS SSO OIDC specific fields
         self._client_id: Optional[str] = client_id
@@ -158,11 +159,21 @@ class KiroAuthManager:
         self._fingerprint = get_machine_fingerprint()
 
         # Load credentials from SQLite if specified (takes priority over JSON)
-        if sqlite_db:
+        if internal_account_id:
+            from kiro.store import load_internal_credential
+
+            self._load_credentials_document(load_internal_credential(internal_account_id) or {})
+        elif sqlite_db:
             self._load_credentials_from_sqlite(sqlite_db)
         # Load credentials from JSON file if specified
         elif creds_file:
             self._load_credentials_from_file(creds_file)
+
+        # External credential stores are immutable inputs.  A token rotated by
+        # this gateway is kept in its private database and takes precedence on
+        # subsequent process starts.
+        if creds_file or sqlite_db:
+            self._load_gateway_overlay()
 
         # Determine auth type based on available credentials
         self._detect_auth_type()
@@ -234,7 +245,7 @@ class KiroAuthManager:
             self._auth_type = AuthType.KIRO_DESKTOP
             logger.info("Detected auth type: Kiro Desktop")
 
-    def _load_credentials_from_sqlite(self, db_path: str) -> None:
+    def _load_credentials_from_sqlite(self, db_path: str, *, apply_overlay: bool = True) -> None:
         """
         Loads credentials from kiro-cli SQLite database.
 
@@ -262,7 +273,7 @@ class KiroAuthManager:
                 logger.warning(f"SQLite database not found: {db_path}")
                 return
 
-            conn = sqlite3.connect(str(path))
+            conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
             cursor = conn.cursor()
 
             # Try all possible token keys in priority order
@@ -361,6 +372,8 @@ class KiroAuthManager:
                 logger.debug(f"Failed to auto-detect API region from profile ARN: {e}")
 
             conn.close()
+            if apply_overlay:
+                self._load_gateway_overlay()
             logger.info(f"Credentials loaded from SQLite database: {db_path}")
 
         except sqlite3.Error as e:
@@ -370,7 +383,7 @@ class KiroAuthManager:
         except Exception as e:
             logger.error(f"Error loading credentials from SQLite: {e}")
 
-    def _load_credentials_from_file(self, file_path: str) -> None:
+    def _load_credentials_from_file(self, file_path: str, *, apply_overlay: bool = True) -> None:
         """
         Loads credentials from a JSON file.
 
@@ -402,47 +415,52 @@ class KiroAuthManager:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
 
-            # Load common data from file
-            if "refreshToken" in data:
-                self._refresh_token = data["refreshToken"]
-            if "accessToken" in data:
-                self._access_token = data["accessToken"]
-            if "profileArn" in data:
-                self._profile_arn = data["profileArn"]
-            if "region" in data:
-                # Store as SSO region for OIDC token refresh
-                self._sso_region = data["region"]
-                # Also use as detected API region (can be overridden by KIRO_API_REGION env var)
-                self._detected_api_region = data["region"]
-                logger.debug(f"Region from JSON credentials: {data['region']}")
-
-            # Load clientIdHash and device registration for Enterprise Kiro IDE
-            if "clientIdHash" in data:
-                self._client_id_hash = data["clientIdHash"]
-                self._load_enterprise_device_registration(self._client_id_hash)
-
-            # Load AWS SSO OIDC specific fields (if directly in credentials file)
-            if "clientId" in data:
-                self._client_id = data["clientId"]
-            if "clientSecret" in data:
-                self._client_secret = data["clientSecret"]
-
-            # Parse expiresAt
-            if "expiresAt" in data:
-                try:
-                    expires_str = data["expiresAt"]
-                    # Support for different date formats
-                    if expires_str.endswith("Z"):
-                        self._expires_at = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
-                    else:
-                        self._expires_at = datetime.fromisoformat(expires_str)
-                except Exception as e:
-                    logger.warning(f"Failed to parse expiresAt: {e}")
+            self._load_credentials_document(data)
+            if apply_overlay:
+                self._load_gateway_overlay()
 
             logger.info(f"Credentials loaded from {file_path}")
 
         except Exception as e:
             logger.error(f"Error loading credentials from file: {e}")
+
+    def _load_credentials_document(self, data: dict) -> None:
+        # Load common credential fields from JSON or the internal store.
+        if "refreshToken" in data:
+            self._refresh_token = data["refreshToken"]
+        if "accessToken" in data:
+            self._access_token = data["accessToken"]
+        if "profileArn" in data:
+            self._profile_arn = data["profileArn"]
+        if "region" in data:
+            # Store as SSO region for OIDC token refresh
+            self._sso_region = data["region"]
+            # Also use as detected API region (can be overridden by KIRO_API_REGION env var)
+            self._detected_api_region = data["region"]
+            logger.debug(f"Region from JSON credentials: {data['region']}")
+
+        # Load clientIdHash and device registration for Enterprise Kiro IDE
+        if "clientIdHash" in data:
+            self._client_id_hash = data["clientIdHash"]
+            self._load_enterprise_device_registration(self._client_id_hash)
+
+        # Load AWS SSO OIDC specific fields (if directly in credentials file)
+        if "clientId" in data:
+            self._client_id = data["clientId"]
+        if "clientSecret" in data:
+            self._client_secret = data["clientSecret"]
+
+        # Parse expiresAt
+        if "expiresAt" in data:
+            try:
+                expires_str = data["expiresAt"]
+                # Support for different date formats
+                if expires_str.endswith("Z"):
+                    self._expires_at = datetime.fromisoformat(expires_str.replace("Z", "+00:00"))
+                else:
+                    self._expires_at = datetime.fromisoformat(expires_str)
+            except Exception as e:
+                logger.warning(f"Failed to parse expiresAt: {e}")
 
     def _load_enterprise_device_registration(self, client_id_hash: str) -> None:
         """
@@ -476,146 +494,103 @@ class KiroAuthManager:
             logger.error(f"Error loading enterprise device registration: {e}")
 
     def _save_credentials_to_file(self) -> None:
-        """
-        Saves updated credentials to a JSON file.
+        """Persist a rotation without modifying the external JSON input."""
+        self._save_gateway_overlay()
 
-        Updates the existing file while preserving other fields.
-        """
-        if not self._creds_file:
+    def _external_account_id(self) -> str | None:
+        source = self._sqlite_db or self._creds_file
+        return str(Path(source).expanduser().resolve()) if source else None
+
+    def _load_gateway_overlay(self) -> None:
+        account_id = self._external_account_id()
+        if not account_id:
             return
-
         try:
-            path = Path(self._creds_file).expanduser()
+            from kiro.store import load_internal_credential
 
-            # Read existing data
-            existing_data = {}
-            if path.exists():
-                with open(path, "r", encoding="utf-8") as f:
-                    existing_data = json.load(f)
+            overlay = load_internal_credential(account_id)
+            if overlay and self._overlay_is_fresher(overlay):
+                self._load_credentials_document(overlay)
+                logger.debug("Loaded gateway credential overlay for {}", account_id)
+        except Exception as exc:
+            logger.debug("No gateway credential overlay for {}: {}", account_id, exc)
 
-            # Update data
-            existing_data["accessToken"] = self._access_token
-            existing_data["refreshToken"] = self._refresh_token
-            if self._expires_at:
-                existing_data["expiresAt"] = self._expires_at.isoformat()
-            if self._profile_arn:
-                existing_data["profileArn"] = self._profile_arn
+    def _overlay_is_fresher(self, overlay: dict) -> bool:
+        """Prefer an overlay only when it is demonstrably at least as fresh."""
+        overlay_refresh = overlay.get("refreshToken")
+        if not overlay_refresh:
+            return False
+        if overlay_refresh == self._refresh_token:
+            return True
+        overlay_expiry = self._parse_expiry(overlay.get("expiresAt"))
+        if not overlay_expiry or not self._expires_at:
+            return False
+        return overlay_expiry > self._expires_at
 
-            # Save
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(existing_data, f, indent=2, ensure_ascii=False)
+    @staticmethod
+    def _parse_expiry(value: object) -> datetime | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed
+        except ValueError:
+            return None
 
-            logger.debug(f"Credentials saved to {self._creds_file}")
+    def _reload_raw_external_credentials(self) -> bool:
+        """Reload the immutable source, deliberately bypassing its overlay."""
+        if self._sqlite_db:
+            self._load_credentials_from_sqlite(self._sqlite_db, apply_overlay=False)
+            return True
+        if self._creds_file:
+            self._load_credentials_from_file(self._creds_file, apply_overlay=False)
+            return True
+        return False
 
-        except Exception as e:
-            logger.error(f"Error saving credentials: {e}")
+    def _save_gateway_overlay(self) -> None:
+        account_id = self._external_account_id()
+        if not account_id:
+            return
+        document = {
+            "accessToken": self._access_token,
+            "refreshToken": self._refresh_token,
+            "expiresAt": self._expires_at.isoformat() if self._expires_at else None,
+        }
+        if self._profile_arn:
+            document["profileArn"] = self._profile_arn
+        from kiro.store import connection, require_runtime_writer
+
+        with connection() as conn:
+            require_runtime_writer(conn)
+            updated = conn.execute(
+                "UPDATE account_sources SET credential_json = ? WHERE account_id = ?",
+                (json.dumps(document), account_id),
+            ).rowcount
+        if not updated:
+            # Standalone auth-manager consumers have no gateway-owned source row.
+            # Writer rejection above remains fatal for managed accounts.
+            logger.warning("Could not persist credential overlay for unregistered account {}", account_id)
+
+    def _save_credentials_to_internal_store(self) -> None:
+        if not self._internal_account_id:
+            return
+        from kiro.store import load_internal_credential, save_internal_credential
+
+        document = load_internal_credential(self._internal_account_id) or {}
+        document.update(
+            accessToken=self._access_token,
+            refreshToken=self._refresh_token,
+            expiresAt=self._expires_at.isoformat() if self._expires_at else None,
+        )
+        if self._profile_arn:
+            document["profileArn"] = self._profile_arn
+        save_internal_credential(self._internal_account_id, document)
 
     def _save_credentials_to_sqlite(self) -> None:
-        """
-        Saves updated credentials back to SQLite database.
-
-        Strategy: Read-Merge-Write (Issue #131 fix)
-        1. Read existing JSON from SQLite
-        2. Merge only updated fields (access_token, refresh_token, expires_at)
-        3. Preserve all unknown fields (startUrl, provider, registrationExpiresAt, etc.)
-        4. Write back merged JSON
-
-        This ensures compatibility with kiro-cli and future schema changes.
-        Unknown fields from kiro-cli are preserved, preventing data loss.
-
-        Respects SQLITE_READONLY flag - when enabled, skips write-back entirely.
-        """
-        if not self._sqlite_db:
-            return
-
-        # Check read-only mode
-        if SQLITE_READONLY:
-            logger.debug("SQLite write-back disabled (SQLITE_READONLY=true)")
-            return
-
-        try:
-            path = Path(self._sqlite_db).expanduser()
-            if not path.exists():
-                logger.warning(f"SQLite database not found for writing: {self._sqlite_db}")
-                return
-
-            # Use timeout to avoid blocking if database is locked
-            conn = sqlite3.connect(str(path), timeout=5.0)
-            cursor = conn.cursor()
-
-            # Try to save to the known key first (if we have it)
-            if self._sqlite_token_key:
-                if self._try_save_to_key(cursor, self._sqlite_token_key):
-                    conn.commit()
-                    conn.close()
-                    logger.debug(f"Credentials saved to SQLite key: {self._sqlite_token_key} (merged)")
-                    return
-                else:
-                    logger.warning(f"Failed to save to primary key: {self._sqlite_token_key}, trying fallback")
-
-            # Fallback: try all keys (for edge cases where source key is unknown or deleted)
-            for key in SQLITE_TOKEN_KEYS:
-                if self._try_save_to_key(cursor, key):
-                    conn.commit()
-                    conn.close()
-                    logger.debug(f"Credentials saved to SQLite key: {key} (fallback, merged)")
-                    return
-
-            # If we get here, no keys were updated
-            conn.close()
-            logger.warning("Failed to save credentials to SQLite: no matching keys found")
-
-        except sqlite3.Error as e:
-            logger.error(f"SQLite error saving credentials: {e}")
-        except Exception as e:
-            logger.error(f"Error saving credentials to SQLite: {e}")
-
-    def _try_save_to_key(self, cursor: sqlite3.Cursor, key: str) -> bool:
-        """
-        Attempts to save credentials to a specific SQLite key using read-merge-write.
-
-        Args:
-            cursor: SQLite cursor
-            key: SQLite key to save to
-
-        Returns:
-            True if save was successful, False otherwise
-        """
-        try:
-            # Read existing data
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", (key,))
-            row = cursor.fetchone()
-
-            if not row:
-                return False
-
-            # Parse existing JSON
-            try:
-                existing_data = json.loads(row[0])
-            except json.JSONDecodeError as e:
-                logger.warning(f"Failed to parse JSON for key {key}, skipping: {e}")
-                return False
-
-            # Merge: update ONLY our fields, preserve EVERYTHING else
-            existing_data["access_token"] = self._access_token
-            existing_data["refresh_token"] = self._refresh_token
-            existing_data["expires_at"] = self._expires_at.isoformat() if self._expires_at else None
-            existing_data["region"] = self._sso_region or self._region
-
-            # Update scopes if we have them
-            if self._scopes:
-                existing_data["scopes"] = self._scopes
-
-            token_json = json.dumps(existing_data)
-
-            # Write back merged data
-            cursor.execute("UPDATE auth_kv SET value = ? WHERE key = ?", (token_json, key))
-
-            return cursor.rowcount > 0
-
-        except Exception as e:
-            logger.debug(f"Failed to save to key {key}: {e}")
-            return False
+        """Persist a rotation without modifying the external Kiro CLI database."""
+        self._save_gateway_overlay()
 
     def is_token_expiring_soon(self) -> bool:
         """
@@ -662,12 +637,26 @@ class KiroAuthManager:
             ValueError: If refresh token is not set or response doesn't contain accessToken
             httpx.HTTPError: On HTTP request error
         """
+        if self._internal_account_id:
+            from kiro.store import refresh_internal_credential
+
+            self._load_credentials_document(refresh_internal_credential(self._internal_account_id))
         if self._auth_type == AuthType.AWS_SSO_OIDC:
             await self._refresh_token_aws_sso_oidc()
         else:
             await self._refresh_token_kiro_desktop()
 
     async def _refresh_token_kiro_desktop(self) -> None:
+        try:
+            await self._do_kiro_desktop_refresh()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 400 and self._reload_raw_external_credentials():
+                logger.warning("Token refresh failed with 400; retrying with raw external credentials")
+                await self._do_kiro_desktop_refresh()
+            else:
+                raise
+
+    async def _do_kiro_desktop_refresh(self) -> None:
         """
         Refreshes token using Kiro Desktop Auth endpoint.
 
@@ -718,7 +707,9 @@ class KiroAuthManager:
         logger.info(f"Token refreshed via Kiro Desktop Auth, expires: {self._expires_at.isoformat()}")
 
         # Save to file or SQLite depending on configuration
-        if self._sqlite_db:
+        if self._internal_account_id:
+            self._save_credentials_to_internal_store()
+        elif self._sqlite_db:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
@@ -750,9 +741,8 @@ class KiroAuthManager:
             await self._do_aws_sso_oidc_refresh()
         except httpx.HTTPStatusError as e:
             # 400 = invalid_request, likely stale token after kiro-cli re-login
-            if e.response.status_code == 400 and self._sqlite_db:
-                logger.warning("Token refresh failed with 400, reloading credentials from SQLite and retrying...")
-                self._load_credentials_from_sqlite(self._sqlite_db)
+            if e.response.status_code == 400 and self._reload_raw_external_credentials():
+                logger.warning("Token refresh failed with 400; retrying with raw external credentials")
                 await self._do_aws_sso_oidc_refresh()
             else:
                 raise
@@ -845,7 +835,9 @@ class KiroAuthManager:
         logger.info(f"Token refreshed via AWS SSO OIDC, expires: {self._expires_at.isoformat()}")
 
         # Save to file or SQLite depending on configuration
-        if self._sqlite_db:
+        if self._internal_account_id:
+            self._save_credentials_to_internal_store()
+        elif self._sqlite_db:
             self._save_credentials_to_sqlite()
         else:
             self._save_credentials_to_file()
@@ -884,7 +876,7 @@ class KiroAuthManager:
 
             # Try to refresh the token
             try:
-                await self._refresh_token_request()
+                await self._refresh_with_store_lease()
             except httpx.HTTPStatusError as e:
                 # Graceful degradation for SQLite mode when refresh fails twice
                 # This happens when kiro-cli refreshed tokens in memory without persisting
@@ -925,9 +917,39 @@ class KiroAuthManager:
             New access token
         """
         async with self._lock:
-            await self._refresh_token_request()
+            await self._refresh_with_store_lease(force=True)
             assert self._access_token is not None
             return self._access_token
+
+    async def _refresh_with_store_lease(self, *, force: bool = False) -> None:
+        """Serialize gateway-owned refreshes across blue/green processes."""
+        account_id = self._internal_account_id or self._external_account_id()
+        if not account_id:
+            await self._refresh_token_request()
+            return
+
+        from kiro.store import (
+            load_internal_credential,
+            release_refresh_lease,
+            try_acquire_refresh_lease,
+        )
+
+        previous_token = self._access_token
+        owner = None
+        while owner is None:
+            owner = try_acquire_refresh_lease(account_id)
+            if owner is None:
+                await asyncio.sleep(0.05)
+        try:
+            latest = load_internal_credential(account_id)
+            if latest:
+                self._load_credentials_document(latest)
+            renewed_elsewhere = self._access_token != previous_token
+            if self._access_token and not self.is_token_expiring_soon() and (not force or renewed_elsewhere):
+                return
+            await self._refresh_token_request()
+        finally:
+            release_refresh_lease(account_id, owner)
 
     @property
     def profile_arn(self) -> Optional[str]:

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -80,7 +80,7 @@ SERVER_PORT: int = int(os.getenv("SERVER_PORT", str(DEFAULT_SERVER_PORT)))
 # ==================================================================================================
 
 # API key for proxy access (clients must pass it in Authorization header)
-PROXY_API_KEY: str = os.getenv("PROXY_API_KEY", "my-super-secret-password-123")
+PROXY_API_KEY: str = os.getenv("PROXY_API_KEY", "")
 
 # ==================================================================================================
 # VPN/Proxy Settings for Kiro API Access
@@ -510,10 +510,10 @@ WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "false").lower() in (
 # When true: enables full failover loop with Circuit Breaker
 ACCOUNT_SYSTEM: bool = os.getenv("ACCOUNT_SYSTEM", "false").lower() in ("true", "1", "yes")
 
-# Path to credentials configuration file
+# Legacy gateway JSON import paths. SQLite is authoritative after first import;
+# these files are never written or deleted by the gateway.
 ACCOUNTS_CONFIG_FILE: str = os.getenv("ACCOUNTS_CONFIG_FILE", "credentials.json")
 
-# Path to runtime state file
 ACCOUNTS_STATE_FILE: str = os.getenv("ACCOUNTS_STATE_FILE", "state.json")
 
 # ==================================================================================================
@@ -593,7 +593,7 @@ ACCOUNT_CACHE_TTL: int = int(os.getenv("ACCOUNT_CACHE_TTL", "43200"))
 # State Persistence Settings
 # ==================================================================================================
 
-# Interval for periodic state.json saving in seconds
+# Interval for periodic runtime-state saving in seconds
 STATE_SAVE_INTERVAL_SECONDS: int = int(os.getenv("STATE_SAVE_INTERVAL_SECONDS", "10"))
 
 # Dashboard live usage polling interval. A value of 0 disables background refresh;

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -826,21 +826,33 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
     for msg in messages:
         # Check if this message has tool_results
         if msg.tool_results:
-            # Check if the previous message is an assistant with tool_calls
-            has_preceding_assistant = result and result[-1].role == "assistant" and result[-1].tool_calls
+            # Adjacent assistant turns are merged later because Kiro requires
+            # alternating roles. Validate against that whole pending assistant
+            # run rather than only its final element.
+            preceding_calls = []
+            for previous in reversed(result):
+                if previous.role != "assistant":
+                    break
+                preceding_calls.extend(previous.tool_calls or [])
+            valid_ids = {
+                call.get("id") or call.get("toolUseId")
+                for call in preceding_calls
+                if call.get("id") or call.get("toolUseId")
+            }
+            matching = [tr for tr in msg.tool_results if tr.get("tool_use_id") in valid_ids]
+            unmatched = [tr for tr in msg.tool_results if tr.get("tool_use_id") not in valid_ids]
 
-            if not has_preceding_assistant:
+            if unmatched:
                 # We cannot create a valid synthetic assistant message because we don't know
                 # the original tool name and arguments. Kiro API validates tool names.
                 # Convert tool_results to text to preserve context for the model.
                 logger.debug(
-                    f"Converting {len(msg.tool_results)} orphaned tool_results to text "
-                    f"(no preceding assistant message with tool_calls). "
-                    f"Tool IDs: {[tr.get('tool_use_id', 'unknown') for tr in msg.tool_results]}"
+                    f"Converting {len(unmatched)} unmatched tool_results to text. "
+                    f"Tool IDs: {[tr.get('tool_use_id', 'unknown') for tr in unmatched]}"
                 )
 
                 # Convert tool_results to text representation
-                tool_results_text = tool_results_to_text(msg.tool_results)
+                tool_results_text = tool_results_to_text(unmatched)
 
                 # Append to existing content
                 original_content = extract_text_content(msg.content) or ""
@@ -856,7 +868,7 @@ def ensure_assistant_before_tool_results(messages: List[UnifiedMessage]) -> Tupl
                     role=msg.role,
                     content=new_content,
                     tool_calls=msg.tool_calls,
-                    tool_results=None,  # Remove orphaned tool_results (now in text)
+                    tool_results=matching or None,
                     images=msg.images,
                     reasoning=msg.reasoning,
                     reasoning_signature=msg.reasoning_signature,
@@ -1310,7 +1322,10 @@ def build_kiro_payload(
     # If current message is assistant, need to add it to history
     # and create user message placeholder
     if current_message.role == "assistant":
-        history.append({"assistantResponseMessage": {"content": current_content}})
+        # Preserve signed reasoning and native tool calls on a final assistant
+        # continuation exactly as for any prior assistant turn. Dropping toolUses
+        # here can leave the following tool result structurally orphaned.
+        history.extend(build_kiro_history([current_message], model_id))
         # No filler text: the assistant turn above is the prompt to continue.
         current_content = ""
 
@@ -1388,6 +1403,8 @@ def build_kiro_payload(
                 f"Trimmed conversation history: {stats.original_entries} -> {stats.final_entries} messages "
                 f"({stats.original_bytes} -> {stats.final_bytes} bytes)"
             )
+            if stats.final_bytes > KIRO_MAX_PAYLOAD_BYTES:
+                raise PayloadTooLargeError(stats.final_bytes, KIRO_MAX_PAYLOAD_BYTES)
         else:
             logger.warning(
                 f"Payload {payload_size} bytes exceeds the {KIRO_MAX_PAYLOAD_BYTES} byte limit "

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -8,15 +8,15 @@ keys, refresh tokens, or OAuth credentials are written to its SQLite database.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import os
 import secrets
 import sqlite3
 import time
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import FileResponse
@@ -41,46 +41,33 @@ from kiro.config import (
 from kiro.device_login import (
     DeviceLoginError,
     discard_flow,
+    internal_credentials,
     poll_device_login,
     resolve_provider,
     start_device_login,
-    write_builder_id_credentials,
-    write_social_credentials,
 )
 from kiro.metrics import CONTENT_TYPE as METRICS_CONTENT_TYPE
 from kiro.metrics import render_metrics
 from kiro.model_resolver import normalize_model_name
+from kiro.store import connection as _db
+from kiro.store import initialize as initialize_shared_store
 from kiro.usage import fetch_account_usage
-from kiro.usage_tracking import ROOT_KEY_ID, drain_pending_usage
+from kiro.usage_tracking import ROOT_KEY_ID, drain_pending_usage, restore_pending_usage
 
 router = APIRouter(tags=["dashboard"])
 
-_DATA_DIR = Path(os.getenv("DASHBOARD_DATA_DIR", "data"))
-_DB_PATH = _DATA_DIR / "dashboard.sqlite3"
 _STATIC_DIR = Path(__file__).parent / "static"
 _COOKIE = "kiro_lb_session"
 _SESSION_TTL_SECONDS = 12 * 60 * 60
-_sessions: dict[str, float] = {}
 
 
-@contextmanager
-def _db() -> Iterator[sqlite3.Connection]:
-    """Yield a dashboard-store connection, committing then closing it.
-
-    sqlite3's own context manager commits but leaves the connection open, which
-    leaks a handle per call. Every store access goes through here.
-    """
-    _DATA_DIR.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(_DB_PATH)
-    conn.row_factory = sqlite3.Row
-    try:
-        with conn:
-            yield conn
-    finally:
-        conn.close()
+def _proxy_api_key() -> str:
+    """Return the legacy root key without caching environment state."""
+    return os.getenv("PROXY_API_KEY", "")
 
 
 def initialize_dashboard_store() -> None:
+    initialize_shared_store()
     with _db() as conn:
         conn.execute(
             """CREATE TABLE IF NOT EXISTS request_logs (
@@ -93,6 +80,45 @@ def initialize_dashboard_store() -> None:
             )"""
         )
         conn.execute("CREATE INDEX IF NOT EXISTS idx_request_logs_created_at ON request_logs(created_at)")
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS request_metric_rollups (
+                route TEXT NOT NULL, model TEXT NOT NULL, status_code INTEGER NOT NULL,
+                requests INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(route, model, status_code)
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS request_latency_rollups (
+                route TEXT NOT NULL, model TEXT NOT NULL,
+                requests INTEGER NOT NULL DEFAULT 0, latency_ms INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY(route, model)
+            )"""
+        )
+        conn.execute("CREATE TABLE IF NOT EXISTS dashboard_migrations (name TEXT PRIMARY KEY)")
+        if not conn.execute("SELECT 1 FROM dashboard_migrations WHERE name = 'request_rollups_v1'").fetchone():
+            conn.execute(
+                "INSERT INTO request_metric_rollups(route, model, status_code, requests)"
+                " SELECT route, COALESCE(model, ''), status_code, COUNT(*)"
+                " FROM request_logs GROUP BY route, COALESCE(model, ''), status_code"
+            )
+            conn.execute(
+                "INSERT INTO request_latency_rollups(route, model, requests, latency_ms)"
+                " SELECT route, COALESCE(model, ''), COUNT(*), COALESCE(SUM(latency_ms), 0) FROM request_logs"
+                " WHERE status_code BETWEEN 200 AND 399 GROUP BY route, COALESCE(model, '')"
+            )
+            conn.execute("INSERT INTO dashboard_migrations(name) VALUES ('request_rollups_v1')")
+        conn.execute(
+            """CREATE TRIGGER IF NOT EXISTS rollup_request_log AFTER INSERT ON request_logs BEGIN
+                INSERT INTO request_metric_rollups(route, model, status_code, requests)
+                VALUES (NEW.route, COALESCE(NEW.model, ''), NEW.status_code, 1)
+                ON CONFLICT(route, model, status_code) DO UPDATE SET requests = requests + 1;
+                INSERT INTO request_latency_rollups(route, model, requests, latency_ms)
+                SELECT NEW.route, COALESCE(NEW.model, ''), 1, NEW.latency_ms
+                WHERE NEW.status_code BETWEEN 200 AND 399
+                ON CONFLICT(route, model) DO UPDATE SET requests = requests + 1,
+                    latency_ms = latency_ms + excluded.latency_ms;
+            END"""
+        )
         # Rate observations back the inferred rate limit shown on the dashboard.
         # Only the RPM at each upstream verdict is kept, which is what the
         # estimate needs; the high-resolution chart ring stays in memory.
@@ -241,18 +267,20 @@ def prune_request_logs() -> int:
         return 0
 
 
-def record_rate_observations(rows: list[tuple[str, float, int, int, str]]) -> None:
+def record_rate_observations(rows: list[tuple[str, float, int, int, str]]) -> bool:
     """Persist (account_id, observed_at, rpm, rejected, outcome) rate samples."""
     if not rows:
-        return
+        return True
     try:
         with _db() as conn:
             conn.executemany(
                 "INSERT INTO rate_observations(account_id, observed_at, rpm, rejected, outcome) VALUES (?, ?, ?, ?, ?)",
                 rows,
             )
-    except Exception:
-        pass
+        return True
+    except Exception as exc:
+        logger.error("Failed to persist rate observations: {}", exc)
+        return False
 
 
 def load_rate_observations(since: float) -> list[tuple[str, float, int, int, str]]:
@@ -303,7 +331,9 @@ def flush_key_model_usage() -> int:
                 ],
             )
         return len(pending)
-    except Exception:
+    except Exception as exc:
+        restore_pending_usage(pending)
+        logger.error("Failed to flush key-model usage; restored pending batch: {}", exc)
         return 0
 
 
@@ -358,6 +388,20 @@ def _password() -> str:
     return os.getenv("DASHBOARD_PASSWORD", "")
 
 
+def _session_token(expires_at: int) -> str:
+    payload = str(expires_at)
+    signature = hmac.new(_password().encode(), payload.encode(), hashlib.sha256).digest()
+    return f"{payload}.{base64.urlsafe_b64encode(signature).decode().rstrip('=')}"
+
+
+def _secure_cookie(request: Request) -> bool:
+    configured = os.getenv("DASHBOARD_SECURE_COOKIE")
+    if configured is not None:
+        return configured.lower() in ("true", "1", "yes")
+    forwarded = request.headers.get("x-forwarded-proto", "").split(",", 1)[0].strip()
+    return request.url.scheme == "https" or forwarded == "https"
+
+
 def _hash_api_key(value: str, salt: bytes) -> bytes:
     return hashlib.scrypt(value.encode("utf-8"), salt=salt, n=2**14, r=8, p=1)
 
@@ -389,7 +433,7 @@ def identify_data_api_key(value: str) -> str | None:
     The legacy environment key answers as ROOT_KEY_ID: it has no row of its own
     but still needs to be attributable in per-key usage.
     """
-    legacy = os.getenv("PROXY_API_KEY", "")
+    legacy = _proxy_api_key()
     if legacy and hmac.compare_digest(value, legacy):
         return ROOT_KEY_ID
     if not value.startswith("klb_"):
@@ -441,9 +485,12 @@ def _authenticated(request: Request) -> bool:
     token = request.cookies.get(_COOKIE)
     if not token:
         return False
-    expires_at = _sessions.get(token, 0)
-    if expires_at <= time.time():
-        _sessions.pop(token, None)
+    try:
+        raw_expiry, supplied = token.split(".", 1)
+        expected = _session_token(int(raw_expiry)).split(".", 1)[1]
+        if int(raw_expiry) <= time.time() or not hmac.compare_digest(supplied, expected):
+            return False
+    except (TypeError, ValueError):
         return False
     return True
 
@@ -578,14 +625,13 @@ async def dashboard_login(request: Request, response: Response) -> dict[str, boo
     candidate = str(payload.get("password", ""))
     if not hmac.compare_digest(candidate, password):
         raise HTTPException(status_code=401, detail="Invalid password")
-    token = secrets.token_urlsafe(32)
-    _sessions[token] = time.time() + _SESSION_TTL_SECONDS
+    token = _session_token(int(time.time()) + _SESSION_TTL_SECONDS)
     response.set_cookie(
         _COOKIE,
         token,
         httponly=True,
         samesite="strict",
-        secure=request.url.scheme == "https",
+        secure=_secure_cookie(request),
         max_age=_SESSION_TTL_SECONDS,
     )
     return {"ok": True}
@@ -593,8 +639,7 @@ async def dashboard_login(request: Request, response: Response) -> dict[str, boo
 
 @router.post("/api/dashboard/logout")
 async def dashboard_logout(request: Request, response: Response) -> dict[str, bool]:
-    _sessions.pop(request.cookies.get(_COOKIE, ""), None)
-    response.delete_cookie(_COOKIE)
+    response.delete_cookie(_COOKIE, httponly=True, samesite="strict", secure=_secure_cookie(request))
     return {"ok": True}
 
 
@@ -605,7 +650,7 @@ async def dashboard_list_keys(request: Request) -> dict[str, list[dict[str, Any]
     # The legacy environment key authenticates real traffic but has no row, so
     # it is listed as a read-only root entry: usage must be attributable to it,
     # and it cannot be revoked from here because it lives in the environment.
-    legacy = os.getenv("PROXY_API_KEY", "")
+    legacy = _proxy_api_key()
     if legacy:
         keys.append(
             {
@@ -735,19 +780,11 @@ async def dashboard_register_device_login(flow_id: str, request: Request) -> dic
     if not refresh_token:
         raise HTTPException(status_code=502, detail="Kiro approved the login without a refresh token")
 
-    # Both providers rotate the refresh token on every refresh, so both need a
-    # file the auth manager can write the rotated token back to. An inline
-    # refresh_token entry has none: the account survived one token lifetime and
-    # then answered 401 "Bad credentials" on the next cold init.
-    if flow.provider == "BuilderId":
-        credential_path = write_builder_id_credentials(flow, _DATA_DIR / "logins")
-        registration: dict[str, Any] = {"type": "json", "path": str(credential_path)}
-    else:
-        credential_path = write_social_credentials(flow, _DATA_DIR / "logins")
-        registration = {"type": "json", "path": str(credential_path)}
-        profile_arn = flow.token.get("profileArn")
-        if profile_arn:
-            registration["profileArn"] = profile_arn
+    registration = {
+        "type": "internal",
+        "id": f"device-{flow.provider.lower()}-{flow.id}",
+        "credential": internal_credentials(flow),
+    }
 
     try:
         result = await register_account(request.app.state.account_manager, registration)
@@ -784,13 +821,8 @@ async def dashboard_accounts(request: Request) -> dict[str, list[dict[str, Any]]
 async def dashboard_delete_account(label: str, request: Request) -> dict[str, bool]:
     _require_auth(request)
 
-    def delete_metadata(account_id: str) -> None:
-        with _db() as conn:
-            conn.execute("DELETE FROM account_usage WHERE account_id = ?", (account_id,))
-            conn.execute("DELETE FROM rate_observations WHERE account_id = ?", (account_id,))
-
     try:
-        await remove_account(request.app.state.account_manager, label, finalize=delete_metadata)
+        await remove_account(request.app.state.account_manager, label)
     except AccountNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except AccountConflictError as exc:

--- a/kiro/device_login.py
+++ b/kiro/device_login.py
@@ -11,12 +11,12 @@ the polling logic is deliberately not shared:
 - Social (Google / GitHub) on ``prod.us-east-1.auth.desktop.kiro.dev``. Pending
   is HTTP 200 with a ``status`` field, timings are milliseconds, and the response
   carries ``profileArn``, which routes the account to ``runtime.kiro.dev``.
-  Refreshing rotates the refresh token, so the credentials must live in a file
-  the auth manager can write back to.
+  Refreshing rotates the refresh token, which is updated in the private store.
 - Builder ID (AWS SSO OIDC) on ``oidc.{region}.amazonaws.com``. Pending is HTTP
   400 with an ``authorization_pending`` code, timings are seconds, and refreshing
   needs the client registration, so the client id and secret are stored with the
-  refresh token. Builder ID has no profile and must use ``q.{region}.amazonaws.com``.
+  refresh token in SQLite. Builder ID has no profile and must use
+  ``q.{region}.amazonaws.com``.
 
 Ported from the kiro-auth TypeScript reference.
 """
@@ -24,12 +24,9 @@ Ported from the kiro-auth TypeScript reference.
 from __future__ import annotations
 
 import asyncio
-import json
-import os
 import secrets
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Dict, Literal, Optional
 
 import httpx
@@ -336,65 +333,32 @@ async def await_approval(flow_id: str, timeout_seconds: float) -> DeviceFlow:
     return flow
 
 
-def _write_credential_file(path: Path, document: Dict[str, Any]) -> Path:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
-    os.chmod(path, 0o600)
-    return path
-
-
 def _expires_at(expires_in: Any) -> str:
     seconds = float(expires_in or 3600)
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + seconds))
 
 
-def write_builder_id_credentials(flow: DeviceFlow, directory: Path) -> Path:
-    """Persist a Builder ID login as a JSON credential file and return its path.
-
-    Builder ID refresh needs the client registration, not just the refresh token.
-    The field names are the ones auth.py reads, and clientId/clientSecret are what
-    make it detect AWS SSO OIDC rather than the Kiro Desktop endpoint.
-    """
-    if not flow.token or not flow.registration:
-        raise ValueError("Builder ID login is not approved")
-
-    document = {
-        "refreshToken": flow.token.get("refreshToken"),
-        "accessToken": flow.token.get("accessToken"),
-        "expiresAt": _expires_at(flow.token.get("expiresIn")),
-        "region": flow.registration["region"],
-        "clientId": flow.registration["clientId"],
-        "clientSecret": flow.registration["clientSecret"],
-        "startUrl": BUILDER_ID_START_URL,
-    }
-    return _write_credential_file(directory / f"builder-id-{flow.id}.json", document)
-
-
-def write_social_credentials(flow: DeviceFlow, directory: Path) -> Path:
-    """Persist a social login as a JSON credential file and return its path.
-
-    The Kiro Desktop refresh endpoint rotates the refresh token and rejects the
-    previous one with 401 "Bad credentials". An inline ``refresh_token`` pool
-    entry has no file to write the rotation back to, so the account worked for one
-    token lifetime and then died on the next cold init. A JSON file gives
-    ``_save_credentials_to_file`` somewhere to persist the rotated token.
-
-    No clientId/clientSecret is written: their absence is what makes auth.py keep
-    using the Kiro Desktop endpoint instead of AWS SSO OIDC.
-    """
+def internal_credentials(flow: DeviceFlow) -> Dict[str, Any]:
+    """Build the private credential document stored for an approved login."""
     if not flow.token:
         raise ValueError(f"{flow.provider} login is not approved")
-
     document: Dict[str, Any] = {
         "refreshToken": flow.token.get("refreshToken"),
         "accessToken": flow.token.get("accessToken"),
         "expiresAt": _expires_at(flow.token.get("expiresIn")),
         "region": SOCIAL_REGION,
     }
-    profile_arn = flow.token.get("profileArn")
-    if profile_arn:
-        document["profileArn"] = profile_arn
-    identity_provider = flow.token.get("identityProvider")
-    if identity_provider:
-        document["identityProvider"] = identity_provider
-    return _write_credential_file(directory / f"social-{flow.provider.lower()}-{flow.id}.json", document)
+    if flow.provider == "BuilderId":
+        if not flow.registration:
+            raise ValueError("Builder ID login has no client registration")
+        document.update(
+            region=flow.registration["region"],
+            clientId=flow.registration["clientId"],
+            clientSecret=flow.registration["clientSecret"],
+            startUrl=BUILDER_ID_START_URL,
+        )
+    else:
+        for source, target in (("profileArn", "profileArn"), ("identityProvider", "identityProvider")):
+            if flow.token.get(source):
+                document[target] = flow.token[source]
+    return document

--- a/kiro/metrics.py
+++ b/kiro/metrics.py
@@ -142,10 +142,7 @@ def _preamble() -> Iterator[str]:
 
 
 def _request_metrics(conn: Any, known: frozenset[str]) -> Iterator[str]:
-    rows = conn.execute(
-        "SELECT route, model, status_code, COUNT(*) AS requests, COALESCE(SUM(latency_ms), 0) AS latency_ms"
-        " FROM request_logs GROUP BY route, model, status_code"
-    ).fetchall()
+    rows = conn.execute("SELECT route, model, status_code, requests FROM request_metric_rollups").fetchall()
     # Re-aggregated in Python rather than SQL: several raw model names collapse
     # into the same label, and emitting one line per raw name would repeat a
     # series, which Prometheus rejects as a duplicate.
@@ -159,10 +156,7 @@ def _request_metrics(conn: Any, known: frozenset[str]) -> Iterator[str]:
 
     # Latency is summed separately: it has no status_class dimension, because a
     # rejected request's latency says nothing about generation speed.
-    latency = conn.execute(
-        "SELECT route, model, COUNT(*) AS requests, COALESCE(SUM(latency_ms), 0) AS latency_ms"
-        " FROM request_logs WHERE status_code BETWEEN 200 AND 399 GROUP BY route, model"
-    ).fetchall()
+    latency = conn.execute("SELECT route, model, requests, latency_ms FROM request_latency_rollups").fetchall()
     timed: dict[tuple[str, str], tuple[int, int]] = {}
     for row in latency:
         timed_key = (_model(row["model"], known), _protocol(row["route"]))

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -197,28 +197,39 @@ async def messages(
     # Account System: Account System Failover or Legacy Mode
     # ==============================================================================
 
-    if request.app.state.account_system:
-        # ==============================================================================
-        # ACCOUNT SYSTEM ENABLED: Failover Loop
-        # ==============================================================================
+    account_system = request.app.state.account_system
+    while True:
         from kiro.account_errors import ErrorType, classify_error
 
         account_manager = request.app.state.account_manager
         all_accounts = list(account_manager._accounts.keys())
-        MAX_ATTEMPTS = len(all_accounts) * 2  # Full circle with margin
+        single_attempt = not account_system or len(all_accounts) == 1
+        max_attempts = 1 if not account_system else max(1, len(all_accounts) * 2)
 
         last_error_message = None
         last_error_status = None
         tried_accounts: set[str] = set()  # Track tried accounts in current failover loop
 
-        for attempt in range(MAX_ATTEMPTS):
-            # Get next available account (excluding already tried)
-            account = await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
+        for _attempt in range(max_attempts):
+            account = (
+                await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
+                if account_system
+                else account_manager.get_first_account()
+            )
 
-            if account is None:
+            if account is None or not account.auth_manager:
                 # All accounts unavailable
-                if len(all_accounts) == 1:
+                if single_attempt:
                     # Single account - return original error with original status code
+                    if not account_system:
+                        logger.error("No initialized accounts available (legacy mode)")
+                        return JSONResponse(
+                            status_code=503,
+                            content={
+                                "type": "error",
+                                "error": {"type": "api_error", "message": "No initialized accounts available"},
+                            },
+                        )
                     return JSONResponse(
                         status_code=last_error_status or 503,
                         content={
@@ -299,6 +310,25 @@ async def messages(
             else:
                 system_for_tokenizer = request_data.system
 
+            async def make_search_request(tool_use_id: str, query: str, result_content: str) -> httpx.Response:
+                followup_request = request_data.model_copy(deep=True)
+                followup_request.messages.extend(
+                    [
+                        AnthropicMessage(
+                            role="assistant",
+                            content=[ToolUseContentBlock(id=tool_use_id, name="web_search", input={"query": query})],
+                        ),
+                        AnthropicMessage(
+                            role="user",
+                            content=[ToolResultContentBlock(tool_use_id=tool_use_id, content=result_content)],
+                        ),
+                    ]
+                )
+                followup_payload = anthropic_to_kiro(followup_request, conversation_id, profile_arn_for_payload)
+                return await http_client.request_with_retry(
+                    "POST", url, followup_payload, stream=True, retry_rate_limits=False
+                )
+
             try:
                 # Make request to Kiro API
                 response = await http_client.request_with_retry(
@@ -306,9 +336,6 @@ async def messages(
                 )
 
                 if response.status_code == 200:
-                    # SUCCESS - report and return
-                    await account_manager.report_success(account.id, request_data.model)
-
                     if request_data.stream:
                         # Streaming mode
                         async def stream_wrapper():
@@ -330,8 +357,11 @@ async def messages(
                                     request_messages=messages_for_tokenizer,
                                     request_tools=tools_for_tokenizer,
                                     request_system=system_for_tokenizer,
+                                    make_search_request=make_search_request,
                                 ):
                                     yield chunk
+                                if account_system:
+                                    await account_manager.report_success(account.id, request_data.model)
                             except GeneratorExit:
                                 client_disconnected = True
                                 logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
@@ -380,7 +410,10 @@ async def messages(
                             request_messages=messages_for_tokenizer,
                             request_tools=tools_for_tokenizer,
                             request_system=system_for_tokenizer,
+                            make_search_request=make_search_request,
                         )
+                        if account_system:
+                            await account_manager.report_success(account.id, request_data.model)
 
                         await http_client.close()
                         logger.info("HTTP 200 - POST /v1/messages (non-streaming) - completed")
@@ -428,14 +461,15 @@ async def messages(
 
                     if error_type == ErrorType.FATAL:
                         # FATAL - return to client immediately
-                        await account_manager.report_failure(
-                            account.id,
-                            request_data.model,
-                            error_type,
-                            response.status_code,
-                            error_reason,
-                            upstream_message,
-                        )
+                        if account_system:
+                            await account_manager.report_failure(
+                                account.id,
+                                request_data.model,
+                                error_type,
+                                response.status_code,
+                                error_reason,
+                                upstream_message,
+                            )
 
                         logger.warning(f"HTTP {response.status_code} - POST /v1/messages - {last_error_message[:100]}")
 
@@ -449,17 +483,25 @@ async def messages(
 
                     else:  # ErrorType.RECOVERABLE
                         # RECOVERABLE - try next account
-                        await account_manager.report_failure(
-                            account.id,
-                            request_data.model,
-                            error_type,
-                            response.status_code,
-                            error_reason,
-                            upstream_message,
-                        )
+                        if account_system:
+                            await account_manager.report_failure(
+                                account.id,
+                                request_data.model,
+                                error_type,
+                                response.status_code,
+                                error_reason,
+                                upstream_message,
+                            )
 
-                        # Single account - no point in failover, break immediately
-                        if len(all_accounts) == 1:
+                        if single_attempt:
+                            if not account_system:
+                                return JSONResponse(
+                                    status_code=response.status_code,
+                                    content={
+                                        "type": "error",
+                                        "error": {"type": "api_error", "message": last_error_message},
+                                    },
+                                )
                             break
 
                         continue  # Next iteration
@@ -472,15 +514,21 @@ async def messages(
                 # NOT for HTTP-level errors (which are returned as response objects)
                 if e.status_code in (502, 504):
                     # Network error → try next account
-                    await account_manager.report_failure(
-                        account.id, request_data.model, ErrorType.RECOVERABLE, e.status_code, None
-                    )
+                    if account_system:
+                        await account_manager.report_failure(
+                            account.id, request_data.model, ErrorType.RECOVERABLE, e.status_code, None
+                        )
 
                     last_error_message = str(e.detail)
                     last_error_status = e.status_code
 
                     # Single account - no point in failover, break immediately
-                    if len(all_accounts) == 1:
+                    if single_attempt:
+                        if not account_system:
+                            logger.warning("Network error (legacy mode, no failover available)")
+                            if debug_logger:
+                                debug_logger.flush_on_error(e.status_code, str(e.detail))
+                            raise
                         break
 
                     logger.warning(f"Network error on account {account.id}, trying next account")
@@ -508,7 +556,7 @@ async def messages(
                 )
 
         # All attempts exhausted
-        if len(all_accounts) == 1:
+        if single_attempt:
             # Single account - return its original error
             # last_error_status and last_error_message are guaranteed to be set
             assert last_error_status is not None
@@ -527,250 +575,6 @@ async def messages(
             return JSONResponse(
                 status_code=503, content={"type": "error", "error": {"type": "api_error", "message": detail}}
             )
-
-    else:
-        # ==============================================================================
-        # LEGACY MODE: Single Account (no failover)
-        # ==============================================================================
-        account = request.app.state.account_manager.get_first_account()
-        if not account.auth_manager:
-            logger.error("No initialized accounts available (legacy mode)")
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "type": "error",
-                    "error": {"type": "api_error", "message": "No initialized accounts available"},
-                },
-            )
-        auth_manager = account.auth_manager
-        model_cache = account.model_cache
-
-    # ==============================================================================
-    # Normal Flow (Path B will be intercepted in streaming, or no web_search)
-    # ==============================================================================
-
-    # Generate conversation ID for Kiro API (random UUID, not used for tracking)
-    conversation_id = generate_conversation_id()
-
-    # Build payload for Kiro
-    # A Builder ID account has no profile and must not be given one: the global
-    # fallback would send a foreign ARN and fail the request.
-    profile_arn_for_payload = auth_manager.profile_arn or (
-        "" if auth_manager.auth_type == AuthType.AWS_SSO_OIDC else PROFILE_ARN or ""
-    )
-
-    try:
-        kiro_payload = anthropic_to_kiro(request_data, conversation_id, profile_arn_for_payload)
-    except PayloadTooLargeError as e:
-        logger.error(f"Payload too large: {e}")
-        return JSONResponse(
-            status_code=400, content={"type": "error", "error": {"type": "invalid_request_error", "message": str(e)}}
-        )
-    except ValueError as e:
-        logger.error(f"Conversion error: {e}")
-        return JSONResponse(
-            status_code=400, content={"type": "error", "error": {"type": "invalid_request_error", "message": str(e)}}
-        )
-
-    # Log Kiro payload
-    try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode("utf-8")
-        if debug_logger:
-            debug_logger.log_kiro_request_body(kiro_request_body)
-    except Exception as e:
-        logger.warning(f"Failed to log Kiro request: {e}")
-
-    # Create HTTP client with retry logic
-    # For streaming: use per-request client to avoid CLOSE_WAIT leak on VPN disconnect (issue #54)
-    # For non-streaming: use shared client for connection pooling
-    url = f"{auth_manager.api_host}/generateAssistantResponse"
-    logger.debug(f"Kiro API URL: {url}")
-
-    if request_data.stream:
-        # Streaming mode: per-request client prevents orphaned connections
-        # when network interface changes (VPN disconnect/reconnect)
-        http_client = KiroHttpClient(auth_manager, shared_client=None)
-    else:
-        # Non-streaming mode: shared client for efficient connection reuse
-        shared_client = request.app.state.http_client
-        http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
-
-    # Prepare data for token counting
-    # Convert Pydantic models to dicts for tokenizer
-    messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
-    tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
-    # Serialize system prompt (may be a list of Pydantic objects)
-    if isinstance(request_data.system, list):
-        system_for_tokenizer = [b.model_dump() if hasattr(b, "model_dump") else b for b in request_data.system]
-    else:
-        system_for_tokenizer = request_data.system
-
-    async def make_search_request(tool_use_id: str, query: str, result_content: str) -> httpx.Response:
-        followup_request = request_data.model_copy(deep=True)
-        followup_request.messages.extend(
-            [
-                AnthropicMessage(
-                    role="assistant",
-                    content=[ToolUseContentBlock(id=tool_use_id, name="web_search", input={"query": query})],
-                ),
-                AnthropicMessage(
-                    role="user",
-                    content=[ToolResultContentBlock(tool_use_id=tool_use_id, content=result_content)],
-                ),
-            ]
-        )
-        followup_payload = anthropic_to_kiro(followup_request, conversation_id, profile_arn_for_payload)
-        return await http_client.request_with_retry("POST", url, followup_payload, stream=True, retry_rate_limits=False)
-
-    try:
-        # Make request to Kiro API (for both streaming and non-streaming modes)
-        # Important: we wait for Kiro response BEFORE returning StreamingResponse,
-        # so that we can return proper HTTP error codes if Kiro fails
-        response = await http_client.request_with_retry("POST", url, kiro_payload, stream=True, retry_rate_limits=False)
-
-        if response.status_code != 200:
-            try:
-                error_content = await response.aread()
-            except Exception:
-                error_content = b"Unknown error"
-
-            await http_client.close()
-            error_text = error_content.decode("utf-8", errors="replace")
-
-            # Try to parse JSON response from Kiro to extract error message
-            error_message = error_text
-            try:
-                error_json = json.loads(error_text)
-                # Enhance Kiro API errors with user-friendly messages
-                from kiro.kiro_errors import enhance_kiro_error
-
-                error_info = enhance_kiro_error(error_json)
-                error_message = error_info.user_message
-                # Log original error for debugging
-                logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
-            except (json.JSONDecodeError, KeyError):
-                pass
-
-            # Log access log for error (before flush, so it gets into app_logs)
-            logger.warning(f"HTTP {response.status_code} - POST /v1/messages - {error_message[:100]}")
-
-            # Flush debug logs on error
-            if debug_logger:
-                debug_logger.flush_on_error(response.status_code, error_message)
-
-            # Return error in Anthropic format
-            return JSONResponse(
-                status_code=response.status_code,
-                content={"type": "error", "error": {"type": "api_error", "message": error_message}},
-            )
-
-        if request_data.stream:
-            # Streaming mode with first token retry
-            async def stream_wrapper():
-                streaming_error = None
-                client_disconnected = False
-                try:
-                    # Create retry request function for retries
-                    async def make_retry_request():
-                        return await http_client.request_with_retry(
-                            "POST", url, kiro_payload, stream=True, retry_rate_limits=False
-                        )
-
-                    # Use retry wrapper with initial response
-                    async for chunk in stream_with_first_token_retry_anthropic(
-                        make_request=make_retry_request,
-                        model=request_data.model,
-                        model_cache=model_cache,
-                        auth_manager=auth_manager,
-                        initial_response=response,
-                        request_messages=messages_for_tokenizer,
-                        request_tools=tools_for_tokenizer,
-                        request_system=system_for_tokenizer,
-                        make_search_request=make_search_request,
-                    ):
-                        yield chunk
-                except GeneratorExit:
-                    client_disconnected = True
-                    logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
-                except Exception as e:
-                    streaming_error = e
-                    # Send error event to client, then gracefully end the stream
-                    try:
-                        error_event = f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'type': 'api_error', 'message': str(e)}})}\n\n"
-                        yield error_event
-                    except Exception:
-                        pass
-                finally:
-                    await http_client.close()
-                    if streaming_error:
-                        error_type = type(streaming_error).__name__
-                        error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
-                        logger.error(f"HTTP 500 - POST /v1/messages (streaming) - [{error_type}] {error_msg[:100]}")
-                    elif client_disconnected:
-                        logger.info("HTTP 200 - POST /v1/messages (streaming) - client disconnected")
-                    else:
-                        logger.info("HTTP 200 - POST /v1/messages (streaming) - completed")
-
-                    if debug_logger:
-                        if streaming_error:
-                            debug_logger.flush_on_error(500, str(streaming_error))
-                        else:
-                            debug_logger.discard_buffers()
-
-            return StreamingResponse(
-                stream_wrapper(),
-                media_type="text/event-stream",
-                headers={
-                    "Cache-Control": "no-cache",
-                    "Connection": "keep-alive",
-                },
-            )
-
-        else:
-            # Non-streaming mode - collect entire response
-            anthropic_response = await collect_anthropic_response(
-                response,
-                request_data.model,
-                model_cache,
-                auth_manager,
-                request_messages=messages_for_tokenizer,
-                request_tools=tools_for_tokenizer,
-                request_system=system_for_tokenizer,
-                make_search_request=make_search_request,
-            )
-
-            await http_client.close()
-
-            logger.info("HTTP 200 - POST /v1/messages (non-streaming) - completed")
-
-            if debug_logger:
-                debug_logger.discard_buffers()
-
-            return JSONResponse(content=anthropic_response)
-
-    except HTTPException as e:
-        await http_client.close()
-
-        # Network errors (502/504 from request_with_retry) = RECOVERABLE
-        # In legacy mode, we still log them but re-raise (no failover available)
-        if e.status_code in (502, 504):
-            logger.warning("Network error (legacy mode, no failover available)")
-
-        logger.error(f"HTTP {e.status_code} - POST /v1/messages - {e.detail}")
-        if debug_logger:
-            debug_logger.flush_on_error(e.status_code, str(e.detail))
-        raise
-    except Exception as e:
-        await http_client.close()
-        logger.error(f"Internal error: {e}", exc_info=True)
-        logger.error(f"HTTP 500 - POST /v1/messages - {str(e)[:100]}")
-        if debug_logger:
-            debug_logger.flush_on_error(500, str(e))
-
-        return JSONResponse(
-            status_code=500,
-            content={"type": "error", "error": {"type": "api_error", "message": f"Internal Server Error: {str(e)}"}},
-        )
 
 
 @router.post("/v1/messages/count_tokens", dependencies=[Depends(verify_anthropic_api_key)])

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -318,28 +318,33 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
     # Account System: Account System Failover or Legacy Mode
     # ==============================================================================
 
-    if request.app.state.account_system:
-        # ==============================================================================
-        # ACCOUNT SYSTEM ENABLED: Failover Loop
-        # ==============================================================================
+    account_system = request.app.state.account_system
+    while True:
         from kiro.account_errors import ErrorType, classify_error
 
         account_manager = request.app.state.account_manager
         all_accounts = list(account_manager._accounts.keys())
-        MAX_ATTEMPTS = len(all_accounts) * 2  # Full circle with margin
+        single_attempt = not account_system or len(all_accounts) == 1
+        max_attempts = 1 if not account_system else max(1, len(all_accounts) * 2)
 
         last_error_message = None
         last_error_status = None
         tried_accounts: set[str] = set()  # Track tried accounts in current failover loop
 
-        for attempt in range(MAX_ATTEMPTS):
-            # Get next available account (excluding already tried)
-            account = await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
+        for _attempt in range(max_attempts):
+            account = (
+                await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
+                if account_system
+                else account_manager.get_first_account()
+            )
 
-            if account is None:
+            if account is None or not account.auth_manager:
                 # All accounts unavailable
-                if len(all_accounts) == 1:
+                if single_attempt:
                     # Single account - return original error with original status code
+                    if not account_system:
+                        logger.error("No initialized accounts available (legacy mode)")
+                        raise HTTPException(503, "No initialized accounts available")
                     raise HTTPException(
                         status_code=last_error_status or 503, detail=last_error_message or "Account unavailable"
                     )
@@ -404,9 +409,6 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                 )
 
                 if response.status_code == 200:
-                    # SUCCESS - report and return
-                    await account_manager.report_success(account.id, request_data.model)
-
                     # Prepare data for token counting
                     messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
                     tools_for_tokenizer = (
@@ -438,15 +440,13 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                                     parallel_tool_calls=request_data.parallel_tool_calls is not False,
                                 ):
                                     yield chunk
+                                if account_system:
+                                    await account_manager.report_success(account.id, request_data.model)
                             except GeneratorExit:
                                 client_disconnected = True
                                 logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
                             except Exception as e:
                                 streaming_error = e
-                                try:
-                                    yield "data: [DONE]\n\n"
-                                except Exception:
-                                    pass
                                 raise
                             finally:
                                 await http_client.close()
@@ -485,6 +485,8 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                             include_reasoning=request_data.include_reasoning,
                             parallel_tool_calls=request_data.parallel_tool_calls is not False,
                         )
+                        if account_system:
+                            await account_manager.report_success(account.id, request_data.model)
 
                         await http_client.close()
                         logger.info("HTTP 200 - POST /v1/chat/completions (non-streaming) - completed")
@@ -532,14 +534,15 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
 
                     if error_type == ErrorType.FATAL:
                         # FATAL - return to client immediately
-                        await account_manager.report_failure(
-                            account.id,
-                            request_data.model,
-                            error_type,
-                            response.status_code,
-                            error_reason,
-                            upstream_message,
-                        )
+                        if account_system:
+                            await account_manager.report_failure(
+                                account.id,
+                                request_data.model,
+                                error_type,
+                                response.status_code,
+                                error_reason,
+                                upstream_message,
+                            )
 
                         logger.warning(
                             f"HTTP {response.status_code} - POST /v1/chat/completions - {last_error_message[:100]}"
@@ -561,17 +564,28 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
 
                     else:  # ErrorType.RECOVERABLE
                         # RECOVERABLE - try next account
-                        await account_manager.report_failure(
-                            account.id,
-                            request_data.model,
-                            error_type,
-                            response.status_code,
-                            error_reason,
-                            upstream_message,
-                        )
+                        if account_system:
+                            await account_manager.report_failure(
+                                account.id,
+                                request_data.model,
+                                error_type,
+                                response.status_code,
+                                error_reason,
+                                upstream_message,
+                            )
 
-                        # Single account - no point in failover, break immediately
-                        if len(all_accounts) == 1:
+                        if single_attempt:
+                            if not account_system:
+                                return JSONResponse(
+                                    status_code=response.status_code,
+                                    content={
+                                        "error": {
+                                            "message": last_error_message,
+                                            "type": "kiro_api_error",
+                                            "code": response.status_code,
+                                        }
+                                    },
+                                )
                             break
 
                         continue  # Next iteration
@@ -584,15 +598,21 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                 # NOT for HTTP-level errors (which are returned as response objects)
                 if e.status_code in (502, 504):
                     # Network error → try next account
-                    await account_manager.report_failure(
-                        account.id, request_data.model, ErrorType.RECOVERABLE, e.status_code, None
-                    )
+                    if account_system:
+                        await account_manager.report_failure(
+                            account.id, request_data.model, ErrorType.RECOVERABLE, e.status_code, None
+                        )
 
                     last_error_message = str(e.detail)
                     last_error_status = e.status_code
 
                     # Single account - no point in failover, break immediately
-                    if len(all_accounts) == 1:
+                    if single_attempt:
+                        if not account_system:
+                            logger.warning("Network error (legacy mode, no failover available)")
+                            if debug_logger:
+                                debug_logger.flush_on_error(e.status_code, str(e.detail))
+                            raise
                         break
 
                     logger.warning(f"Network error on account {account.id}, trying next account")
@@ -613,7 +633,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                 raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")
 
         # All attempts exhausted
-        if len(all_accounts) == 1:
+        if single_attempt:
             # Single account - return its original error
             # last_error_status and last_error_message are guaranteed to be set
             assert last_error_status is not None
@@ -627,212 +647,3 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             if last_error_message:
                 detail += f" Error from last account: {last_error_message}"
             raise HTTPException(status_code=503, detail=detail)
-
-    else:
-        # ==============================================================================
-        # LEGACY MODE: Single Account (no failover)
-        # ==============================================================================
-        account = request.app.state.account_manager.get_first_account()
-        if not account.auth_manager:
-            logger.error("No initialized accounts available (legacy mode)")
-            raise HTTPException(503, "No initialized accounts available")
-        auth_manager = account.auth_manager
-        model_cache = account.model_cache
-
-    # Generate conversation ID for Kiro API (random UUID, not used for tracking)
-    conversation_id = generate_conversation_id()
-
-    # Build payload for Kiro
-    # A Builder ID account has no profile and must not be given one: the global
-    # fallback would send a foreign ARN and fail the request.
-    profile_arn_for_payload = auth_manager.profile_arn or (
-        "" if auth_manager.auth_type == AuthType.AWS_SSO_OIDC else PROFILE_ARN or ""
-    )
-
-    try:
-        kiro_payload = build_kiro_payload(request_data, conversation_id, profile_arn_for_payload)
-    except PayloadTooLargeError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-    # Log Kiro payload
-    try:
-        kiro_request_body = json.dumps(kiro_payload, ensure_ascii=False, indent=2).encode("utf-8")
-        if debug_logger:
-            debug_logger.log_kiro_request_body(kiro_request_body)
-    except Exception as e:
-        logger.warning(f"Failed to log Kiro request: {e}")
-
-    # Create HTTP client with retry logic
-    # For streaming: use per-request client to avoid CLOSE_WAIT leak on VPN disconnect (issue #54)
-    # For non-streaming: use shared client for connection pooling
-    url = f"{auth_manager.api_host}/generateAssistantResponse"
-    logger.debug(f"Kiro API URL: {url}")
-
-    if request_data.stream:
-        # Streaming mode: per-request client prevents orphaned connections
-        # when network interface changes (VPN disconnect/reconnect)
-        http_client = KiroHttpClient(auth_manager, shared_client=None)
-    else:
-        # Non-streaming mode: shared client for efficient connection reuse
-        shared_client = request.app.state.http_client
-        http_client = KiroHttpClient(auth_manager, shared_client=shared_client)
-    try:
-        # Make request to Kiro API (for both streaming and non-streaming modes)
-        # Important: we wait for Kiro response BEFORE returning StreamingResponse,
-        # so that 200 OK means Kiro accepted the request and started responding
-        response = await http_client.request_with_retry("POST", url, kiro_payload, stream=True, retry_rate_limits=False)
-
-        if response.status_code != 200:
-            try:
-                error_content = await response.aread()
-            except Exception:
-                error_content = b"Unknown error"
-
-            await http_client.close()
-            error_text = error_content.decode("utf-8", errors="replace")
-
-            # Try to parse JSON response from Kiro to extract error message
-            error_message = error_text
-            try:
-                error_json = json.loads(error_text)
-                # Enhance Kiro API errors with user-friendly messages
-                from kiro.kiro_errors import enhance_kiro_error
-
-                error_info = enhance_kiro_error(error_json)
-                error_message = error_info.user_message
-                # Log original error for debugging
-                logger.debug(f"Original Kiro error: {error_info.original_message} (reason: {error_info.reason})")
-            except (json.JSONDecodeError, KeyError):
-                pass
-
-            # Log access log for error (before flush, so it gets into app_logs)
-            logger.warning(f"HTTP {response.status_code} - POST /v1/chat/completions - {error_message[:100]}")
-
-            # Flush debug logs on error ("errors" mode)
-            if debug_logger:
-                debug_logger.flush_on_error(response.status_code, error_message)
-
-            # Return error in OpenAI API format
-            return JSONResponse(
-                status_code=response.status_code,
-                content={"error": {"message": error_message, "type": "kiro_api_error", "code": response.status_code}},
-            )
-
-        # Prepare data for fallback token counting
-        # Convert Pydantic models to dicts for tokenizer
-        messages_for_tokenizer = [msg.model_dump() for msg in request_data.messages]
-        tools_for_tokenizer = [tool.model_dump() for tool in request_data.tools] if request_data.tools else None
-
-        if request_data.stream:
-            # Streaming mode with first token retry
-            async def stream_wrapper():
-                streaming_error = None
-                client_disconnected = False
-                try:
-                    # Create retry request function for retries
-                    async def make_retry_request():
-                        return await http_client.request_with_retry(
-                            "POST", url, kiro_payload, stream=True, retry_rate_limits=False
-                        )
-
-                    # Use retry wrapper with initial response
-                    async for chunk in stream_with_first_token_retry(
-                        make_request=make_retry_request,
-                        client=http_client.client,
-                        model=request_data.model,
-                        model_cache=model_cache,
-                        auth_manager=auth_manager,
-                        initial_response=response,
-                        request_messages=messages_for_tokenizer,
-                        request_tools=tools_for_tokenizer,
-                        include_reasoning=request_data.include_reasoning,
-                        parallel_tool_calls=request_data.parallel_tool_calls is not False,
-                    ):
-                        yield chunk
-                except GeneratorExit:
-                    # Client disconnected - this is normal
-                    client_disconnected = True
-                    logger.debug("Client disconnected during streaming (GeneratorExit in routes)")
-                except Exception as e:
-                    streaming_error = e
-                    # Try to send [DONE] to client before finishing
-                    # so client doesn't "hang" waiting for data
-                    try:
-                        yield "data: [DONE]\n\n"
-                    except Exception:
-                        pass  # Client already disconnected
-                    raise
-                finally:
-                    await http_client.close()
-                    # Log access log for streaming (success or error)
-                    if streaming_error:
-                        error_type = type(streaming_error).__name__
-                        error_msg = str(streaming_error) if str(streaming_error) else "(empty message)"
-                        logger.error(
-                            f"HTTP 500 - POST /v1/chat/completions (streaming) - [{error_type}] {error_msg[:100]}"
-                        )
-                    elif client_disconnected:
-                        logger.info("HTTP 200 - POST /v1/chat/completions (streaming) - client disconnected")
-                    else:
-                        logger.info("HTTP 200 - POST /v1/chat/completions (streaming) - completed")
-                    # Write debug logs AFTER streaming completes
-                    if debug_logger:
-                        if streaming_error:
-                            debug_logger.flush_on_error(500, str(streaming_error))
-                        else:
-                            debug_logger.discard_buffers()
-
-            return StreamingResponse(stream_wrapper(), media_type="text/event-stream")
-
-        else:
-            # Non-streaming mode - collect entire response
-            client = http_client.client
-            assert client is not None
-            openai_response = await collect_stream_response(
-                client,
-                response,
-                request_data.model,
-                model_cache,
-                auth_manager,
-                request_messages=messages_for_tokenizer,
-                request_tools=tools_for_tokenizer,
-                include_reasoning=request_data.include_reasoning,
-                parallel_tool_calls=request_data.parallel_tool_calls is not False,
-            )
-
-            await http_client.close()
-
-            # Log access log for non-streaming success
-            logger.info("HTTP 200 - POST /v1/chat/completions (non-streaming) - completed")
-
-            # Write debug logs after non-streaming request completes
-            if debug_logger:
-                debug_logger.discard_buffers()
-
-            return JSONResponse(content=openai_response)
-
-    except HTTPException as e:
-        await http_client.close()
-
-        # Network errors (502/504 from request_with_retry) = RECOVERABLE
-        # In legacy mode, we still log them but re-raise (no failover available)
-        if e.status_code in (502, 504):
-            logger.warning("Network error (legacy mode, no failover available)")
-
-        # Log access log for HTTP error
-        logger.error(f"HTTP {e.status_code} - POST /v1/chat/completions - {e.detail}")
-        # Flush debug logs on HTTP error ("errors" mode)
-        if debug_logger:
-            debug_logger.flush_on_error(e.status_code, str(e.detail))
-        raise
-    except Exception as e:
-        await http_client.close()
-        logger.error(f"Internal error: {e}", exc_info=True)
-        # Log access log for internal error
-        logger.error(f"HTTP 500 - POST /v1/chat/completions - {str(e)[:100]}")
-        # Flush debug logs on internal error ("errors" mode)
-        if debug_logger:
-            debug_logger.flush_on_error(500, str(e))
-        raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")

--- a/kiro/store.py
+++ b/kiro/store.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+"""Shared private SQLite persistence for gateway and dashboard state."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sqlite3
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+DB_FILENAME = "dashboard.sqlite3"
+LEGACY_MIGRATION = "gateway-json-v1"
+
+
+def database_path() -> Path:
+    return Path(os.getenv("DASHBOARD_DATA_DIR", "data")) / DB_FILENAME
+
+
+@contextmanager
+def connection() -> Iterator[sqlite3.Connection]:
+    path = database_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=5.0)
+    os.chmod(path, 0o600)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout = 5000")
+    conn.execute("PRAGMA journal_mode = WAL")
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
+
+
+def initialize() -> None:
+    with connection() as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS account_sources (
+                account_id TEXT PRIMARY KEY,
+                position INTEGER NOT NULL,
+                config_json TEXT NOT NULL,
+                credential_json TEXT
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS account_runtime (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                state_json TEXT NOT NULL
+            )"""
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS store_migrations (name TEXT PRIMARY KEY, completed_at INTEGER NOT NULL)"
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS runtime_writer (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                slot TEXT NOT NULL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS credential_refresh_leases (
+                account_id TEXT PRIMARY KEY,
+                owner TEXT NOT NULL,
+                expires_at REAL NOT NULL
+            )"""
+        )
+
+
+def set_runtime_writer(slot: str) -> None:
+    """Assign runtime-state persistence to the active blue/green slot."""
+    initialize()
+    with connection() as conn:
+        conn.execute(
+            "INSERT INTO runtime_writer(id, slot) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET slot=excluded.slot",
+            (slot,),
+        )
+
+
+def can_write_runtime_state() -> bool:
+    """Return whether this process owns runtime-state writes.
+
+    Non-slot deployments remain single-writer and need no deploy coordination.
+    """
+    slot = os.getenv("KIRO_SLOT", "")
+    if not slot:
+        return True
+    with connection() as conn:
+        row = conn.execute("SELECT slot FROM runtime_writer WHERE id = 1").fetchone()
+    return bool(row and row[0] == slot)
+
+
+def require_runtime_writer(conn: sqlite3.Connection) -> None:
+    """Reject gateway-owned mutations from an inactive blue/green slot."""
+    slot = os.getenv("KIRO_SLOT", "")
+    if not slot:
+        return
+    row = conn.execute("SELECT slot FROM runtime_writer WHERE id = 1").fetchone()
+    if not row or row[0] != slot:
+        raise RuntimeError(f"gateway store write rejected: slot {slot!r} is not the active writer")
+
+
+def load_account_sources(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    if conn is None:
+        with connection() as owned:
+            return load_account_sources(owned)
+    return [json.loads(row[0]) for row in conn.execute("SELECT config_json FROM account_sources ORDER BY position")]
+
+
+def replace_account_sources(entries: list[dict[str, Any]], conn: sqlite3.Connection, *, ungated: bool = False) -> None:
+    if not ungated:
+        require_runtime_writer(conn)
+    existing_credentials = {
+        row["account_id"]: row["credential_json"]
+        for row in conn.execute("SELECT account_id, credential_json FROM account_sources")
+    }
+    conn.execute("DELETE FROM account_sources")
+    for position, entry in enumerate(entries):
+        account_id = account_id_for_entry(entry)
+        credential = entry.get("credential") if entry.get("type") == "internal" else None
+        credential_json = existing_credentials.get(account_id)
+        if credential_json is None and credential is not None:
+            credential_json = json.dumps(credential)
+        stored = {key: value for key, value in entry.items() if key != "credential"}
+        conn.execute(
+            "INSERT INTO account_sources(account_id, position, config_json, credential_json) VALUES (?, ?, ?, ?)",
+            (account_id, position, json.dumps(stored), credential_json),
+        )
+
+
+def account_id_for_entry(entry: dict[str, Any]) -> str:
+    if entry.get("type") == "internal":
+        return str(entry["id"])
+    if entry.get("type") == "refresh_token":
+        import hashlib
+
+        digest = hashlib.sha256(str(entry.get("refresh_token", "")).encode()).hexdigest()[:16]
+        return f"refresh_token_{digest}"
+    return str(Path(str(entry.get("path", ""))).expanduser().resolve())
+
+
+def load_internal_credential(account_id: str) -> dict[str, Any] | None:
+    with connection() as conn:
+        row = conn.execute("SELECT credential_json FROM account_sources WHERE account_id = ?", (account_id,)).fetchone()
+    return json.loads(row[0]) if row and row[0] else None
+
+
+def save_internal_credential(account_id: str, document: dict[str, Any]) -> None:
+    with connection() as conn:
+        require_runtime_writer(conn)
+        updated = conn.execute(
+            "UPDATE account_sources SET credential_json = ? WHERE account_id = ? AND credential_json IS NOT NULL",
+            (json.dumps(document), account_id),
+        ).rowcount
+        if not updated:
+            raise KeyError(f"Unknown internal account: {account_id}")
+
+
+def refresh_internal_credential(account_id: str) -> dict[str, Any]:
+    """Load the latest internal credential immediately before a refresh."""
+    document = load_internal_credential(account_id)
+    if document is None:
+        raise KeyError(f"Unknown internal account: {account_id}")
+    return document
+
+
+def try_acquire_refresh_lease(account_id: str, lease_seconds: float = 60.0) -> str | None:
+    """Atomically acquire a short per-account cross-process refresh lease."""
+    initialize()
+    owner = uuid.uuid4().hex
+    now = time.time()
+    with connection() as conn:
+        slot = os.getenv("KIRO_SLOT", "")
+        rowcount = conn.execute(
+            """INSERT INTO credential_refresh_leases(account_id, owner, expires_at)
+               SELECT ?, ?, ?
+               WHERE ? = '' OR EXISTS (
+                   SELECT 1 FROM runtime_writer WHERE id = 1 AND slot = ?
+               )
+               ON CONFLICT(account_id) DO UPDATE SET owner=excluded.owner, expires_at=excluded.expires_at
+               WHERE credential_refresh_leases.expires_at <= ?""",
+            (account_id, owner, now + lease_seconds, slot, slot, now),
+        ).rowcount
+    return owner if rowcount else None
+
+
+def release_refresh_lease(account_id: str, owner: str) -> None:
+    with connection() as conn:
+        conn.execute(
+            "DELETE FROM credential_refresh_leases WHERE account_id = ? AND owner = ?",
+            (account_id, owner),
+        )
+
+
+def load_runtime_state() -> dict[str, Any] | None:
+    with connection() as conn:
+        row = conn.execute("SELECT state_json FROM account_runtime WHERE id = 1").fetchone()
+    return json.loads(row[0]) if row else None
+
+
+def save_runtime_state(
+    state: dict[str, Any],
+    conn: sqlite3.Connection | None = None,
+    *,
+    ungated: bool = False,
+    require_write: bool = False,
+) -> bool:
+    """Persist runtime state if this process is the current writer.
+
+    The ownership predicate is part of the UPSERT, so a deploy handoff cannot
+    race a check performed before the write transaction. Migration uses
+    ``ungated`` because imported state predates blue/green ownership.
+    """
+    if conn is None:
+        with connection() as owned:
+            return save_runtime_state(state, owned, ungated=ungated, require_write=require_write)
+    slot = os.getenv("KIRO_SLOT", "")
+    written = bool(
+        conn.execute(
+            """INSERT INTO account_runtime(id, state_json)
+               SELECT 1, ?
+               WHERE ? OR ? = '' OR EXISTS (
+                   SELECT 1 FROM runtime_writer WHERE id = 1 AND slot = ?
+               )
+               ON CONFLICT(id) DO UPDATE SET state_json=excluded.state_json""",
+            (json.dumps(state), ungated, slot, slot),
+        ).rowcount
+    )
+    if require_write and not written:
+        raise RuntimeError(f"runtime state write rejected: slot {slot!r} is not the active writer")
+    return written
+
+
+def _read_json(path: Path, expected: type[Any]) -> Any | None:
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, expected):
+        raise ValueError(f"{path} has the wrong JSON shape")
+    return value
+
+
+def canonicalize_account_sources(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    canonical: list[dict[str, Any]] = []
+    for original in entries:
+        entry = dict(original)
+        if entry.get("type") == "refresh_token":
+            token = str(entry.pop("refresh_token", ""))
+            if not token:
+                raise ValueError("legacy refresh_token source has no token")
+            account_id = account_id_for_entry(original)
+            entry.update(type="internal", id=account_id, credential={"refreshToken": token})
+        canonical.append(entry)
+    return canonical
+
+
+def import_legacy_files(credentials_file: str, state_file: str, recovery_file: str | None = None) -> bool:
+    """Import gateway JSON once without replacing an already populated store."""
+    initialize()
+    with connection() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        if conn.execute("SELECT 1 FROM store_migrations WHERE name=?", (LEGACY_MIGRATION,)).fetchone():
+            return False
+        entries: list[dict[str, Any]] | None = None
+        state: dict[str, Any] | None = None
+        recovery_path = Path(recovery_file).expanduser() if recovery_file else None
+        if recovery_path and recovery_path.exists():
+            payload = _read_json(recovery_path, dict)
+            assert isinstance(payload, dict)
+            if payload.get("version") != 1 or not isinstance(payload.get("credentials_entries"), list):
+                raise ValueError("invalid account deletion recovery record")
+            entries = payload["credentials_entries"]
+            encoded = payload.get("state_file")
+            if encoded is not None:
+                state = json.loads(base64.b64decode(encoded, validate=True))
+                if not isinstance(state, dict):
+                    raise ValueError("invalid state in account deletion recovery record")
+        else:
+            entries = _read_json(Path(credentials_file).expanduser(), list)
+            state = _read_json(Path(state_file).expanduser(), dict)
+        if entries is not None and not all(isinstance(item, dict) for item in entries):
+            raise ValueError("legacy credentials contain a non-object entry")
+        if not conn.execute("SELECT 1 FROM account_sources LIMIT 1").fetchone() and entries:
+            replace_account_sources(canonicalize_account_sources(entries), conn, ungated=True)
+        if not conn.execute("SELECT 1 FROM account_runtime WHERE id=1").fetchone() and state is not None:
+            save_runtime_state(state, conn, ungated=True, require_write=True)
+        conn.execute(
+            "INSERT INTO store_migrations(name, completed_at) VALUES (?, unixepoch())",
+            (LEGACY_MIGRATION,),
+        )
+    if recovery_path and recovery_path.exists():
+        recovery_path.unlink()
+    return True

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -182,6 +182,7 @@ async def stream_kiro_to_anthropic(
     pending_content: List[str] = []
     tool_blocks: List[Dict[str, Any]] = []
     upstream_stop_reason: Optional[str] = None
+    received_upstream_event = False
 
     # Native reasoning blocks carry their own upstream signature events, so no
     # placeholder signature is generated here.
@@ -190,6 +191,16 @@ async def stream_kiro_to_anthropic(
     upstream_cache_usage: Dict[str, int] = {}
     current_response = response
     pending_response: Optional[httpx.Response] = None
+    closed_response_ids: set[int] = set()
+
+    async def close_response_once(response_to_close: Optional[httpx.Response]) -> None:
+        if response_to_close is None or id(response_to_close) in closed_response_ids:
+            return
+        closed_response_ids.add(id(response_to_close))
+        try:
+            await response_to_close.aclose()
+        except Exception as close_error:
+            logger.debug(f"Error closing response: {close_error}")
 
     async def iter_events() -> AsyncGenerator[Any, None]:
         nonlocal current_response, pending_response
@@ -201,7 +212,7 @@ async def stream_kiro_to_anthropic(
                     previous_response = current_response
                     current_response = pending_response
                     pending_response = None
-                    await previous_response.aclose()
+                    await close_response_once(previous_response)
                     break
             else:
                 break
@@ -268,6 +279,7 @@ async def stream_kiro_to_anthropic(
     begin_anthropic_stream()
     try:
         async for event in iter_events():
+            received_upstream_event = True
             if not message_started:
                 yield format_sse_event("message_start", message_start_data)
                 message_started = True
@@ -419,7 +431,7 @@ async def stream_kiro_to_anthropic(
                         try:
                             tool_input = json.loads(tool_input)
                         except json.JSONDecodeError:
-                            tool_input = {}
+                            raise StreamProtocolError("Malformed upstream tool input")
 
                     # Extract query
                     query = tool_input.get("query", "")
@@ -520,7 +532,7 @@ async def stream_kiro_to_anthropic(
                     try:
                         tool_input = json.loads(tool_input)
                     except json.JSONDecodeError:
-                        tool_input = {}
+                        raise StreamProtocolError("Malformed upstream tool input")
 
                 # Send tool_use block start
                 yield format_sse_event(
@@ -559,6 +571,9 @@ async def stream_kiro_to_anthropic(
             elif event.type == "stop_reason" and event.stop_reason:
                 upstream_stop_reason = event.stop_reason
 
+        if not received_upstream_event:
+            raise StreamProtocolError("Upstream stream ended before any events were received")
+
         # Track completion signals for truncation detection
         stream_completed_normally = context_usage_percentage is not None
 
@@ -592,7 +607,7 @@ async def stream_kiro_to_anthropic(
                     try:
                         tool_input = json.loads(tool_input)
                     except json.JSONDecodeError:
-                        tool_input = {}
+                        raise StreamProtocolError("Malformed upstream tool input")
 
                 yield format_sse_event(
                     "content_block_start",
@@ -711,17 +726,15 @@ async def stream_kiro_to_anthropic(
         error_msg = str(e) if str(e) else "(empty message)"
         logger.error(f"Error during Anthropic streaming: [{error_type}] {error_msg}", exc_info=True)
 
-        # Send error event
-        yield format_sse_event(
-            "error", {"type": "error", "error": {"type": "api_error", "message": f"Internal error: {error_msg}"}}
-        )
         raise
     finally:
         end_anthropic_stream()
-        try:
-            await current_response.aclose()
-        except Exception as close_error:
-            logger.debug(f"Error closing response: {close_error}")
+        # A disconnect can happen after the follow-up response is opened but
+        # before iter_events promotes it to current_response. Close both slots;
+        # identity tracking also protects against closing an already-promoted
+        # or previously consumed response twice.
+        await close_response_once(current_response)
+        await close_response_once(pending_response)
 
 
 async def collect_anthropic_response(
@@ -768,7 +781,15 @@ async def collect_anthropic_response(
         )
         input_tokens = request_token_stats["total_tokens"]
 
-    result = await collect_stream_to_result(response)
+    async def collect_and_close(response_to_collect: httpx.Response) -> Any:
+        try:
+            return await collect_stream_to_result(response_to_collect)
+        finally:
+            # Shared-client close is intentionally a no-op, but response bodies
+            # still need explicit lifecycle management after they are drained.
+            await response_to_collect.aclose()
+
+    result = await collect_and_close(response)
     native_blocks: List[Dict[str, Any]] = []
     accumulated_content = ""
     accumulated_thinking = ""
@@ -856,7 +877,7 @@ async def collect_anthropic_response(
             ]
         )
         followup_response = await make_search_request(tool_id, query, generate_search_summary(query, results))
-        result = await collect_stream_to_result(followup_response)
+        result = await collect_and_close(followup_response)
 
     upstream_cache_usage = _extract_cache_usage_fields(result.usage)
 

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -29,6 +29,7 @@ from kiro.parsers import (
     deduplicate_tool_calls,
     parse_bracket_tool_calls,
 )
+from kiro.sse_validation import StreamProtocolError
 
 if TYPE_CHECKING:
     from kiro.cache import ModelInfoCache
@@ -126,6 +127,7 @@ async def parse_kiro_stream(
     prompt tags or response text.  Content is passed through verbatim.
     """
     parser = AwsEventStreamParser()
+    received_event = False
     try:
         byte_iterator = response.aiter_bytes()
         try:
@@ -133,11 +135,12 @@ async def parse_kiro_stream(
         except asyncio.TimeoutError:
             raise FirstTokenTimeoutError(f"No response within {first_token_timeout} seconds")
         except StopAsyncIteration:
-            return
+            raise StreamProtocolError("Upstream stream ended before any events were received")
 
         if debug_logger:
             debug_logger.log_raw_chunk(first_chunk)
         async for event in _process_chunk(parser, first_chunk):
+            received_event = True
             if debug_logger:
                 debug_logger.log_parsed_event(asdict(event))
             yield event
@@ -153,6 +156,7 @@ async def parse_kiro_stream(
             if debug_logger:
                 debug_logger.log_raw_chunk(chunk)
             async for event in _process_chunk(parser, chunk):
+                received_event = True
                 if debug_logger:
                     debug_logger.log_parsed_event(asdict(event))
                 yield event
@@ -168,9 +172,12 @@ async def parse_kiro_stream(
             if tool_call.get("_parse_error"):
                 raise MalformedToolInputError("Malformed upstream tool input")
             event = KiroEvent(type="tool_use", tool_use=tool_call)
+            received_event = True
             if debug_logger:
                 debug_logger.log_parsed_event(asdict(event))
             yield event
+        if not received_event:
+            raise StreamProtocolError("Upstream stream ended before any events were received")
     except FirstTokenTimeoutError:
         raise
     except GeneratorExit:
@@ -234,8 +241,10 @@ async def collect_stream_to_result(
     """
     result = StreamResult()
     full_content_for_bracket_tools = ""
+    received_event = False
 
     async for event in parse_kiro_stream(response, first_token_timeout):
+        received_event = True
         if event.type == "content" and event.content:
             result.content += event.content
             full_content_for_bracket_tools += event.content
@@ -250,7 +259,6 @@ async def collect_stream_to_result(
                 )
         elif event.type == "thinking" and event.thinking_content:
             result.thinking_content += event.thinking_content
-            full_content_for_bracket_tools += event.thinking_content
             if result.content_blocks and result.content_blocks[-1]["type"] == "thinking":
                 result.content_blocks[-1]["thinking"] += event.thinking_content
             else:
@@ -282,7 +290,13 @@ async def collect_stream_to_result(
         elif event.type == "stop_reason" and event.stop_reason:
             result.stop_reason = event.stop_reason
 
-    # Check for bracket-style tool calls in full content
+    # Keep this guard at the collector boundary as well: tests and alternate
+    # transports may replace the parser with another KiroEvent iterator.
+    if not received_event:
+        raise StreamProtocolError("Upstream stream ended before any events were received")
+
+    # Recovery is intentionally limited to client-visible text. Reasoning can
+    # discuss bracket syntax without actually invoking a tool.
     bracket_tool_calls = parse_bracket_tool_calls(full_content_for_bracket_tools)
     if bracket_tool_calls:
         result.tool_calls = deduplicate_tool_calls(result.tool_calls + bracket_tool_calls)

--- a/kiro/streaming_openai.py
+++ b/kiro/streaming_openai.py
@@ -154,6 +154,7 @@ async def stream_kiro_to_openai_internal(
     upstream_stop_reason = None
     streaming_error_occurred = False
     tool_calls_from_stream = []
+    received_upstream_event = False
 
     begin_openai_stream()
     try:
@@ -176,6 +177,7 @@ async def stream_kiro_to_openai_internal(
         # Use streaming_core.parse_kiro_stream for unified event parsing
         # This handles AWS SSE parsing, first token timeout, and thinking parser
         async for event in parse_kiro_stream(response, first_token_timeout):
+            received_upstream_event = True
             if event.type == "content" and event.content:
                 # Accumulate content for bracket tool call detection
                 full_content += event.content
@@ -294,6 +296,9 @@ async def stream_kiro_to_openai_internal(
 
             elif event.type == "stop_reason" and event.stop_reason:
                 upstream_stop_reason = event.stop_reason
+
+        if not received_upstream_event:
+            raise StreamProtocolError("Upstream stream ended before any events were received")
 
         # Track completion signals for truncation detection
         received_usage = metering_data is not None
@@ -421,9 +426,11 @@ async def stream_kiro_to_openai_internal(
         # Propagate timeout up for retry
         raise
     except GeneratorExit:
-        # Client disconnected - this is normal, don't log as error
+        # Propagate disconnect so wrappers cannot mistake an incomplete stream
+        # for a successful completion and report account success.
         logger.debug("Client disconnected (GeneratorExit)")
         streaming_error_occurred = True
+        raise
     except Exception as e:
         streaming_error_occurred = True
         # Log exception type and message for better diagnostics

--- a/kiro/usage_tracking.py
+++ b/kiro/usage_tracking.py
@@ -104,3 +104,12 @@ def drain_pending_usage() -> List[Tuple[str, str, int, int, int, int, int]]:
         ]
         _pending.clear()
     return drained
+
+
+def restore_pending_usage(rows: List[Tuple[str, str, int, int, int, int, int]]) -> None:
+    """Add a failed durable flush back without overwriting concurrent usage."""
+    with _lock:
+        for key_id, model, prompt, completion, requests, generation_ms, timed in rows:
+            entry = _pending.setdefault((key_id, model), [0, 0, 0, 0, 0])
+            for index, value in enumerate((prompt, completion, requests, generation_ms, timed)):
+                entry[index] += value

--- a/main.py
+++ b/main.py
@@ -32,9 +32,10 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import httpx
-from fastapi import FastAPI
+from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
@@ -203,27 +204,23 @@ def validate_configuration() -> None:
     Validates that required configuration is present.
 
     Priority:
-    1. credentials.json (Account System) - if exists, skip legacy validation
-    2. Legacy .env variables (REFRESH_TOKEN, KIRO_CREDS_FILE, KIRO_CLI_DB_FILE)
+    1. Existing SQLite account sources or legacy credentials.json import
+    2. Environment sources (REFRESH_TOKEN, KIRO_CREDS_FILE, KIRO_CLI_DB_FILE)
 
     Checks:
-    - Either credentials.json exists OR legacy variables are configured
+    - Either a stored/importable account exists or an environment source is configured
     - Supports both .env file (local) and environment variables (Docker)
 
     Raises:
         SystemExit: If critical configuration is missing
     """
-    # Priority 1: Check if credentials.json exists (Account System)
-    # If it exists, legacy .env validation is skipped
-    from kiro.config import ACCOUNTS_CONFIG_FILE
+    from kiro.store import initialize, load_account_sources
 
-    creds_json_path = Path(ACCOUNTS_CONFIG_FILE)
-
-    if creds_json_path.exists():
-        logger.debug(f"Found {ACCOUNTS_CONFIG_FILE}, skipping legacy .env validation")
+    initialize()
+    if load_account_sources() or Path(ACCOUNTS_CONFIG_FILE).exists():
         return
 
-    # Priority 2: credentials.json doesn't exist - validate legacy .env variables
+    # Priority 2: no stored/importable account - validate environment sources
     errors = []
 
     # Check if .env file exists (optional - can use environment variables)
@@ -310,6 +307,40 @@ def validate_configuration() -> None:
 
 
 # --- Lifespan Manager ---
+class HandoffGateMiddleware:
+    """Drain data-plane and account mutations during a blue/green handoff."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        app = scope.get("app")
+        path = scope.get("path", "")
+        method = scope.get("method", "GET")
+        guarded = path.startswith("/v1/") or (
+            path.startswith("/api/dashboard/accounts") and method not in {"GET", "HEAD", "OPTIONS"}
+        )
+        if not guarded or app is None or not hasattr(app.state, "handoff_condition"):
+            await self.app(scope, receive, send)
+            return
+        condition = app.state.handoff_condition
+        async with condition:
+            if app.state.handoff_quiesced:
+                response = JSONResponse({"detail": "slot is quiesced for deployment"}, status_code=503)
+                await response(scope, receive, send)
+                return
+            app.state.handoff_inflight += 1
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            async with condition:
+                app.state.handoff_inflight -= 1
+                condition.notify_all()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -327,6 +358,11 @@ async def lifespan(app: FastAPI):
     logger.info("Starting application... Creating state managers.")
     app.state.started_at = time.time()
     initialize_dashboard_store()
+    app.state.handoff_condition = asyncio.Condition()
+    app.state.handoff_inflight = 0
+    from kiro.store import can_write_runtime_state
+
+    app.state.handoff_quiesced = not can_write_runtime_state()
 
     # Create shared HTTP client with connection pooling
     # This reduces memory usage and enables connection reuse across requests
@@ -346,10 +382,22 @@ async def lifespan(app: FastAPI):
     app.state.http_client = httpx.AsyncClient(limits=limits, timeout=timeout, follow_redirects=True)
     logger.info("Shared HTTP client created with connection pooling")
 
-    # ==============================================================================
-    # Legacy Fallback: .env → credentials.json
-    # ==============================================================================
-    creds_path = Path(ACCOUNTS_CONFIG_FILE)
+    # Import old gateway JSON once, then apply the legacy environment policy in
+    # SQLite. External JSON and kiro-cli SQLite paths remain source adapters.
+    from kiro.store import (
+        canonicalize_account_sources,
+        connection,
+        import_legacy_files,
+        load_account_sources,
+        replace_account_sources,
+    )
+
+    recovery_file = str(
+        Path(ACCOUNTS_CONFIG_FILE)
+        .expanduser()
+        .with_name(f"{Path(ACCOUNTS_CONFIG_FILE).name}.account-deletion-recovery")
+    )
+    import_legacy_files(ACCOUNTS_CONFIG_FILE, ACCOUNTS_STATE_FILE, recovery_file)
 
     # Check if we have legacy .env credentials
     has_refresh_token = bool(REFRESH_TOKEN)
@@ -371,57 +419,19 @@ async def lifespan(app: FastAPI):
         if api_region:
             entry["api_region"] = api_region
 
-    if ACCOUNT_SYSTEM:
-        # Account system enabled: create credentials.json ONCE (migration)
-        if not creds_path.exists():
-            if has_refresh_token or has_creds_file or has_cli_db:
-                logger.info("credentials.json not found, creating from .env (one-time migration)")
-                credentials = []
-
-                # Priority: SQLite DB > JSON file > environment variables (same as KiroAuthManager)
-                if has_cli_db:
-                    entry = {"type": "sqlite", "path": KIRO_CLI_DB_FILE}
-                    _add_env_overrides(entry)
-                    credentials.append(entry)
-                elif has_creds_file:
-                    entry = {"type": "json", "path": KIRO_CREDS_FILE}
-                    _add_env_overrides(entry)
-                    credentials.append(entry)
-                elif has_refresh_token:
-                    entry = {"type": "refresh_token", "refresh_token": REFRESH_TOKEN}
-                    _add_env_overrides(entry)
-                    credentials.append(entry)
-
-                # Save credentials.json
-                with open(creds_path, "w", encoding="utf-8") as f:
-                    json.dump(credentials, f, indent=2, ensure_ascii=False)
-
-                logger.info("Created credentials.json from .env (one-time migration)")
-    else:
-        # Legacy mode: ALWAYS recreate credentials.json from .env
-        if has_refresh_token or has_creds_file or has_cli_db:
-            logger.debug("Legacy mode: recreating credentials.json from .env")
-            credentials = []
-
-            # Priority: SQLite DB > JSON file > environment variables (same as KiroAuthManager)
-            if has_cli_db:
-                entry = {"type": "sqlite", "path": KIRO_CLI_DB_FILE}
-                _add_env_overrides(entry)
-                credentials.append(entry)
-            elif has_creds_file:
-                entry = {"type": "json", "path": KIRO_CREDS_FILE}
-                _add_env_overrides(entry)
-                credentials.append(entry)
-            elif has_refresh_token:
-                entry = {"type": "refresh_token", "refresh_token": REFRESH_TOKEN}
-                _add_env_overrides(entry)
-                credentials.append(entry)
-
-            # Save credentials.json (overwrite if exists)
-            with open(creds_path, "w", encoding="utf-8") as f:
-                json.dump(credentials, f, indent=2, ensure_ascii=False)
-
-            logger.debug("credentials.json recreated from .env (legacy mode)")
+    env_entry = None
+    if has_cli_db:
+        env_entry = {"type": "sqlite", "path": KIRO_CLI_DB_FILE}
+    elif has_creds_file:
+        env_entry = {"type": "json", "path": KIRO_CREDS_FILE}
+    elif has_refresh_token:
+        env_entry = {"type": "refresh_token", "refresh_token": REFRESH_TOKEN}
+    if env_entry:
+        _add_env_overrides(env_entry)
+        env_entry = canonicalize_account_sources([env_entry])[0]
+        if not ACCOUNT_SYSTEM or not load_account_sources():
+            with connection() as conn:
+                replace_account_sources([env_entry], conn)
 
     # ==============================================================================
     # Create AccountManager
@@ -441,10 +451,10 @@ async def lifespan(app: FastAPI):
     all_accounts = list(app.state.account_manager._accounts.keys())
 
     if not all_accounts:
-        logger.error("No accounts configured in credentials.json")
-        raise RuntimeError("No accounts configured in credentials.json")
+        logger.error("No accounts configured in the private store")
+        raise RuntimeError("No accounts configured in the private store")
 
-    # Determine start index from state.json
+    # Determine start index from persisted runtime state
     start_index = app.state.account_manager._current_account_index
 
     # Try to initialize accounts (full circle)
@@ -469,9 +479,6 @@ async def lifespan(app: FastAPI):
         logger.error("Failed to initialize any account. Check your credentials.")
         raise RuntimeError("Failed to initialize any account")
 
-    # Save initial state
-    await app.state.account_manager._save_state()
-
     # Start background task for periodic state saving.
     save_task = asyncio.create_task(app.state.account_manager.save_state_periodically())
 
@@ -480,16 +487,18 @@ async def lifespan(app: FastAPI):
         # startup or impact the proxy data plane on endpoint/auth failures.
         while True:
             try:
-                await refresh_all_account_usage(app.state.account_manager)
+                if not app.state.handoff_quiesced:
+                    await refresh_all_account_usage(app.state.account_manager)
             except Exception as exc:
                 logger.warning("Background Kiro usage refresh failed: {}", exc)
             await asyncio.sleep(max(USAGE_REFRESH_INTERVAL_SECONDS, 60))
 
     # Populate the dashboard promptly, then keep a bounded periodic cache.
-    try:
-        await refresh_all_account_usage(app.state.account_manager)
-    except Exception as exc:
-        logger.warning("Initial Kiro usage refresh failed: {}", exc)
+    if not app.state.handoff_quiesced:
+        try:
+            await refresh_all_account_usage(app.state.account_manager)
+        except Exception as exc:
+            logger.warning("Initial Kiro usage refresh failed: {}", exc)
     usage_task = asyncio.create_task(refresh_usage_periodically())
 
     async def prune_request_logs_periodically() -> None:
@@ -512,8 +521,8 @@ async def lifespan(app: FastAPI):
 
     async def flush_rate_observations() -> None:
         pending = app.state.account_manager.drain_unsaved_rate_observations()
-        if pending:
-            await asyncio.to_thread(record_rate_observations, pending)
+        if pending and not await asyncio.to_thread(record_rate_observations, pending):
+            app.state.account_manager.restore_unsaved_rate_observations(pending)
 
     async def persist_rate_observations_periodically() -> None:
         while True:
@@ -564,6 +573,49 @@ async def lifespan(app: FastAPI):
 
 # --- FastAPI Application ---
 app = FastAPI(title=APP_TITLE, description=APP_DESCRIPTION, version=APP_VERSION, lifespan=lifespan)
+app.add_middleware(HandoffGateMiddleware)
+
+
+def _authorize_handoff(request: Request, secret: str | None) -> None:
+    expected = os.getenv("HANDOFF_SECRET", "")
+    host = request.headers.get("host", "").split(":", 1)[0]
+    if not expected or host not in {"127.0.0.1", "localhost", "::1"} or secret != expected:
+        raise HTTPException(status_code=403, detail="handoff control is direct-slot only")
+
+
+@app.post("/_internal/handoff/quiesce", include_in_schema=False)
+async def handoff_quiesce(request: Request, x_handoff_secret: str | None = Header(default=None)):
+    """Stop new work, drain existing streams, and persist the writer snapshot."""
+    _authorize_handoff(request, x_handoff_secret)
+    condition = request.app.state.handoff_condition
+    async with condition:
+        request.app.state.handoff_quiesced = True
+        await condition.wait_for(lambda: request.app.state.handoff_inflight == 0)
+    await request.app.state.account_manager.flush_for_handoff()
+    return {"ready": True, "state": "quiesced"}
+
+
+@app.post("/_internal/handoff/activate", include_in_schema=False)
+async def handoff_activate(request: Request, x_handoff_secret: str | None = Header(default=None)):
+    """Reload the final writer snapshot and permit this slot to serve traffic."""
+    _authorize_handoff(request, x_handoff_secret)
+    from kiro.store import can_write_runtime_state
+
+    if not can_write_runtime_state():
+        raise HTTPException(status_code=409, detail="slot does not own runtime state")
+    await request.app.state.account_manager.reload_durable_state()
+    request.app.state.handoff_quiesced = False
+    return {"ready": True, "state": "active"}
+
+
+@app.get("/_internal/handoff/ready", include_in_schema=False)
+async def handoff_ready(request: Request, x_handoff_secret: str | None = Header(default=None)):
+    """Authenticated direct-slot readiness used by the deploy script."""
+    _authorize_handoff(request, x_handoff_secret)
+    ready = not request.app.state.handoff_quiesced and bool(request.app.state.account_manager._accounts)
+    if not ready:
+        raise HTTPException(status_code=503, detail="slot is not active")
+    return {"ready": True, "state": "active"}
 
 
 # --- CORS Middleware ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,10 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+# Authentication intentionally has no production default. Set the test-only
+# key before pytest imports application modules during collection.
+os.environ.setdefault("PROXY_API_KEY", "test_proxy_key_12345")
+
 # =============================================================================
 # Event Loop Fixtures
 # =============================================================================
@@ -83,9 +87,11 @@ def setup_test_environment(tmp_path_factory):
 
     original_creds_file = kiro.config.ACCOUNTS_CONFIG_FILE
     original_state_file = kiro.config.ACCOUNTS_STATE_FILE
+    original_proxy_api_key = kiro.config.PROXY_API_KEY
 
     kiro.config.ACCOUNTS_CONFIG_FILE = str(creds_file)
     kiro.config.ACCOUNTS_STATE_FILE = str(tmp_dir / "state.json")
+    kiro.config.PROXY_API_KEY = "test_proxy_key_12345"
 
     # main.py binds these at import time, and .env may point at deployment-only
     # container paths, so the environment must be isolated too.
@@ -96,10 +102,8 @@ def setup_test_environment(tmp_path_factory):
     os.environ["ACCOUNTS_CONFIG_FILE"] = str(creds_file)
     os.environ["ACCOUNTS_STATE_FILE"] = str(tmp_dir / "state.json")
     os.environ["DASHBOARD_DATA_DIR"] = str(tmp_dir / "dashboard")
-    # config.PROXY_API_KEY falls back to a built-in default, but the data-plane
-    # authenticator reads PROXY_API_KEY straight from the environment. Without a
-    # local .env (as in CI) the two disagree and every authenticated route
-    # answers 401, so pin the environment to whatever config actually resolved.
+    # Authentication has no insecure production default. Pin an explicit test
+    # key in both the imported config and request-time environment.
     os.environ["PROXY_API_KEY"] = kiro.config.PROXY_API_KEY
 
     import main
@@ -115,6 +119,7 @@ def setup_test_environment(tmp_path_factory):
     # Restore original paths
     kiro.config.ACCOUNTS_CONFIG_FILE = original_creds_file
     kiro.config.ACCOUNTS_STATE_FILE = original_state_file
+    kiro.config.PROXY_API_KEY = original_proxy_api_key
     main.ACCOUNTS_CONFIG_FILE = original_creds_file
     main.ACCOUNTS_STATE_FILE = original_state_file
     for key, value in original_environ.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,18 @@ def setup_test_environment(tmp_path_factory):
     print("🧹 Test environment cleaned up")
 
 
+@pytest.fixture(autouse=True)
+def isolate_gateway_store(setup_test_environment):
+    """Give each test a clean gateway partition in the shared dashboard DB."""
+    from kiro.store import connection, initialize
+
+    initialize()
+    with connection() as conn:
+        conn.execute("DELETE FROM account_sources")
+        conn.execute("DELETE FROM account_runtime")
+        conn.execute("DELETE FROM store_migrations")
+
+
 @pytest.fixture
 def mock_env_vars(monkeypatch):
     """

--- a/tests/unit/test_account_manager.py
+++ b/tests/unit/test_account_manager.py
@@ -11,6 +11,7 @@ Tests the AccountManager class that manages multiple Kiro accounts with:
 - State persistence
 """
 
+import asyncio
 import json
 import time
 from pathlib import Path
@@ -624,6 +625,43 @@ class TestAccountManagerInitializeAccount:
     """
     Tests for AccountManager._initialize_account() method.
     """
+
+    def test_internal_source_matches_only_its_explicit_id(self, tmp_path):
+        manager = AccountManager(str(tmp_path / "credentials.json"), str(tmp_path / "state.json"))
+        internal = {"type": "internal", "id": "internal-1"}
+        file_source = {"type": "json", "path": str(tmp_path / "account.json")}
+        manager._credentials_config = [internal, file_source]
+
+        assert manager._credentials_for_account("internal-1") is internal
+        assert manager._credentials_for_account(str((tmp_path / "account.json").resolve())) is file_source
+        assert manager._credentials_for_account(str(tmp_path.resolve())) is None
+
+    @pytest.mark.asyncio
+    async def test_deleted_account_is_not_committed_after_initialization(self, tmp_path):
+        manager = AccountManager(str(tmp_path / "credentials.json"), str(tmp_path / "state.json"))
+        account_id = "internal-1"
+        source = {"type": "internal", "id": account_id}
+        manager._credentials_config = [source]
+        manager._accounts[account_id] = Account(id=account_id)
+        token_started = asyncio.Event()
+        allow_token = asyncio.Event()
+
+        async def delayed_token(_auth):
+            token_started.set()
+            await allow_token.wait()
+            return "token"
+
+        with patch("kiro.account_manager.KiroAuthManager.get_access_token", delayed_token):
+            task = asyncio.create_task(manager.initialize_account(account_id))
+            await token_started.wait()
+            async with manager._lock:
+                manager._remove_account_state(account_id)
+                manager._credentials_config.clear()
+            allow_token.set()
+            assert await task is False
+
+        assert account_id not in manager._accounts
+        assert all(account_id not in mapping.accounts for mapping in manager._model_to_accounts.values())
 
     @pytest.mark.asyncio
     async def test_initialize_account_json_success(self, tmp_path, mock_list_models_response):
@@ -1427,6 +1465,17 @@ class TestAccountManagerSaveState:
     """
 
     @pytest.mark.asyncio
+    async def test_non_writer_skip_reports_false_and_preserves_dirty(self, tmp_path):
+        manager = AccountManager(str(tmp_path / "credentials.json"), str(tmp_path / "state.json"))
+        manager._dirty = True
+
+        with patch("kiro.store.save_runtime_state", return_value=False):
+            assert await manager._save_state() is False
+            assert manager._dirty is True
+            with pytest.raises(RuntimeError, match="not the active writer"):
+                await manager._save_state(raise_errors=True)
+
+    @pytest.mark.asyncio
     async def test_save_state_atomic_write(self, tmp_path):
         """
         Test atomic state saving via tmp file.
@@ -1443,14 +1492,14 @@ class TestAccountManagerSaveState:
         # Act
         await manager._save_state()
 
-        # Assert
-        print(f"State file exists: {state_file.exists()}")
-        assert state_file.exists()
+        # Assert: the unified store transaction publishes the complete document.
+        from kiro.store import load_runtime_state
 
-        # Verify tmp file was cleaned up
-        tmp_file = tmp_path / "state.json.tmp"
-        print(f"Tmp file exists: {tmp_file.exists()}")
-        assert not tmp_file.exists()
+        saved = load_runtime_state()
+        assert saved is not None
+        assert saved["current_account_index"] == 0
+        assert saved["accounts"] == {}
+        assert not state_file.exists()
 
 
 class TestAccountManagerGetFirstAccount:

--- a/tests/unit/test_account_suspension.py
+++ b/tests/unit/test_account_suspension.py
@@ -448,7 +448,8 @@ class TestSuspensionDetectedOnTtlRefresh:
 class TestSuspensionPersistence:
     def test_suspension_survives_a_restart(self, tmp_path):
         import asyncio
-        import json
+
+        from kiro.store import load_runtime_state
 
         state_file = tmp_path / "state.json"
         mgr = AccountManager(str(tmp_path / "credentials.json"), str(state_file))
@@ -457,7 +458,8 @@ class TestSuspensionPersistence:
         mgr._accounts[account.id] = account
         asyncio.run(mgr._save_state())
 
-        saved = json.loads(state_file.read_text())
+        saved = load_runtime_state()
+        assert saved is not None
         assert saved["accounts"][account.id]["suspended_until"] == pytest.approx(account.suspended_until)
 
         reloaded = AccountManager(str(tmp_path / "credentials.json"), str(state_file))

--- a/tests/unit/test_accounts_admin.py
+++ b/tests/unit/test_accounts_admin.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
-import os
+import sqlite3
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import pytest
 
-import kiro.accounts_admin as accounts_admin_module
-from kiro.account_manager import AccountManager, AccountStats, ModelAccountList, RateObservation, account_label
-from kiro.accounts_admin import AccountDeletionRecoveryError, register_account, remove_account
+import kiro.store as store
+from kiro.account_manager import AccountManager, ModelAccountList, account_label
+from kiro.accounts_admin import register_account, remove_account
 from kiro.auth import KiroAuthManager
 
 
@@ -20,69 +21,22 @@ def _write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _direct_pool(
-    tmp_path: Path, monkeypatch, names: tuple[str, ...]
-) -> tuple[AccountManager, Path, Path, dict[str, Path], list[dict[str, str]]]:
-    credentials_file = tmp_path / "credentials.json"
-    state_file = tmp_path / "state.json"
+def _pool(tmp_path: Path, names: tuple[str, ...]) -> tuple[AccountManager, dict[str, Path], list[dict[str, str]]]:
     sources = {name: tmp_path / f"{name}.json" for name in names}
     for name, source in sources.items():
         _write_json(source, {"refreshToken": f"{name}-token"})
     entries = [{"type": "json", "path": str(sources[name]), "region": "us-west-2"} for name in names]
-    _write_json(credentials_file, entries)
-    monkeypatch.setenv("ACCOUNTS_CONFIG_FILE", str(credentials_file))
-    return AccountManager(str(credentials_file), str(state_file)), credentials_file, state_file, sources, entries
+    store.initialize()
+    with store.connection() as conn:
+        store.replace_account_sources(entries, conn)
+    from kiro.dashboard import initialize_dashboard_store
+
+    initialize_dashboard_store()
+    return AccountManager("unused-accounts.json", "unused-runtime.json"), sources, entries
 
 
-def _parsed(path: Path) -> object:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _observation_state(observation: RateObservation) -> tuple[float, str, int, bool, str]:
-    return (
-        observation.at,
-        observation.account_id,
-        observation.rpm,
-        observation.rejected,
-        observation.outcome,
-    )
-
-
-def _manager_state(manager: AccountManager) -> dict[str, object]:
-    return {
-        "dirty": manager._dirty,
-        "accounts": {
-            account_id: (
-                id(account),
-                id(account.auth_manager),
-                account.failures,
-                account.last_failure_time,
-                account.rate_limited_until,
-                account.quota_exhausted_until,
-                account.suspended_until,
-                account.models_cached_at,
-                (
-                    account.stats.total_requests,
-                    account.stats.successful_requests,
-                    account.stats.failed_requests,
-                ),
-            )
-            for account_id, account in manager._accounts.items()
-        },
-        "credentials_config": json.loads(json.dumps(manager._credentials_config)),
-        "model_to_accounts": {
-            model: list(model_accounts.accounts) for model, model_accounts in manager._model_to_accounts.items()
-        },
-        "current_account_index": manager._current_account_index,
-        "rate_observations": [_observation_state(item) for item in manager._rate_observations],
-        "unsaved_rate_observations": [_observation_state(item) for item in manager._unsaved_rate_observations],
-    }
-
-
-def _disk_and_manager_state(
-    manager: AccountManager, credentials_file: Path, state_file: Path
-) -> tuple[object, object, dict[str, object]]:
-    return _parsed(credentials_file), _parsed(state_file), _manager_state(manager)
+def _snapshot(manager: AccountManager) -> tuple[object, object, tuple[str, ...], bool]:
+    return store.load_account_sources(), store.load_runtime_state(), tuple(manager._accounts), manager._dirty
 
 
 class _ObservedLock:
@@ -90,502 +44,201 @@ class _ObservedLock:
         self._lock = lock
         self._attempted = attempted
 
-    async def acquire(self) -> bool:
+    async def __aenter__(self):
         self._attempted.set()
-        return await self._lock.acquire()
-
-    def release(self) -> None:
-        self._lock.release()
-
-    async def __aenter__(self) -> _ObservedLock:
-        await self.acquire()
+        await self._lock.acquire()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
-        self.release()
+    async def __aexit__(self, *args):
+        self._lock.release()
 
 
 @pytest.mark.asyncio
-async def test_direct_registration_preserves_initialized_account_and_credentials_entry(tmp_path, monkeypatch):
-    credentials_file = tmp_path / "credentials.json"
-    state_file = tmp_path / "state.json"
-    existing_source = tmp_path / "existing.json"
+async def test_registration_preserves_initialized_account(tmp_path):
+    manager, sources, entries = _pool(tmp_path, ("existing",))
     new_source = tmp_path / "new.json"
-    _write_json(existing_source, {"refreshToken": "existing-token"})
     _write_json(new_source, {"refreshToken": "new-token"})
-    existing_entry = {"type": "json", "path": str(existing_source), "region": "us-west-2"}
-    new_entry = {"type": "json", "path": str(new_source)}
-    _write_json(credentials_file, [existing_entry])
-    monkeypatch.setenv("ACCOUNTS_CONFIG_FILE", str(credentials_file))
-
-    manager = AccountManager(str(credentials_file), str(state_file))
     await manager.load_credentials()
-    existing_id = str(existing_source.resolve())
-    initialized_account = manager._accounts[existing_id]
-    initialized_account.auth_manager = KiroAuthManager(creds_file=str(existing_source))
+    existing_id = str(sources["existing"].resolve())
+    existing = manager._accounts[existing_id]
+    existing.auth_manager = KiroAuthManager(creds_file=str(sources["existing"]))
     manager._initialize_account = AsyncMock(return_value=True)
 
     await register_account(manager, {"type": "json", "path": str(new_source)})
 
-    assert manager._accounts[existing_id] is initialized_account
-    assert manager._credentials_config == [existing_entry, new_entry]
-    assert _parsed(credentials_file) == [existing_entry, new_entry]
+    assert manager._accounts[existing_id] is existing
+    assert store.load_account_sources() == [*entries, {"type": "json", "path": str(new_source)}]
+    assert store.load_runtime_state() == manager._state_document()
 
 
 @pytest.mark.asyncio
-async def test_remove_registered_account_updates_config_runtime_state(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, entries = _direct_pool(
-        tmp_path, monkeypatch, ("removed", "survivor")
-    )
+async def test_removal_updates_store_and_live_pool(tmp_path):
+    manager, sources, entries = _pool(tmp_path, ("removed", "survivor"))
     await manager.load_credentials()
     removed_id = str(sources["removed"].resolve())
     survivor_id = str(sources["survivor"].resolve())
-    removed_account = manager._accounts[removed_id]
-    survivor_account = manager._accounts[survivor_id]
-    removed_account.failures = 7
-    survivor_account.failures = 2
-    survivor_account.last_failure_time = 125.0
-    survivor_account.stats = AccountStats(total_requests=8, successful_requests=6, failed_requests=2)
+    survivor = manager._accounts[survivor_id]
     manager._model_to_accounts = {
-        "shared-model": ModelAccountList(accounts=[removed_id, survivor_id]),
-        "removed-only-model": ModelAccountList(accounts=[removed_id]),
-        "survivor-only-model": ModelAccountList(accounts=[survivor_id]),
+        "shared": ModelAccountList(accounts=[removed_id, survivor_id]),
+        "removed-only": ModelAccountList(accounts=[removed_id]),
     }
-    manager._current_account_index = 1
-    removed_observation = RateObservation(10.0, removed_id, 3, True, "rate_limited")
-    survivor_observation = RateObservation(20.0, survivor_id, 4, False, "success")
-    manager._rate_observations = [removed_observation, survivor_observation]
-    manager._unsaved_rate_observations = [removed_observation, survivor_observation]
-    await manager._save_state()
 
     await remove_account(manager, account_label(removed_id))
 
-    assert _parsed(credentials_file) == [entries[1]]
-    assert manager._credentials_config == [entries[1]]
-    assert list(manager._accounts) == [survivor_id]
-    assert manager._accounts[survivor_id] is survivor_account
-    assert manager._current_account_index == 0
-    assert manager._model_to_accounts == {
-        "shared-model": ModelAccountList(accounts=[survivor_id]),
-        "survivor-only-model": ModelAccountList(accounts=[survivor_id]),
-    }
-    assert [_observation_state(item) for item in manager._rate_observations] == [
-        _observation_state(survivor_observation)
-    ]
-    assert [_observation_state(item) for item in manager._unsaved_rate_observations] == [
-        _observation_state(survivor_observation)
-    ]
-    assert _parsed(state_file) == {
-        "current_account_index": 0,
-        "accounts": {
-            survivor_id: {
-                "failures": 2,
-                "last_failure_time": 125.0,
-                "quota_exhausted_until": 0.0,
-                "suspended_until": 0.0,
-                "models_cached_at": 0.0,
-                "stats": {"total_requests": 8, "successful_requests": 6, "failed_requests": 2},
-            }
-        },
-        "model_to_accounts": {
-            "shared-model": {"accounts": [survivor_id]},
-            "survivor-only-model": {"accounts": [survivor_id]},
-        },
-    }
+    assert store.load_account_sources() == [entries[1]]
+    assert tuple(manager._accounts) == (survivor_id,)
+    assert manager._accounts[survivor_id] is survivor
+    assert manager._model_to_accounts == {"shared": ModelAccountList(accounts=[survivor_id])}
+    state = store.load_runtime_state()
+    assert state is not None and removed_id not in state["accounts"]
     assert sources["removed"].is_file()
-    assert _parsed(sources["removed"]) == {"refreshToken": "removed-token"}
 
 
 @pytest.mark.asyncio
-async def test_remove_account_rolls_back_when_required_state_save_fails(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, entries = _direct_pool(
-        tmp_path, monkeypatch, ("removed", "survivor")
-    )
+@pytest.mark.parametrize("failure_point", ["replace_account_sources", "save_runtime_state"])
+async def test_removal_transaction_failure_rolls_back_store_and_manager(tmp_path, monkeypatch, failure_point):
+    manager, sources, _ = _pool(tmp_path, ("removed", "survivor"))
     await manager.load_credentials()
-    removed_id = str(sources["removed"].resolve())
-    survivor_id = str(sources["survivor"].resolve())
-    removed_account = manager._accounts[removed_id]
-    survivor_account = manager._accounts[survivor_id]
-    manager._model_to_accounts = {
-        "shared-model": ModelAccountList(accounts=[removed_id, survivor_id]),
-        "removed-only-model": ModelAccountList(accounts=[removed_id]),
-    }
-    manager._current_account_index = 1
-    removed_observation = RateObservation(10.0, removed_id, 3, True, "rate_limited")
-    survivor_observation = RateObservation(20.0, survivor_id, 4, False, "success")
-    manager._rate_observations = [removed_observation, survivor_observation]
-    manager._unsaved_rate_observations = [removed_observation, survivor_observation]
     await manager._save_state()
     manager._dirty = False
-    before = _disk_and_manager_state(manager, credentials_file, state_file)
+    removed_id = str(sources["removed"].resolve())
+    before = _snapshot(manager)
 
-    original_replace = Path.replace
-    state_tmp = state_file.with_suffix(".json.tmp")
+    def fail(*args, **kwargs):
+        raise sqlite3.OperationalError(f"injected {failure_point} failure")
 
-    def fail_state_replace(path: Path, target: Path) -> Path:
-        if path == state_tmp:
-            raise OSError("injected state persistence failure")
-        return original_replace(path, target)
-
-    monkeypatch.setattr(Path, "replace", fail_state_replace)
-
-    with pytest.raises(OSError, match="injected state persistence failure"):
+    monkeypatch.setattr(store, failure_point, fail)
+    with pytest.raises(sqlite3.OperationalError, match="injected"):
         await remove_account(manager, account_label(removed_id))
 
-    assert _disk_and_manager_state(manager, credentials_file, state_file) == before
-    assert manager._accounts[removed_id] is removed_account
-    assert manager._accounts[survivor_id] is survivor_account
-    assert sources["removed"].is_file()
-
-    monkeypatch.setattr(Path, "replace", original_replace)
-    await remove_account(manager, account_label(removed_id))
-
-    assert _parsed(credentials_file) == [entries[1]]
-    assert tuple(manager._accounts) == (survivor_id,)
-    persisted_state = _parsed(state_file)
-    assert isinstance(persisted_state, dict)
-    assert removed_id not in persisted_state["accounts"]
+    assert _snapshot(manager) == before
 
 
 @pytest.mark.asyncio
-async def test_remove_account_serializes_with_manager_lock(tmp_path, monkeypatch):
-    manager, credentials_file, _, sources, entries = _direct_pool(tmp_path, monkeypatch, ("removed", "survivor"))
+async def test_remove_and_register_serialize_with_manager_lock(tmp_path, monkeypatch):
+    manager, sources, entries = _pool(tmp_path, ("removed", "survivor"))
     await manager.load_credentials()
-    removed_id = str(sources["removed"].resolve())
     attempted = asyncio.Event()
     raw_lock = manager._lock
     await raw_lock.acquire()
     monkeypatch.setattr(manager, "_lock", _ObservedLock(raw_lock, attempted))
-    delete_task: asyncio.Task[str] | None = None
-    attempted_task: asyncio.Task[bool] | None = None
+    task = asyncio.create_task(remove_account(manager, account_label(str(sources["removed"].resolve()))))
+    await asyncio.wait_for(attempted.wait(), 1)
+    assert not task.done()
+    assert store.load_account_sources() == entries
+    raw_lock.release()
+    await asyncio.wait_for(task, 1)
 
-    try:
-        delete_task = asyncio.create_task(remove_account(manager, account_label(removed_id)))
-        attempted_task = asyncio.create_task(attempted.wait())
-        done, _ = await asyncio.wait_for(
-            asyncio.wait({delete_task, attempted_task}, return_when=asyncio.FIRST_COMPLETED),
-            timeout=1,
-        )
-
-        assert attempted_task in done, "remove_account did not serialize through AccountManager._lock"
-        assert delete_task not in done
-        assert _parsed(credentials_file) == entries
-        assert list(manager._accounts) == [str(source.resolve()) for source in sources.values()]
-
-        raw_lock.release()
-        await asyncio.wait_for(delete_task, timeout=1)
-    finally:
-        if raw_lock.locked():
-            raw_lock.release()
-        for task in (delete_task, attempted_task):
-            if task is not None and not task.done():
-                task.cancel()
-        await asyncio.gather(
-            *(task for task in (delete_task, attempted_task) if task is not None), return_exceptions=True
-        )
-
-    assert _parsed(credentials_file) == [entries[1]]
-    assert list(manager._accounts) == [str(sources["survivor"].resolve())]
+    new_source = tmp_path / "new.json"
+    _write_json(new_source, {"refreshToken": "new-token"})
+    manager._initialize_account = AsyncMock(return_value=True)
+    await register_account(manager, {"type": "json", "path": str(new_source)})
+    assert store.load_account_sources() == [entries[1], {"type": "json", "path": str(new_source)}]
 
 
 @pytest.mark.asyncio
-async def test_remove_account_rejects_unknown_label_without_changes(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, _, _ = _direct_pool(tmp_path, monkeypatch, ("first", "second"))
-    await manager.load_credentials()
-    await manager._save_state()
-    before = _disk_and_manager_state(manager, credentials_file, state_file)
-
-    with pytest.raises(ValueError, match="(?i)unknown account"):
-        await remove_account(manager, "000000000000")
-
-    assert _disk_and_manager_state(manager, credentials_file, state_file) == before
-
-
-@pytest.mark.asyncio
-async def test_remove_account_rejects_last_account_without_changes(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, _ = _direct_pool(tmp_path, monkeypatch, ("only",))
-    await manager.load_credentials()
-    await manager._save_state()
-    before = _disk_and_manager_state(manager, credentials_file, state_file)
-    only_id = str(sources["only"].resolve())
-
-    with pytest.raises(ValueError, match="(?i)last account"):
-        await remove_account(manager, account_label(only_id))
-
-    assert _disk_and_manager_state(manager, credentials_file, state_file) == before
-    assert sources["only"].is_file()
-
-
-@pytest.mark.asyncio
-async def test_remove_account_rejects_directory_backed_account_without_changes(tmp_path, monkeypatch):
-    credentials_file = tmp_path / "credentials.json"
-    state_file = tmp_path / "state.json"
-    credentials_directory = tmp_path / "scanned"
-    credentials_directory.mkdir()
-    scanned_source = credentials_directory / "scanned.json"
-    direct_source = tmp_path / "direct.json"
-    _write_json(scanned_source, {"refreshToken": "scanned-token"})
-    _write_json(direct_source, {"refreshToken": "direct-token"})
-    entries = [
-        {"type": "json", "path": str(credentials_directory)},
-        {"type": "json", "path": str(direct_source)},
-    ]
-    _write_json(credentials_file, entries)
-    monkeypatch.setenv("ACCOUNTS_CONFIG_FILE", str(credentials_file))
-    manager = AccountManager(str(credentials_file), str(state_file))
-    await manager.load_credentials()
-    await manager._save_state()
-    before = _disk_and_manager_state(manager, credentials_file, state_file)
-
-    with pytest.raises(ValueError, match="(?i)directory"):
-        await remove_account(manager, account_label(str(scanned_source.resolve())))
-
-    assert _disk_and_manager_state(manager, credentials_file, state_file) == before
-    assert scanned_source.is_file()
-    assert direct_source.is_file()
-
-
-@pytest.mark.asyncio
-async def test_remove_account_repeated_delete_is_unknown_and_preserves_survivor(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, entries = _direct_pool(
-        tmp_path, monkeypatch, ("removed", "survivor")
-    )
-    await manager.load_credentials()
-    removed_id = str(sources["removed"].resolve())
-    removed_label = account_label(removed_id)
-    await remove_account(manager, removed_label)
-    after_first_delete = _disk_and_manager_state(manager, credentials_file, state_file)
-
-    with pytest.raises(ValueError, match="(?i)unknown account"):
-        await remove_account(manager, removed_label)
-
-    assert _disk_and_manager_state(manager, credentials_file, state_file) == after_first_delete
-    assert _parsed(credentials_file) == [entries[1]]
-    assert list(manager._accounts) == [str(sources["survivor"].resolve())]
-    assert sources["removed"].is_file()
-
-
-@pytest.mark.asyncio
-async def test_removed_account_does_not_return_after_restart_and_survivor_routes(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, entries = _direct_pool(
-        tmp_path, monkeypatch, ("removed", "survivor")
-    )
+async def test_removed_account_stays_removed_after_restart(tmp_path):
+    manager, sources, entries = _pool(tmp_path, ("removed", "survivor"))
     await manager.load_credentials()
     removed_id = str(sources["removed"].resolve())
     survivor_id = str(sources["survivor"].resolve())
-    manager._model_to_accounts = {
-        "shared-model": ModelAccountList(accounts=[removed_id, survivor_id]),
-        "removed-only-model": ModelAccountList(accounts=[removed_id]),
-    }
-    manager._current_account_index = 1
-
+    manager._model_to_accounts = {"shared": ModelAccountList(accounts=[removed_id, survivor_id])}
     await remove_account(manager, account_label(removed_id))
 
-    restarted = AccountManager(str(credentials_file), str(state_file))
+    restarted = AccountManager("unused-accounts.json", "unused-runtime.json")
     await restarted.load_credentials()
     await restarted.load_state()
     restarted._accounts[survivor_id].auth_manager = KiroAuthManager(creds_file=str(sources["survivor"]))
-    routed = await restarted.get_next_account("shared-model")
 
-    assert _parsed(credentials_file) == [entries[1]]
-    assert list(restarted._accounts) == [survivor_id]
-    assert restarted._current_account_index == 0
-    assert all(removed_id not in model_accounts.accounts for model_accounts in restarted._model_to_accounts.values())
-    assert routed is restarted._accounts[survivor_id]
-    assert sources["removed"].is_file()
-    assert _parsed(sources["removed"]) == {"refreshToken": "removed-token"}
+    assert store.load_account_sources() == [entries[1]]
+    assert tuple(restarted._accounts) == (survivor_id,)
+    assert await restarted.get_next_account("shared") is restarted._accounts[survivor_id]
 
 
-@pytest.mark.asyncio
-async def test_retry_recovery_cannot_erase_successful_registration(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, entries = _direct_pool(
-        tmp_path, monkeypatch, ("removed", "survivor")
+def test_imports_legacy_recovery_record_once(tmp_path):
+    original_entries = [{"type": "json", "path": str(tmp_path / "restored.json")}]
+    runtime = {"current_account_index": 0, "accounts": {}}
+    recovery = tmp_path / "deletion-recovery.json"
+    _write_json(
+        recovery,
+        {
+            "version": 1,
+            "credentials_entries": original_entries,
+            "state_file": base64.b64encode(json.dumps(runtime).encode()).decode(),
+        },
     )
-    new_source = tmp_path / "new.json"
-    _write_json(new_source, {"refreshToken": "new-token"})
-    new_entry = {"type": "json", "path": str(new_source)}
-    await manager.load_credentials()
-    await manager._save_state()
-    manager._initialize_account = AsyncMock(return_value=True)
-    removed_id = str(sources["removed"].resolve())
-    original_write_entries = accounts_admin_module._write_entries
-    write_count = 0
 
-    def fail_first_rollback(candidate_manager: AccountManager, candidate_entries: list[dict[str, object]]) -> None:
-        nonlocal write_count
-        write_count += 1
-        if write_count == 2:
-            raise OSError("injected rollback credentials failure")
-        original_write_entries(candidate_manager, candidate_entries)
-
-    def fail_finalize(_: str) -> None:
-        raise RuntimeError("injected finalization failure")
-
-    monkeypatch.setattr(accounts_admin_module, "_write_entries", fail_first_rollback)
-
-    with pytest.raises(AccountDeletionRecoveryError, match="rollback is incomplete"):
-        await remove_account(manager, account_label(removed_id), finalize=fail_finalize)
-
-    await register_account(manager, {"type": "json", "path": str(new_source)})
-    assert new_entry in _parsed(credentials_file)
-
-    await remove_account(manager, account_label(removed_id))
-
-    assert _parsed(credentials_file) == [entries[1], new_entry]
-    assert tuple(manager._accounts) == (str(sources["survivor"].resolve()), str(new_source.resolve()))
-    assert not accounts_admin_module._recovery_path(manager).exists()
+    assert store.import_legacy_files("missing.json", "missing-state.json", str(recovery)) is True
+    assert store.load_account_sources() == original_entries
+    assert store.load_runtime_state() == runtime
+    assert not recovery.exists()
+    assert store.import_legacy_files("missing.json", "missing-state.json", str(recovery)) is False
 
 
-@pytest.mark.asyncio
-async def test_pending_deletion_recovery_survives_manager_recreation(tmp_path, monkeypatch):
-    manager, credentials_file, state_file, sources, entries = _direct_pool(
-        tmp_path, monkeypatch, ("removed", "survivor")
-    )
-    new_source = tmp_path / "new.json"
-    _write_json(new_source, {"refreshToken": "new-token"})
-    new_entry = {"type": "json", "path": str(new_source)}
-    await manager.load_credentials()
-    await manager._save_state()
-    removed_id = str(sources["removed"].resolve())
-    original_write_entries = accounts_admin_module._write_entries
-    write_count = 0
+def test_runtime_writer_gate_skips_and_then_writes_atomically(monkeypatch):
+    store.initialize()
+    monkeypatch.setenv("KIRO_SLOT", "blue")
+    store.set_runtime_writer("green")
 
-    def fail_first_rollback(candidate_manager: AccountManager, candidate_entries: list[dict[str, object]]) -> None:
-        nonlocal write_count
-        write_count += 1
-        if write_count == 2:
-            raise OSError("injected rollback credentials failure")
-        original_write_entries(candidate_manager, candidate_entries)
+    assert store.save_runtime_state({"value": "skipped"}) is False
+    assert store.load_runtime_state() is None
+    with pytest.raises(RuntimeError, match="not the active writer"):
+        store.save_runtime_state({"value": "rejected"}, require_write=True)
 
-    def fail_finalize(_: str) -> None:
-        raise RuntimeError("injected finalization failure")
+    store.set_runtime_writer("blue")
+    assert store.save_runtime_state({"value": "written"}) is True
+    assert store.load_runtime_state() == {"value": "written"}
 
-    monkeypatch.setattr(accounts_admin_module, "_write_entries", fail_first_rollback)
 
-    with pytest.raises(AccountDeletionRecoveryError, match="rollback is incomplete"):
-        await remove_account(manager, account_label(removed_id), finalize=fail_finalize)
+def test_standby_cannot_mutate_sources_or_internal_credentials(monkeypatch):
+    store.initialize()
+    entry = {"type": "internal", "id": "account", "credential": {"refreshToken": "original"}}
+    with store.connection() as conn:
+        store.replace_account_sources([entry], conn)
+    monkeypatch.setenv("KIRO_SLOT", "blue")
+    store.set_runtime_writer("green")
 
-    recovery_path = accounts_admin_module._recovery_path(manager)
-    assert recovery_path.exists()
-    assert recovery_path.stat().st_mode & 0o777 == 0o600
+    with store.connection() as conn, pytest.raises(RuntimeError, match="not the active writer"):
+        store.replace_account_sources([], conn)
+    with pytest.raises(RuntimeError, match="not the active writer"):
+        store.save_internal_credential("account", {"refreshToken": "standby"})
 
-    restarted = AccountManager(str(credentials_file), str(state_file))
+    assert store.load_account_sources() == [{"type": "internal", "id": "account"}]
+    assert store.load_internal_credential("account") == {"refreshToken": "original"}
 
-    def fail_restarted_recovery(candidate_entries: list[dict[str, object]]) -> None:
-        if candidate_entries == entries:
-            raise OSError("injected restarted recovery failure")
-        original_write_entries(candidate_entries)
 
-    monkeypatch.setattr(accounts_admin_module, "_write_entries", fail_restarted_recovery)
-    with pytest.raises(AccountDeletionRecoveryError, match="credentials.json remains changed"):
-        await restarted.load_credentials()
-    assert _parsed(credentials_file) == [entries[1]]
+def test_refresh_lease_is_exclusive_across_connections_and_owner_safe():
+    store.initialize()
+    first = store.try_acquire_refresh_lease("account")
+    assert first is not None
+    assert store.try_acquire_refresh_lease("account") is None
 
-    monkeypatch.setattr(accounts_admin_module, "_write_entries", original_write_entries)
-    await restarted.load_credentials()
+    store.release_refresh_lease("account", "different-owner")
+    assert store.try_acquire_refresh_lease("account") is None
+    store.release_refresh_lease("account", first)
+    assert store.try_acquire_refresh_lease("account") is not None
 
-    assert _parsed(credentials_file) == entries
-    assert tuple(restarted._accounts) == (removed_id, str(sources["survivor"].resolve()))
 
-    await restarted.load_state()
-    restarted._initialize_account = AsyncMock(return_value=True)
+def test_legacy_runtime_import_is_not_writer_gated(tmp_path, monkeypatch):
+    monkeypatch.setenv("KIRO_SLOT", "blue")
+    store.initialize()
+    store.set_runtime_writer("green")
+    state_file = tmp_path / "state.json"
+    _write_json(state_file, {"current_account_index": 3})
 
-    await register_account(restarted, {"type": "json", "path": str(new_source)})
-
-    assert _parsed(credentials_file) == [*entries, new_entry]
-    assert tuple(restarted._accounts) == (
-        removed_id,
-        str(sources["survivor"].resolve()),
-        str(new_source.resolve()),
-    )
-    assert not recovery_path.exists()
+    assert store.import_legacy_files("missing.json", str(state_file)) is True
+    assert store.load_runtime_state() == {"current_account_index": 3}
 
 
 @pytest.mark.asyncio
-async def test_successful_removal_does_not_persist_recovery_record(tmp_path, monkeypatch):
-    manager, _, _, sources, _ = _direct_pool(tmp_path, monkeypatch, ("removed", "survivor"))
+@pytest.mark.parametrize(
+    "names,label,error", [(("one", "two"), "000000000000", "unknown"), (("only",), None, "last account")]
+)
+async def test_rejected_removal_does_not_mutate(tmp_path, names, label, error):
+    manager, sources, _ = _pool(tmp_path, names)
     await manager.load_credentials()
-    persist_recovery = Mock(wraps=accounts_admin_module._persist_removal_recovery)
-    monkeypatch.setattr(accounts_admin_module, "_persist_removal_recovery", persist_recovery)
-
-    await remove_account(manager, account_label(str(sources["removed"].resolve())))
-
-    persist_recovery.assert_not_called()
-
-
-def test_recovery_record_uses_exclusive_secure_temp_file(tmp_path, monkeypatch):
-    manager, _, _, _, entries = _direct_pool(tmp_path, monkeypatch, ("removed", "survivor"))
-    snapshot = {"state_file": None}
-    observed_modes: list[int] = []
-    secure_temp = tmp_path / ".exclusive-recovery-temp"
-
-    def secure_mkstemp(*, prefix: str, dir: Path) -> tuple[int, str]:
-        assert prefix.startswith(".credentials.json.account-deletion-recovery.")
-        assert dir == tmp_path
-        descriptor = os.open(secure_temp, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
-        observed_modes.append(os.fstat(descriptor).st_mode & 0o777)
-        return descriptor, str(secure_temp)
-
-    monkeypatch.setattr(accounts_admin_module.tempfile, "mkstemp", secure_mkstemp)
-
-    accounts_admin_module._persist_removal_recovery(manager, entries, snapshot)
-    try:
-        assert observed_modes == [0o600]
-        assert accounts_admin_module._recovery_path(manager).exists()
-    finally:
-        accounts_admin_module._clear_removal_recovery(manager)
-
-
-@pytest.mark.asyncio
-async def test_remove_account_uses_manager_credentials_path_when_env_differs(tmp_path, monkeypatch):
-    manager, credentials_file, _, sources, entries = _direct_pool(tmp_path, monkeypatch, ("removed", "survivor"))
-    await manager.load_credentials()
-    unrelated_credentials = tmp_path / "unrelated-credentials.json"
-    _write_json(unrelated_credentials, entries)
-    monkeypatch.setenv("ACCOUNTS_CONFIG_FILE", str(unrelated_credentials))
-
-    await remove_account(manager, account_label(str(sources["removed"].resolve())))
-
-    assert _parsed(credentials_file) == [entries[1]]
-    assert _parsed(unrelated_credentials) == entries
-
-
-@pytest.mark.asyncio
-async def test_register_account_serializes_with_manager_lock(tmp_path, monkeypatch):
-    manager, credentials_file, _, _, entries = _direct_pool(tmp_path, monkeypatch, ("existing",))
-    new_source = tmp_path / "new.json"
-    _write_json(new_source, {"refreshToken": "new-token"})
-    await manager.load_credentials()
-    manager._initialize_account = AsyncMock(return_value=True)
-    attempted = asyncio.Event()
-    raw_lock = manager._lock
-    await raw_lock.acquire()
-    monkeypatch.setattr(manager, "_lock", _ObservedLock(raw_lock, attempted))
-    register_task: asyncio.Task[dict[str, object]] | None = None
-    attempted_task: asyncio.Task[bool] | None = None
-
-    try:
-        register_task = asyncio.create_task(register_account(manager, {"type": "json", "path": str(new_source)}))
-        attempted_task = asyncio.create_task(attempted.wait())
-        done, _ = await asyncio.wait_for(
-            asyncio.wait({register_task, attempted_task}, return_when=asyncio.FIRST_COMPLETED),
-            timeout=1,
-        )
-
-        assert attempted_task in done, "register_account did not serialize through AccountManager._lock"
-        assert register_task not in done
-        assert _parsed(credentials_file) == entries
-
-        raw_lock.release()
-        await asyncio.wait_for(register_task, timeout=1)
-    finally:
-        if raw_lock.locked():
-            raw_lock.release()
-        for task in (register_task, attempted_task):
-            if task is not None and not task.done():
-                task.cancel()
-        await asyncio.gather(
-            *(task for task in (register_task, attempted_task) if task is not None), return_exceptions=True
-        )
-
-    assert _parsed(credentials_file) == [*entries, {"type": "json", "path": str(new_source)}]
+    before = _snapshot(manager)
+    target = label or account_label(str(sources["only"].resolve()))
+    with pytest.raises(ValueError, match=f"(?i){error}"):
+        await remove_account(manager, target)
+    assert _snapshot(manager) == before

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -7,6 +7,7 @@ Tests token management logic for Kiro without real network requests.
 
 import asyncio
 import json
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -15,6 +16,7 @@ import pytest
 
 from kiro.auth import AuthType, KiroAuthManager
 from kiro.config import TOKEN_REFRESH_THRESHOLD
+from kiro.store import connection, initialize, replace_account_sources
 
 
 class TestKiroAuthManagerInitialization:
@@ -1935,288 +1937,149 @@ class TestKiroAuthManagerGracefulDegradation:
             assert exc_info.value.response.status_code == 400
 
 
-# =============================================================================
-# Tests for _save_credentials_to_sqlite() - NEW FUNCTIONALITY
-# =============================================================================
+class TestExternalCredentialOverlayPersistence:
+    """Rotations persist in the gateway store without mutating source credentials."""
 
+    @staticmethod
+    def _register_source(source_type: str, path: str) -> str:
+        initialize()
+        with connection() as conn:
+            replace_account_sources([{"type": source_type, "path": path}], conn)
+            return conn.execute("SELECT account_id FROM account_sources").fetchone()[0]
 
-class TestKiroAuthManagerSaveCredentialsToSqlite:
-    """Tests for _save_credentials_to_sqlite() method (Issue #43 fix).
+    @staticmethod
+    def _overlay(account_id: str) -> dict:
+        with connection() as conn:
+            row = conn.execute(
+                "SELECT credential_json FROM account_sources WHERE account_id = ?", (account_id,)
+            ).fetchone()
+        assert row is not None and row[0] is not None
+        return json.loads(row[0])
 
-    Background: Gateway was not persisting refreshed tokens back to SQLite,
-    causing stale tokens to be reloaded after 1-2 hours.
-    """
+    def test_save_from_external_sqlite_uses_overlay_and_survives_restart(self, temp_sqlite_db_social):
+        account_id = self._register_source("kiro_cli", temp_sqlite_db_social)
+        source_before = open(temp_sqlite_db_social, "rb").read()
+        manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
+        manager._access_token = "rotated_access"
+        manager._refresh_token = "rotated_refresh"
+        manager._expires_at = datetime(2099, 2, 3, tzinfo=timezone.utc)
 
-    def test_save_credentials_to_sqlite_writes_token_data(self, tmp_path):
-        """
-        What it does: Verifies that _save_credentials_to_sqlite writes token data.
-        Purpose: Ensure tokens are persisted to SQLite after refresh.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite database...")
-        db_file = tmp_path / "data.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # Initial token data
-        initial_token_data = {
-            "access_token": "old_access_token",
-            "refresh_token": "old_refresh_token",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating tokens in memory...")
-        manager._access_token = "new_access_token"
-        manager._refresh_token = "new_refresh_token"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _save_credentials_to_sqlite()...")
         manager._save_credentials_to_sqlite()
 
-        print("Verification: Reading SQLite to check saved data...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
-        row = cursor.fetchone()
-        conn.close()
+        assert open(temp_sqlite_db_social, "rb").read() == source_before
+        assert self._overlay(account_id) == {
+            "accessToken": "rotated_access",
+            "refreshToken": "rotated_refresh",
+            "expiresAt": "2099-02-03T00:00:00+00:00",
+            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789:profile/social",
+        }
+        restarted = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
+        assert restarted._access_token == "rotated_access"
+        assert restarted._refresh_token == "rotated_refresh"
+        assert restarted._expires_at == datetime(2099, 2, 3, tzinfo=timezone.utc)
 
-        assert row is not None
-        saved_data = json.loads(row[0])
+    def test_save_from_external_json_uses_overlay_and_survives_restart(self, temp_creds_file):
+        account_id = self._register_source("json", temp_creds_file)
+        source_before = open(temp_creds_file, "rb").read()
+        manager = KiroAuthManager(creds_file=temp_creds_file)
+        manager._access_token = "json_rotated_access"
+        manager._refresh_token = "json_rotated_refresh"
+        manager._expires_at = datetime(2099, 4, 5, tzinfo=timezone.utc)
 
-        print(f"Comparing access_token: Expected 'new_access_token', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "new_access_token"
+        manager._save_credentials_to_file()
 
-        print(f"Comparing refresh_token: Expected 'new_refresh_token', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "new_refresh_token"
+        assert open(temp_creds_file, "rb").read() == source_before
+        overlay = self._overlay(account_id)
+        assert overlay["accessToken"] == "json_rotated_access"
+        assert overlay["refreshToken"] == "json_rotated_refresh"
+        assert overlay["expiresAt"] == "2099-04-05T00:00:00+00:00"
+        restarted = KiroAuthManager(creds_file=temp_creds_file)
+        assert restarted._access_token == "json_rotated_access"
+        assert restarted._refresh_token == "json_rotated_refresh"
 
-    def test_save_credentials_to_sqlite_handles_missing_database(self, tmp_path):
-        """
-        What it does: Verifies handling of missing SQLite file.
-        Purpose: Ensure application doesn't crash when database is missing.
-        """
-        print("Setup: Creating KiroAuthManager with non-existent SQLite...")
-        non_existent_db = str(tmp_path / "non_existent.sqlite3")
-
-        manager = KiroAuthManager(refresh_token="test_token", sqlite_db=non_existent_db)
-        manager._access_token = "new_token"
-
-        print("Action: Calling _save_credentials_to_sqlite() with missing database...")
-        # Should not raise exception
+    def test_newer_external_sqlite_login_supersedes_stale_overlay(self, temp_sqlite_db_social):
+        self._register_source("kiro_cli", temp_sqlite_db_social)
+        manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
+        manager._access_token = "stale_overlay_access"
+        manager._refresh_token = "stale_overlay_refresh"
+        manager._expires_at = datetime(2099, 2, 3, tzinfo=timezone.utc)
         manager._save_credentials_to_sqlite()
 
-        print("Verification: No exception raised...")
-        assert True
-
-    def test_save_credentials_to_sqlite_returns_early_when_no_sqlite_db(self):
-        """
-        What it does: Verifies early return when sqlite_db is None.
-        Purpose: Ensure method is no-op when SQLite is not configured.
-        """
-        print("Setup: Creating KiroAuthManager without sqlite_db...")
-        manager = KiroAuthManager(refresh_token="test_token")
-        manager._sqlite_db = None
-        manager._access_token = "new_token"
-
-        print("Action: Calling _save_credentials_to_sqlite()...")
-        # Should return early without doing anything
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: No exception raised...")
-        assert True
-
-
-# =============================================================================
-# Tests for token persistence after refresh (Issue #43 fix)
-# =============================================================================
-
-
-class TestKiroAuthManagerTokenPersistence:
-    """Tests for token persistence after refresh.
-
-    Background: After refresh, tokens must be saved to SQLite so they're
-    available after gateway restart or when reloaded.
-    """
-
-    @pytest.mark.asyncio
-    async def test_refresh_token_aws_sso_oidc_saves_to_sqlite(self, tmp_path, mock_aws_sso_oidc_token_response):
-        """
-        What it does: Verifies tokens are saved to SQLite after AWS SSO OIDC refresh.
-        Purpose: Ensure refreshed tokens are persisted (Issue #43 fix).
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite database...")
-        db_file = tmp_path / "data.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        initial_token_data = {
-            "access_token": "old_access_token",
-            "refresh_token": "old_refresh_token",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
-        )
-
-        registration_data = {
-            "client_id": "test_client_id",
-            "client_secret": "test_client_secret",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:device-registration", json.dumps(registration_data)),
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Setup: Mocking HTTP client for successful refresh...")
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
-        mock_response.raise_for_status = Mock()
-
-        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.post = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_class.return_value = mock_client
-
-            print("Action: Calling _do_aws_sso_oidc_refresh()...")
-            await manager._do_aws_sso_oidc_refresh()
-
-            print("Verification: Tokens updated in memory...")
-            assert manager._access_token == "new_aws_sso_access_token"
-            assert manager._refresh_token == "new_aws_sso_refresh_token"
-
-            print("Verification: Reading SQLite to check persistence...")
-            conn = sqlite3.connect(str(db_file))
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
-            row = cursor.fetchone()
-            conn.close()
-
+        with sqlite3.connect(temp_sqlite_db_social) as conn:
+            row = conn.execute("SELECT value FROM auth_kv WHERE key = 'kirocli:social:token'").fetchone()
             assert row is not None
-            saved_data = json.loads(row[0])
-
-            print(
-                f"Comparing saved access_token: Expected 'new_aws_sso_access_token', Got '{saved_data['access_token']}'"
+            external = json.loads(row[0])
+            external.update(
+                access_token="new_login_access",
+                refresh_token="new_login_refresh",
+                expires_at="2099-03-04T00:00:00Z",
             )
-            assert saved_data["access_token"] == "new_aws_sso_access_token"
-
-            print(
-                f"Comparing saved refresh_token: Expected 'new_aws_sso_refresh_token', Got '{saved_data['refresh_token']}'"
+            conn.execute(
+                "UPDATE auth_kv SET value = ? WHERE key = 'kirocli:social:token'",
+                (json.dumps(external),),
             )
-            assert saved_data["refresh_token"] == "new_aws_sso_refresh_token"
+
+        restarted = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
+        assert restarted._access_token == "new_login_access"
+        assert restarted._refresh_token == "new_login_refresh"
+        assert restarted._expires_at == datetime(2099, 3, 4, tzinfo=timezone.utc)
+
+    def test_newer_external_json_login_supersedes_stale_overlay(self, temp_creds_file):
+        self._register_source("json", temp_creds_file)
+        manager = KiroAuthManager(creds_file=temp_creds_file)
+        manager._access_token = "stale_json_overlay_access"
+        manager._refresh_token = "stale_json_overlay_refresh"
+        manager._expires_at = datetime(2099, 2, 3, tzinfo=timezone.utc)
+        manager._save_credentials_to_file()
+
+        with open(temp_creds_file, encoding="utf-8") as source:
+            external = json.load(source)
+        external.update(
+            accessToken="new_json_login_access",
+            refreshToken="new_json_login_refresh",
+            expiresAt="2099-03-04T00:00:00Z",
+        )
+        with open(temp_creds_file, "w", encoding="utf-8") as source:
+            json.dump(external, source)
+
+        restarted = KiroAuthManager(creds_file=temp_creds_file)
+        assert restarted._access_token == "new_json_login_access"
+        assert restarted._refresh_token == "new_json_login_refresh"
+        assert restarted._expires_at == datetime(2099, 3, 4, tzinfo=timezone.utc)
 
     @pytest.mark.asyncio
-    async def test_refresh_token_kiro_desktop_saves_to_sqlite(self, tmp_path, mock_kiro_token_response):
-        """
-        What it does: Verifies tokens are saved to SQLite after Kiro Desktop refresh.
-        Purpose: Ensure consistency between both refresh methods.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite database...")
-        db_file = tmp_path / "data.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        initial_token_data = {
-            "access_token": "old_access_token",
-            "refresh_token": "old_refresh_token",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("codewhisperer:odic:token", json.dumps(initial_token_data)),
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite and Kiro Desktop auth...")
-        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
-
-        print("Setup: Mocking HTTP client for successful refresh...")
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.json = Mock(return_value=mock_kiro_token_response())
+    async def test_refresh_from_external_sqlite_updates_only_overlay(
+        self, temp_sqlite_db_social, mock_kiro_token_response, valid_kiro_token
+    ):
+        account_id = self._register_source("kiro_cli", temp_sqlite_db_social)
+        source_before = open(temp_sqlite_db_social, "rb").read()
+        manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
+        mock_response = AsyncMock(status_code=200)
+        refreshed = mock_kiro_token_response()
+        refreshed["expiresIn"] = 4_000_000_000
+        mock_response.json = Mock(return_value=refreshed)
         mock_response.raise_for_status = Mock()
 
-        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.post = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_class.return_value = mock_client
-
-            print("Action: Calling _refresh_token_kiro_desktop()...")
+        with patch("kiro.auth.httpx.AsyncClient") as client_class:
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_response)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=None)
+            client_class.return_value = client
             await manager._refresh_token_kiro_desktop()
 
-            print("Verification: Reading SQLite to check persistence...")
-            conn = sqlite3.connect(str(db_file))
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("codewhisperer:odic:token",))
-            row = cursor.fetchone()
-            conn.close()
-
-            assert row is not None
-            saved_data = json.loads(row[0])
-
-            print(
-                f"Comparing saved refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'"
-            )
-            assert saved_data["refresh_token"] == "new_refresh_token_xyz"
+        assert open(temp_sqlite_db_social, "rb").read() == source_before
+        overlay = self._overlay(account_id)
+        assert overlay["accessToken"] == valid_kiro_token
+        assert overlay["refreshToken"] == "new_refresh_token_xyz"
+        restarted = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
+        assert restarted._access_token == valid_kiro_token
+        assert restarted._refresh_token == "new_refresh_token_xyz"
 
 
 # =============================================================================
-# Tests for Social Login Support (kirocli:social:token)
+# Legacy SQLite write-back tests (superseded by immutable source overlays)
 # =============================================================================
-
-
 class TestKiroAuthManagerSocialLogin:
     """Tests for social login support (Google, GitHub, etc.).
 
@@ -2306,147 +2169,6 @@ class TestKiroAuthManagerSocialLogin:
         print(f"Comparing _sqlite_token_key: Expected 'codewhisperer:odic:token', Got '{manager._sqlite_token_key}'")
         assert manager._sqlite_token_key == "codewhisperer:odic:token"
 
-    def test_save_credentials_to_sqlite_uses_source_key(self, temp_sqlite_db_social):
-        """
-        What it does: Verifies tokens are saved back to the same key they were loaded from.
-        Purpose: Ensure social login tokens go to kirocli:social:token, not OIDC keys.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating KiroAuthManager with social login SQLite...")
-        manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-
-        print("Verification: Loaded from kirocli:social:token...")
-        assert manager._sqlite_token_key == "kirocli:social:token"
-
-        print("Action: Updating tokens in memory...")
-        manager._access_token = "updated_social_access"
-        manager._refresh_token = "updated_social_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _save_credentials_to_sqlite()...")
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite to check saved data...")
-        conn = sqlite3.connect(temp_sqlite_db_social)
-        cursor = conn.cursor()
-
-        # Check that kirocli:social:token was updated
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        assert row is not None
-        saved_data = json.loads(row[0])
-
-        print(f"Comparing saved access_token: Expected 'updated_social_access', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "updated_social_access"
-
-        print(f"Comparing saved refresh_token: Expected 'updated_social_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "updated_social_refresh"
-
-    @pytest.mark.asyncio
-    async def test_refresh_token_kiro_desktop_saves_to_social_key(
-        self, temp_sqlite_db_social, mock_kiro_token_response
-    ):
-        """
-        What it does: Verifies tokens are saved to kirocli:social:token after Kiro Desktop refresh.
-        Purpose: Ensure social login tokens persist correctly after refresh.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating KiroAuthManager with social login SQLite...")
-        manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-
-        print("Verification: Loaded from kirocli:social:token...")
-        assert manager._sqlite_token_key == "kirocli:social:token"
-        assert manager.auth_type == AuthType.KIRO_DESKTOP
-
-        print("Setup: Mocking HTTP client for successful refresh...")
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.json = Mock(return_value=mock_kiro_token_response())
-        mock_response.raise_for_status = Mock()
-
-        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.post = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_class.return_value = mock_client
-
-            print("Action: Calling _refresh_token_kiro_desktop()...")
-            await manager._refresh_token_kiro_desktop()
-
-            print("Verification: Reading SQLite to check persistence...")
-            conn = sqlite3.connect(temp_sqlite_db_social)
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-            row = cursor.fetchone()
-            conn.close()
-
-            assert row is not None
-            saved_data = json.loads(row[0])
-
-            print(
-                f"Comparing saved refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'"
-            )
-            assert saved_data["refresh_token"] == "new_refresh_token_xyz"
-
-    def test_save_credentials_fallback_when_source_key_unknown(self, tmp_path):
-        """
-        What it does: Verifies fallback behavior when _sqlite_token_key is None.
-        Purpose: Ensure robustness when source key is not tracked.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite database with kirocli:social:token...")
-        db_file = tmp_path / "data_fallback.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {"access_token": "old_token", "refresh_token": "old_refresh", "expires_at": "2099-01-01T00:00:00Z"}
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with direct credentials (not from SQLite)...")
-        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
-
-        # Simulate scenario where _sqlite_token_key is None (edge case)
-        manager._sqlite_token_key = None
-        manager._access_token = "new_fallback_token"
-        manager._refresh_token = "new_fallback_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _save_credentials_to_sqlite() with unknown source key...")
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Fallback should try all keys and update first match...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        assert row is not None
-        saved_data = json.loads(row[0])
-
-        print(f"Comparing saved access_token: Expected 'new_fallback_token', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "new_fallback_token"
-
     def test_social_login_no_device_registration_key(self, temp_sqlite_db_social):
         """
         What it does: Verifies social login works without device-registration key.
@@ -2471,39 +2193,6 @@ class TestKiroAuthManagerSocialLogin:
         assert manager._access_token == "social_access_token"
         assert manager._client_id is None
         assert manager._client_secret is None
-
-    def test_provider_field_preserved_in_social_token(self, temp_sqlite_db_social):
-        """
-        What it does: Verifies provider field is preserved when saving social tokens.
-        Purpose: Ensure metadata like 'provider: google' is not lost.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating KiroAuthManager with social login SQLite...")
-        manager = KiroAuthManager(sqlite_db=temp_sqlite_db_social)
-
-        print("Action: Updating tokens and saving...")
-        manager._access_token = "new_social_token"
-        manager._refresh_token = "new_social_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite to check provider field...")
-        conn = sqlite3.connect(temp_sqlite_db_social)
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        saved_data = json.loads(row[0])
-
-        # Note: provider field is NOT explicitly saved by gateway (it's metadata from kiro-cli)
-        # Gateway only saves: access_token, refresh_token, expires_at, region, scopes
-        # This is acceptable because provider is not needed for token refresh
-        print("Verification: Core token fields saved correctly...")
-        assert saved_data["access_token"] == "new_social_token"
-        assert saved_data["refresh_token"] == "new_social_refresh"
 
 
 # =============================================================================
@@ -2865,888 +2554,6 @@ class TestKiroAuthManagerEnterpriseIDE:
 # =============================================================================
 # Tests for SQLite write-back preserving unknown fields (Issue #131)
 # =============================================================================
-
-
-class TestKiroAuthManagerSqliteWriteBackPreservation:
-    """Tests for _save_credentials_to_sqlite() preserving unknown fields (Issue #131).
-
-    Background: kiro-cli stores additional fields in SQLite (startUrl, provider,
-    registrationExpiresAt for social login). Gateway must preserve these fields
-    when saving refreshed tokens, using Read-Merge-Write strategy.
-    """
-
-    def test_save_preserves_unknown_fields_social_login(self, tmp_path):
-        """
-        What it does: Verifies unknown fields are preserved for social login.
-        Purpose: Ensure startUrl, provider, registrationExpiresAt are not lost (Issue #131 fix).
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with social login + extra fields...")
-        db_file = tmp_path / "data_social_extra.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # Social login with extra fields that kiro-cli uses
-        token_data = {
-            "access_token": "old_social_access",
-            "refresh_token": "old_social_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-            "startUrl": "https://example.awsapps.com/start",
-            "provider": "google",
-            "registrationExpiresAt": "2099-12-31T23:59:59Z",
-            "customField": "custom_value",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating tokens in memory...")
-        manager._access_token = "new_social_access"
-        manager._refresh_token = "new_social_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _save_credentials_to_sqlite()...")
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite to check preserved fields...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        assert row is not None
-        saved_data = json.loads(row[0])
-
-        print("Verification: Tokens updated...")
-        print(f"Comparing access_token: Expected 'new_social_access', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "new_social_access"
-
-        print(f"Comparing refresh_token: Expected 'new_social_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "new_social_refresh"
-
-        print("Verification: Extra fields preserved...")
-        print(f"Comparing startUrl: Expected 'https://example.awsapps.com/start', Got '{saved_data.get('startUrl')}'")
-        assert saved_data.get("startUrl") == "https://example.awsapps.com/start"
-
-        print(f"Comparing provider: Expected 'google', Got '{saved_data.get('provider')}'")
-        assert saved_data.get("provider") == "google"
-
-        print(
-            f"Comparing registrationExpiresAt: Expected '2099-12-31T23:59:59Z', Got '{saved_data.get('registrationExpiresAt')}'"
-        )
-        assert saved_data.get("registrationExpiresAt") == "2099-12-31T23:59:59Z"
-
-        print(f"Comparing customField: Expected 'custom_value', Got '{saved_data.get('customField')}'")
-        assert saved_data.get("customField") == "custom_value"
-
-    def test_save_preserves_unknown_fields_oidc(self, tmp_path):
-        """
-        What it does: Verifies unknown fields are preserved for AWS SSO OIDC.
-        Purpose: Ensure future kiro-cli fields are not lost.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with OIDC + extra fields...")
-        db_file = tmp_path / "data_oidc_extra.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # OIDC with unknown fields
-        token_data = {
-            "access_token": "old_oidc_access",
-            "refresh_token": "old_oidc_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "eu-west-1",
-            "unknownField1": "value1",
-            "unknownField2": "value2",
-        }
-        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(token_data)))
-
-        registration_data = {
-            "client_id": "test_client_id",
-            "client_secret": "test_client_secret",
-            "region": "eu-west-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:device-registration", json.dumps(registration_data)),
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating tokens and saving...")
-        manager._access_token = "new_oidc_access"
-        manager._refresh_token = "new_oidc_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite to check preserved fields...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        saved_data = json.loads(row[0])
-
-        print("Verification: Unknown fields preserved...")
-        print(f"Comparing unknownField1: Expected 'value1', Got '{saved_data.get('unknownField1')}'")
-        assert saved_data.get("unknownField1") == "value1"
-
-        print(f"Comparing unknownField2: Expected 'value2', Got '{saved_data.get('unknownField2')}'")
-        assert saved_data.get("unknownField2") == "value2"
-
-    def test_save_updates_only_our_fields(self, tmp_path):
-        """
-        What it does: Verifies only gateway-managed fields are updated.
-        Purpose: Ensure Read-Merge-Write updates only necessary fields.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with mixed fields...")
-        db_file = tmp_path / "data_mixed.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {
-            "access_token": "old_token",
-            "refresh_token": "old_refresh",
-            "expires_at": "2020-01-01T00:00:00Z",
-            "region": "us-west-2",
-            "customField": "original_value",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating tokens to new values...")
-        manager._access_token = "new_token"
-        manager._refresh_token = "new_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=2)
-        manager._sso_region = "eu-central-1"
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        saved_data = json.loads(row[0])
-
-        print("Verification: Our fields updated...")
-        print(f"Comparing access_token: Expected 'new_token', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "new_token"
-
-        print(f"Comparing refresh_token: Expected 'new_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "new_refresh"
-
-        print(f"Comparing region: Expected 'eu-central-1', Got '{saved_data['region']}'")
-        assert saved_data["region"] == "eu-central-1"
-
-        print("Verification: Custom field unchanged...")
-        print(f"Comparing customField: Expected 'original_value', Got '{saved_data.get('customField')}'")
-        assert saved_data.get("customField") == "original_value"
-
-    def test_save_with_sqlite_readonly_flag(self, tmp_path, monkeypatch):
-        """
-        What it does: Verifies SQLITE_READONLY flag prevents write-back.
-        Purpose: Ensure read-only mode works correctly (Issue #131 feature).
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite database...")
-        db_file = tmp_path / "data_readonly.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {
-            "access_token": "original_access",
-            "refresh_token": "original_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Enabling SQLITE_READONLY flag...")
-        monkeypatch.setattr("kiro.auth.SQLITE_READONLY", True)
-
-        print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating tokens in memory...")
-        manager._access_token = "new_access"
-        manager._refresh_token = "new_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _save_credentials_to_sqlite() with READONLY=True...")
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite to check data NOT changed...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        saved_data = json.loads(row[0])
-
-        print("Verification: Tokens NOT updated (read-only mode)...")
-        print(f"Comparing access_token: Expected 'original_access', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "original_access"
-
-        print(f"Comparing refresh_token: Expected 'original_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "original_refresh"
-
-    def test_save_fallback_when_primary_key_deleted(self, tmp_path):
-        """
-        What it does: Verifies fallback mechanism when primary key is deleted.
-        Purpose: Ensure tokens are saved to alternative key if primary is missing.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with kirocli:social:token...")
-        db_file = tmp_path / "data_fallback.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # Create initial token in social key
-        token_data = {
-            "access_token": "social_access",
-            "refresh_token": "social_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Loading credentials from kirocli:social:token...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Verification: Primary key tracked...")
-        assert manager._sqlite_token_key == "kirocli:social:token"
-
-        print("Action: Deleting primary key and creating alternative key...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        # Delete social token
-        cursor.execute("DELETE FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-
-        # Create alternative key (kirocli:odic:token)
-        odic_data = {
-            "access_token": "odic_access",
-            "refresh_token": "odic_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(odic_data)))
-        conn.commit()
-        conn.close()
-
-        print("Action: Updating tokens and saving...")
-        manager._access_token = "fallback_access"
-        manager._refresh_token = "fallback_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Tokens saved to fallback key (kirocli:odic:token)...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        assert row is not None
-        saved_data = json.loads(row[0])
-
-        print(f"Comparing access_token: Expected 'fallback_access', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "fallback_access"
-
-        print(f"Comparing refresh_token: Expected 'fallback_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "fallback_refresh"
-
-    def test_save_fallback_when_primary_key_is_none(self, tmp_path):
-        """
-        What it does: Verifies fallback when _sqlite_token_key is None.
-        Purpose: Ensure robustness when source key is not tracked.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with kirocli:social:token...")
-        db_file = tmp_path / "data_none_key.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {
-            "access_token": "existing_access",
-            "refresh_token": "existing_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with direct credentials...")
-        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
-
-        print("Action: Manually setting _sqlite_token_key to None...")
-        manager._sqlite_token_key = None
-
-        print("Action: Updating tokens and saving...")
-        manager._access_token = "none_key_access"
-        manager._refresh_token = "none_key_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Fallback found and updated kirocli:social:token...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        assert row is not None
-        saved_data = json.loads(row[0])
-
-        print(f"Comparing access_token: Expected 'none_key_access', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "none_key_access"
-
-        print(f"Comparing refresh_token: Expected 'none_key_refresh', Got '{saved_data['refresh_token']}'")
-        assert saved_data["refresh_token"] == "none_key_refresh"
-
-    def test_save_handles_corrupted_json_gracefully(self, tmp_path):
-        """
-        What it does: Verifies graceful handling of corrupted JSON during save.
-        Purpose: Ensure _try_save_to_key skips corrupted key and fallback is used.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with valid key...")
-        db_file = tmp_path / "data_corrupted.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # Valid JSON in social key (will be loaded)
-        social_data = {
-            "access_token": "social_access",
-            "refresh_token": "social_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(social_data))
-        )
-
-        # Valid JSON in odic key (fallback)
-        odic_data = {
-            "access_token": "odic_access",
-            "refresh_token": "odic_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(odic_data)))
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager (loads from social)...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Verification: Loaded from social key...")
-        assert manager._access_token == "social_access"
-        assert manager._sqlite_token_key == "kirocli:social:token"
-
-        print("Action: Corrupting primary key in database...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("UPDATE auth_kv SET value = ? WHERE key = ?", ("not a valid json {{{", "kirocli:social:token"))
-        conn.commit()
-        conn.close()
-
-        print("Action: Updating tokens and saving (primary key now corrupted)...")
-        manager._access_token = "corrupted_test_access"
-        manager._refresh_token = "corrupted_test_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Tokens saved to fallback key (skipped corrupted primary)...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        assert row is not None
-        saved_data = json.loads(row[0])
-
-        print(f"Comparing access_token: Expected 'corrupted_test_access', Got '{saved_data['access_token']}'")
-        assert saved_data["access_token"] == "corrupted_test_access"
-
-    def test_save_preserves_scopes_when_present(self, tmp_path):
-        """
-        What it does: Verifies scopes field is updated when present.
-        Purpose: Ensure scopes are saved correctly for AWS SSO OIDC.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with scopes...")
-        db_file = tmp_path / "data_scopes.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {
-            "access_token": "old_access",
-            "refresh_token": "old_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-            "scopes": ["old_scope_1", "old_scope_2"],
-        }
-        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(token_data)))
-
-        registration_data = {
-            "client_id": "test_client_id",
-            "client_secret": "test_client_secret",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:device-registration", json.dumps(registration_data)),
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating scopes and saving...")
-        manager._access_token = "new_access"
-        manager._refresh_token = "new_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._scopes = ["new_scope_1", "new_scope_2", "new_scope_3"]
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        saved_data = json.loads(row[0])
-
-        print("Verification: Scopes updated...")
-        print(
-            f"Comparing scopes: Expected ['new_scope_1', 'new_scope_2', 'new_scope_3'], Got {saved_data.get('scopes')}"
-        )
-        assert saved_data.get("scopes") == ["new_scope_1", "new_scope_2", "new_scope_3"]
-
-    def test_save_updates_region_always(self, tmp_path):
-        """
-        What it does: Verifies region field is always updated.
-        Purpose: Ensure region reflects current SSO region.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with old region...")
-        db_file = tmp_path / "data_region.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {
-            "access_token": "access",
-            "refresh_token": "refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Action: Updating region and saving...")
-        manager._access_token = "new_access"
-        manager._refresh_token = "new_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-        manager._sso_region = "eu-west-1"
-        manager._save_credentials_to_sqlite()
-
-        print("Verification: Reading SQLite...")
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-        cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-        row = cursor.fetchone()
-        conn.close()
-
-        saved_data = json.loads(row[0])
-
-        print("Verification: Region updated...")
-        print(f"Comparing region: Expected 'eu-west-1', Got '{saved_data['region']}'")
-        assert saved_data["region"] == "eu-west-1"
-
-    def test_try_save_to_key_returns_false_when_key_not_found(self, tmp_path):
-        """
-        What it does: Verifies _try_save_to_key returns False when key doesn't exist.
-        Purpose: Ensure helper method correctly reports failure.
-        """
-        import sqlite3
-
-        print("Setup: Creating empty SQLite database...")
-        db_file = tmp_path / "data_empty.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-        conn.commit()
-
-        print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
-        manager._access_token = "test_access"
-        manager._refresh_token = "test_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _try_save_to_key with nonexistent key...")
-        result = manager._try_save_to_key(cursor, "nonexistent_key")
-
-        conn.close()
-
-        print("Verification: Returns False...")
-        print(f"Comparing result: Expected False, Got {result}")
-        assert result is False
-
-    def test_try_save_to_key_returns_true_on_success(self, tmp_path):
-        """
-        What it does: Verifies _try_save_to_key returns True on successful save.
-        Purpose: Ensure helper method correctly reports success.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with valid key...")
-        db_file = tmp_path / "data_valid.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        token_data = {
-            "access_token": "old_access",
-            "refresh_token": "old_refresh",
-            "expires_at": "2099-01-01T00:00:00Z",
-            "region": "us-east-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-
-        print("Setup: Creating KiroAuthManager...")
-        manager = KiroAuthManager(refresh_token="test_refresh", sqlite_db=str(db_file))
-        manager._access_token = "new_access"
-        manager._refresh_token = "new_refresh"
-        manager._expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-
-        print("Action: Calling _try_save_to_key with valid key...")
-        result = manager._try_save_to_key(cursor, "kirocli:social:token")
-
-        conn.commit()
-        conn.close()
-
-        print("Verification: Returns True...")
-        print(f"Comparing result: Expected True, Got {result}")
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_save_after_token_refresh_kiro_desktop(self, tmp_path, mock_kiro_token_response):
-        """
-        What it does: Verifies tokens are saved after Kiro Desktop refresh with extra fields preserved.
-        Purpose: Integration test for Issue #131 fix with Kiro Desktop auth.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with social login + extra fields...")
-        db_file = tmp_path / "data_refresh_desktop.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # Social login with extra fields
-        token_data = {
-            "access_token": "old_desktop_access",
-            "refresh_token": "old_desktop_refresh",
-            "expires_at": "2020-01-01T00:00:00Z",
-            "region": "us-east-1",
-            "startUrl": "https://example.awsapps.com/start",
-            "provider": "github",
-            "customField": "must_be_preserved",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:social:token", json.dumps(token_data))
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Setup: Mocking successful Kiro Desktop refresh...")
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.json = Mock(return_value=mock_kiro_token_response())
-        mock_response.raise_for_status = Mock()
-
-        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.post = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_class.return_value = mock_client
-
-            print("Action: Calling _refresh_token_kiro_desktop()...")
-            await manager._refresh_token_kiro_desktop()
-
-            print("Verification: Reading SQLite to check persistence...")
-            conn = sqlite3.connect(str(db_file))
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:social:token",))
-            row = cursor.fetchone()
-            conn.close()
-
-            assert row is not None
-            saved_data = json.loads(row[0])
-
-            print("Verification: New tokens saved...")
-            print(f"Comparing refresh_token: Expected 'new_refresh_token_xyz', Got '{saved_data['refresh_token']}'")
-            assert saved_data["refresh_token"] == "new_refresh_token_xyz"
-
-            print("Verification: Extra fields preserved...")
-            print(
-                f"Comparing startUrl: Expected 'https://example.awsapps.com/start', Got '{saved_data.get('startUrl')}'"
-            )
-            assert saved_data.get("startUrl") == "https://example.awsapps.com/start"
-
-            print(f"Comparing provider: Expected 'github', Got '{saved_data.get('provider')}'")
-            assert saved_data.get("provider") == "github"
-
-            print(f"Comparing customField: Expected 'must_be_preserved', Got '{saved_data.get('customField')}'")
-            assert saved_data.get("customField") == "must_be_preserved"
-
-    @pytest.mark.asyncio
-    async def test_save_after_token_refresh_aws_sso_oidc(self, tmp_path, mock_aws_sso_oidc_token_response):
-        """
-        What it does: Verifies tokens are saved after AWS SSO OIDC refresh with extra fields preserved.
-        Purpose: Integration test for Issue #131 fix with AWS SSO OIDC auth.
-        """
-        import json
-        import sqlite3
-
-        print("Setup: Creating SQLite with OIDC + extra fields...")
-        db_file = tmp_path / "data_refresh_oidc.sqlite3"
-        conn = sqlite3.connect(str(db_file))
-        cursor = conn.cursor()
-
-        cursor.execute("""
-            CREATE TABLE auth_kv (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            )
-        """)
-
-        # OIDC with extra fields
-        token_data = {
-            "access_token": "old_oidc_access",
-            "refresh_token": "old_oidc_refresh",
-            "expires_at": "2020-01-01T00:00:00Z",
-            "region": "eu-west-1",
-            "unknownField1": "value1",
-            "unknownField2": "value2",
-            "futureField": "future_value",
-        }
-        cursor.execute("INSERT INTO auth_kv (key, value) VALUES (?, ?)", ("kirocli:odic:token", json.dumps(token_data)))
-
-        registration_data = {
-            "client_id": "test_client_id",
-            "client_secret": "test_client_secret",
-            "region": "eu-west-1",
-        }
-        cursor.execute(
-            "INSERT INTO auth_kv (key, value) VALUES (?, ?)",
-            ("kirocli:odic:device-registration", json.dumps(registration_data)),
-        )
-        conn.commit()
-        conn.close()
-
-        print("Setup: Creating KiroAuthManager with SQLite...")
-        manager = KiroAuthManager(sqlite_db=str(db_file))
-
-        print("Setup: Mocking successful AWS SSO OIDC refresh...")
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.json = Mock(return_value=mock_aws_sso_oidc_token_response())
-        mock_response.raise_for_status = Mock()
-
-        with patch("kiro.auth.httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client.post = AsyncMock(return_value=mock_response)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=None)
-            mock_client_class.return_value = mock_client
-
-            print("Action: Calling _do_aws_sso_oidc_refresh()...")
-            await manager._do_aws_sso_oidc_refresh()
-
-            print("Verification: Reading SQLite to check persistence...")
-            conn = sqlite3.connect(str(db_file))
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM auth_kv WHERE key = ?", ("kirocli:odic:token",))
-            row = cursor.fetchone()
-            conn.close()
-
-            assert row is not None
-            saved_data = json.loads(row[0])
-
-            print("Verification: New tokens saved...")
-            print(f"Comparing access_token: Expected 'new_aws_sso_access_token', Got '{saved_data['access_token']}'")
-            assert saved_data["access_token"] == "new_aws_sso_access_token"
-
-            print(f"Comparing refresh_token: Expected 'new_aws_sso_refresh_token', Got '{saved_data['refresh_token']}'")
-            assert saved_data["refresh_token"] == "new_aws_sso_refresh_token"
-
-            print("Verification: Extra fields preserved...")
-            print(f"Comparing unknownField1: Expected 'value1', Got '{saved_data.get('unknownField1')}'")
-            assert saved_data.get("unknownField1") == "value1"
-
-            print(f"Comparing unknownField2: Expected 'value2', Got '{saved_data.get('unknownField2')}'")
-            assert saved_data.get("unknownField2") == "value2"
-
-            print(f"Comparing futureField: Expected 'future_value', Got '{saved_data.get('futureField')}'")
-            assert saved_data.get("futureField") == "future_value"
-
-
-# =============================================================================
-# Tests for API Region Auto-Detection from SQLite
-# =============================================================================
-
-
 class TestAPIRegionAutoDetectionSQLite:
     """Tests for automatic API region detection from SQLite profile ARN.
 

--- a/tests/unit/test_dashboard_account_deletion.py
+++ b/tests/unit/test_dashboard_account_deletion.py
@@ -6,16 +6,17 @@ import asyncio
 import importlib
 import json
 import sqlite3
-from contextlib import contextmanager
 from pathlib import Path
-from typing import ContextManager, Iterator, Protocol
+from typing import Iterator, Protocol
 
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 import kiro.dashboard as dashboard_module
+import kiro.store as store
 from kiro.account_manager import AccountManager, account_label
+from kiro.store import connection, load_account_sources, load_runtime_state, replace_account_sources
 
 JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
 Metadata = dict[str, list[tuple[object, ...]]]
@@ -23,9 +24,6 @@ Metadata = dict[str, list[tuple[object, ...]]]
 
 class DashboardModule(Protocol):
     router: APIRouter
-    _sessions: dict[str, float]
-
-    def _db(self) -> ContextManager[sqlite3.Connection]: ...
 
     def initialize_dashboard_store(self) -> None: ...
 
@@ -37,7 +35,6 @@ def dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Dashb
     importlib.reload(dashboard_module)
     dashboard_module.initialize_dashboard_store()
     yield dashboard_module
-    dashboard_module._sessions.clear()
 
 
 def _write_json(path: Path, payload: object) -> None:
@@ -53,6 +50,8 @@ def _manager_for_entries(
     state_file = tmp_path / "state.json"
     _write_json(credentials_file, entries)
     monkeypatch.setenv("ACCOUNTS_CONFIG_FILE", str(credentials_file))
+    with connection() as conn:
+        replace_account_sources(entries, conn)
     manager = AccountManager(str(credentials_file), str(state_file))
     asyncio.run(manager.load_credentials())
     return manager, credentials_file, state_file
@@ -135,9 +134,9 @@ def _metadata(dashboard: DashboardModule) -> Metadata:
 
 
 def _mutation_snapshot(
-    dashboard: DashboardModule, manager: AccountManager, credentials_file: Path
-) -> tuple[JSONValue, tuple[str, ...], Metadata]:
-    return (_parsed(credentials_file), tuple(manager._accounts), _metadata(dashboard))
+    dashboard: DashboardModule, manager: AccountManager
+) -> tuple[object, object, tuple[str, ...], Metadata]:
+    return load_account_sources(), load_runtime_state(), tuple(manager._accounts), _metadata(dashboard)
 
 
 def test_account_listing_requires_dashboard_auth(
@@ -172,7 +171,7 @@ def test_delete_requires_dashboard_session_not_data_plane_bearer(
 ) -> None:
     manager, credentials_file, _, sources = _direct_manager(tmp_path, monkeypatch, ("target", "survivor"))
     target_id = str(sources["target"].resolve())
-    before = _mutation_snapshot(dashboard, manager, credentials_file)
+    before = _mutation_snapshot(dashboard, manager)
 
     with _client(dashboard, manager) as client:
         response = client.delete(
@@ -181,7 +180,7 @@ def test_delete_requires_dashboard_session_not_data_plane_bearer(
         )
 
     assert response.status_code == 401
-    assert _mutation_snapshot(dashboard, manager, credentials_file) == before
+    assert _mutation_snapshot(dashboard, manager) == before
 
 
 def test_metadata_deletion_failure_rolls_back_pool_and_allows_retry(
@@ -194,13 +193,13 @@ def test_metadata_deletion_failure_rolls_back_pool_and_allows_retry(
     asyncio.run(manager._save_state())
     manager._dirty = False
     before = (
-        _parsed(credentials_file),
-        _parsed(state_file),
+        load_account_sources(),
+        load_runtime_state(),
         tuple(manager._accounts),
         manager._dirty,
         _metadata(dashboard),
     )
-    original_db = dashboard._db
+    original_connection = store.connection
 
     class FailingDeleteConnection:
         def __init__(self, conn: sqlite3.Connection):
@@ -211,12 +210,14 @@ def test_metadata_deletion_failure_rolls_back_pool_and_allows_retry(
                 raise sqlite3.OperationalError("injected metadata deletion failure")
             return self._conn.execute(sql, parameters)
 
+    from contextlib import contextmanager
+
     @contextmanager
-    def failing_db() -> Iterator[FailingDeleteConnection]:
-        with original_db() as conn:
+    def failing_connection() -> Iterator[FailingDeleteConnection]:
+        with original_connection() as conn:
             yield FailingDeleteConnection(conn)
 
-    monkeypatch.setattr(dashboard, "_db", failing_db)
+    monkeypatch.setattr(store, "connection", failing_connection)
 
     with _client(dashboard, manager) as client:
         _login(client)
@@ -224,21 +225,21 @@ def test_metadata_deletion_failure_rolls_back_pool_and_allows_retry(
             client.delete(f"/api/dashboard/accounts/{account_label(target_id)}")
 
         assert (
-            _parsed(credentials_file),
-            _parsed(state_file),
+            load_account_sources(),
+            load_runtime_state(),
             tuple(manager._accounts),
             manager._dirty,
             _metadata(dashboard),
         ) == before
 
-        monkeypatch.setattr(dashboard, "_db", original_db)
+        monkeypatch.setattr(store, "connection", original_connection)
         retry = client.delete(f"/api/dashboard/accounts/{account_label(target_id)}")
 
     assert retry.status_code == 200
     assert retry.json() == {"ok": True}
-    assert _parsed(credentials_file) == [{"type": "json", "path": str(sources["survivor"])}]
+    assert load_account_sources() == [{"type": "json", "path": str(sources["survivor"])}]
     assert tuple(manager._accounts) == (survivor_id,)
-    state = _parsed(state_file)
+    state = load_runtime_state()
     assert isinstance(state, dict)
     accounts = state["accounts"]
     assert isinstance(accounts, dict)
@@ -265,7 +266,7 @@ def test_authenticated_delete_returns_only_ok_and_clears_target_metadata(
     assert set(response.json()) == {"ok"}
     assert target_id not in response.text
     assert str(sources["target"]) not in response.text
-    assert _parsed(credentials_file) == [{"type": "json", "path": str(sources["survivor"])}]
+    assert load_account_sources() == [{"type": "json", "path": str(sources["survivor"])}]
     assert tuple(manager._accounts) == (survivor_id,)
     assert sources["target"].is_file()
 
@@ -287,14 +288,14 @@ def test_unknown_or_malformed_label_is_404_without_mutation(
 ) -> None:
     manager, credentials_file, _, sources = _direct_manager(tmp_path, monkeypatch, ("target", "survivor"))
     _seed_metadata(dashboard, str(sources["target"].resolve()), str(sources["survivor"].resolve()))
-    before = _mutation_snapshot(dashboard, manager, credentials_file)
+    before = _mutation_snapshot(dashboard, manager)
 
     with _client(dashboard, manager) as client:
         _login(client)
         response = client.delete(f"/api/dashboard/accounts/{opaque_label}")
 
     assert response.status_code == 404
-    assert _mutation_snapshot(dashboard, manager, credentials_file) == before
+    assert _mutation_snapshot(dashboard, manager) == before
 
 
 def test_repeated_delete_is_404_and_does_not_mutate_survivor(
@@ -308,12 +309,12 @@ def test_repeated_delete_is_404_and_does_not_mutate_survivor(
     with _client(dashboard, manager) as client:
         _login(client)
         first = client.delete(f"/api/dashboard/accounts/{account_label(target_id)}")
-        after_first = _mutation_snapshot(dashboard, manager, credentials_file)
+        after_first = _mutation_snapshot(dashboard, manager)
         second = client.delete(f"/api/dashboard/accounts/{account_label(target_id)}")
 
     assert first.status_code == 200
     assert second.status_code == 404
-    assert _mutation_snapshot(dashboard, manager, credentials_file) == after_first
+    assert _mutation_snapshot(dashboard, manager) == after_first
 
 
 def test_last_direct_account_is_not_deletable_and_delete_is_409_without_mutation(
@@ -322,7 +323,7 @@ def test_last_direct_account_is_not_deletable_and_delete_is_409_without_mutation
     manager, credentials_file, _, sources = _direct_manager(tmp_path, monkeypatch, ("only",))
     only_id = str(sources["only"].resolve())
     _seed_metadata(dashboard, only_id)
-    before = _mutation_snapshot(dashboard, manager, credentials_file)
+    before = _mutation_snapshot(dashboard, manager)
 
     with _client(dashboard, manager) as client:
         _login(client)
@@ -332,7 +333,7 @@ def test_last_direct_account_is_not_deletable_and_delete_is_409_without_mutation
     assert listing.status_code == 200
     assert listing.json()["accounts"][0]["deletable"] is False
     assert response.status_code == 409
-    assert _mutation_snapshot(dashboard, manager, credentials_file) == before
+    assert _mutation_snapshot(dashboard, manager) == before
     assert sources["only"].is_file()
 
 
@@ -356,7 +357,7 @@ def test_directory_scanned_account_is_not_deletable_and_delete_is_409_without_mu
     scanned_id = str(scanned_source.resolve())
     direct_id = str(direct_source.resolve())
     _seed_metadata(dashboard, scanned_id, direct_id)
-    before = _mutation_snapshot(dashboard, manager, credentials_file)
+    before = _mutation_snapshot(dashboard, manager)
 
     with _client(dashboard, manager) as client:
         _login(client)
@@ -368,7 +369,7 @@ def test_directory_scanned_account_is_not_deletable_and_delete_is_409_without_mu
     assert accounts[account_label(scanned_id)]["deletable"] is False
     assert accounts[account_label(direct_id)]["deletable"] is True
     assert response.status_code == 409
-    assert _mutation_snapshot(dashboard, manager, credentials_file) == before
+    assert _mutation_snapshot(dashboard, manager) == before
     assert scanned_source.is_file()
     assert direct_source.is_file()
 

--- a/tests/unit/test_device_login.py
+++ b/tests/unit/test_device_login.py
@@ -8,7 +8,6 @@ milliseconds, and the poll response carries the profileArn directly.
 from __future__ import annotations
 
 import time
-from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -257,14 +256,12 @@ async def test_registering_an_approved_login_adds_the_account(dashboard, tmp_pat
     assert result["initialized"] is True
     assert result["provider"] == "Google"
 
-    entries = __import__("json").loads((tmp_path / "credentials.json").read_text())
-    # The Kiro Desktop endpoint rotates the refresh token and answers 401 "Bad
-    # credentials" for the previous one, so a social login must be stored as a
-    # JSON file that _save_credentials_to_file can write the rotation back to.
-    assert entries[0]["type"] == "json"
-    assert entries[0]["profile_arn"] == APPROVED["profileArn"]
+    from kiro.store import load_account_sources, load_internal_credential
 
-    document = __import__("json").loads(Path(entries[0]["path"]).read_text())
+    entries = load_account_sources()
+    assert entries[0]["type"] == "internal"
+    document = load_internal_credential(entries[0]["id"])
+    assert document is not None
     assert document["refreshToken"] == APPROVED["refreshToken"]
     assert document["accessToken"] == APPROVED["accessToken"]
     assert document["profileArn"] == APPROVED["profileArn"]
@@ -272,30 +269,6 @@ async def test_registering_an_approved_login_adds_the_account(dashboard, tmp_pat
     # refresh endpoint instead of AWS SSO OIDC.
     assert "clientId" not in document
     assert "clientSecret" not in document
-
-
-@pytest.mark.asyncio
-async def test_a_social_account_persists_its_rotated_refresh_token(dashboard, tmp_path):
-    """The rotation must reach disk, or the account dies on the next cold init."""
-    with patch("kiro.device_login.httpx.AsyncClient", return_value=_client(_Response(AUTHORIZATION))):
-        flow = await start_device_login("Google")
-    with patch("kiro.device_login.httpx.AsyncClient", return_value=_client(_Response(APPROVED))):
-        await poll_device_login(flow.id)
-
-    path = device_login.write_social_credentials(flow, tmp_path / "logins")
-
-    from kiro.auth import AuthType, KiroAuthManager
-
-    manager = KiroAuthManager(creds_file=str(path))
-    assert manager.auth_type is AuthType.KIRO_DESKTOP
-
-    manager._refresh_token = "rotated-refresh-token"
-    manager._access_token = "rotated-access-token"
-    manager._save_credentials_to_file()
-
-    document = __import__("json").loads(path.read_text())
-    assert document["refreshToken"] == "rotated-refresh-token"
-    assert document["accessToken"] == "rotated-access-token"
 
 
 @pytest.mark.asyncio
@@ -447,26 +420,6 @@ async def test_builder_id_approval_carries_no_profile_arn():
 
 
 @pytest.mark.asyncio
-async def test_builder_id_credentials_file_carries_the_client_registration(tmp_path):
-    client = _client(_Response(REGISTRATION), _Response(OIDC_AUTHORIZATION))
-    with patch("kiro.device_login.httpx.AsyncClient", return_value=client):
-        flow = await start_device_login("BuilderId")
-    with patch("kiro.device_login.httpx.AsyncClient", return_value=_client(_Response(OIDC_TOKEN))):
-        await poll_device_login(flow.id)
-
-    path = device_login.write_builder_id_credentials(flow, tmp_path / "logins")
-    document = __import__("json").loads(path.read_text())
-
-    # clientId/clientSecret are what make auth.py pick the OIDC refresh endpoint.
-    assert document["clientId"] == "client-id-value"
-    assert document["clientSecret"] == "client-secret-value"
-    assert document["refreshToken"] == OIDC_TOKEN["refreshToken"]
-    assert document["region"] == "us-east-1"
-    assert "profileArn" not in document
-    assert oct(path.stat().st_mode)[-3:] == "600"
-
-
-@pytest.mark.asyncio
 async def test_registering_builder_id_adds_a_json_account(dashboard, tmp_path):
     client = _client(_Response(REGISTRATION), _Response(OIDC_AUTHORIZATION))
     with patch("kiro.device_login.httpx.AsyncClient", return_value=client):
@@ -479,19 +432,15 @@ async def test_registering_builder_id_adds_a_json_account(dashboard, tmp_path):
         result = await dashboard.dashboard_register_device_login(flow.id, request)
 
     assert result["provider"] == "BuilderId"
-    entries = __import__("json").loads((tmp_path / "credentials.json").read_text())
-    assert entries[0]["type"] == "json"
+    from kiro.store import load_account_sources, load_internal_credential
+
+    entries = load_account_sources()
+    assert entries[0]["type"] == "internal"
     assert "profile_arn" not in entries[0]
-
-
-@pytest.mark.asyncio
-async def test_writing_credentials_for_an_unapproved_flow_is_refused(tmp_path):
-    client = _client(_Response(REGISTRATION), _Response(OIDC_AUTHORIZATION))
-    with patch("kiro.device_login.httpx.AsyncClient", return_value=client):
-        flow = await start_device_login("BuilderId")
-
-    with pytest.raises(ValueError):
-        device_login.write_builder_id_credentials(flow, tmp_path / "logins")
+    document = load_internal_credential(entries[0]["id"])
+    assert document is not None
+    assert document["clientSecret"] == "client-secret-value"
+    assert document["refreshToken"] == OIDC_TOKEN["refreshToken"]
 
 
 # =============================================================================

--- a/tests/unit/test_main_lifespan.py
+++ b/tests/unit/test_main_lifespan.py
@@ -16,6 +16,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro.store import load_account_sources
+
 # =============================================================================
 # Test Class: Legacy Fallback (Migration)
 # =============================================================================
@@ -80,14 +82,13 @@ class TestLifespanLegacyFallback:
                 async with lifespan(app):
                     pass
 
-        # Assert: credentials.json was recreated
-        assert creds_file.exists()
-        new_creds = json.loads(creds_file.read_text())
+        # Assert: legacy environment credentials replace the SQLite source only.
+        new_creds = load_account_sources()
         print(f"New credentials.json: {new_creds}")
 
         assert len(new_creds) == 1
-        assert new_creds[0]["type"] == "refresh_token"
-        assert new_creds[0]["refresh_token"] == "test_refresh_token"
+        assert new_creds[0]["type"] == "internal"
+        assert not creds_file.exists() or json.loads(creds_file.read_text()) == old_creds
         print("✓ credentials.json was recreated from .env in legacy mode")
 
     @pytest.mark.asyncio
@@ -135,8 +136,7 @@ class TestLifespanLegacyFallback:
                 async with lifespan(app):
                     pass
 
-        assert creds_file.exists()
-        first_content = creds_file.read_text()
+        first_content = load_account_sources()
         print(f"First run created: {first_content}")
 
         # Modify credentials.json manually
@@ -154,10 +154,10 @@ class TestLifespanLegacyFallback:
                     pass
 
         # Assert: credentials.json was NOT overwritten
-        second_content = json.loads(creds_file.read_text())
+        second_content = load_account_sources()
         print(f"Second run kept: {second_content}")
 
-        assert second_content == manual_creds
+        assert second_content == first_content
         print("✓ credentials.json was not overwritten on second run")
 
     @pytest.mark.asyncio
@@ -223,7 +223,7 @@ class TestLifespanLegacyFallback:
                     pass
 
         # Assert: SQLite was chosen (highest priority)
-        creds = json.loads(creds_file.read_text())
+        creds = load_account_sources()
         print(f"Created credentials: {creds}")
 
         assert len(creds) == 1
@@ -280,7 +280,7 @@ class TestLifespanLegacyFallback:
                     pass
 
         # Assert: overrides were added
-        creds = json.loads(creds_file.read_text())
+        creds = load_account_sources()
         print(f"Created credentials with overrides: {creds}")
 
         assert creds[0]["profile_arn"] == "arn:aws:codewhisperer:eu-central-1:123456789:profile/test"
@@ -949,7 +949,7 @@ class TestLifespanAccountManagerInit:
                 async with lifespan(app):
                     pass
 
-        # Assert: at least 2 saves (initial + final)
+        # Initialization no longer writes unchanged state; shutdown still does.
         print(f"Save calls: {len(save_calls)}")
-        assert len(save_calls) >= 2
+        assert save_calls == ["save"]
         print("✓ Final state save was performed on shutdown")

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -24,6 +24,7 @@ _KEY_ID = "6f1c2d3e4a5b"
 @pytest.fixture
 def dashboard(tmp_path, monkeypatch):
     monkeypatch.setenv("DASHBOARD_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("DASHBOARD_PASSWORD", "dashboard-password")
     module = importlib.reload(importlib.import_module("kiro.dashboard"))
     module.initialize_dashboard_store()
     return module
@@ -550,9 +551,9 @@ class TestEndpoint:
     def test_a_dashboard_cookie_cannot_scrape(self, dashboard, monkeypatch):
         """Control-plane sessions stay out of the metrics plane."""
         client = self._client(dashboard, monkeypatch)
-        token = "session-token"
-        dashboard._sessions[token] = time.time() + 3600
-        client.cookies.set(dashboard._COOKIE, token)
+        login = client.post("/api/dashboard/login", json={"password": "dashboard-password"})
+        assert login.status_code == 200
+        assert dashboard._COOKIE in client.cookies
 
         response = client.get("/metrics")
 

--- a/tests/unit/test_payload_guards.py
+++ b/tests/unit/test_payload_guards.py
@@ -250,22 +250,41 @@ class TestOversizedPayloadWithoutAutoTrim:
         assert str(error.payload_bytes) in str(error)
         assert str(error.limit_bytes) in str(error)
 
-    def test_trims_instead_of_raising_when_trim_enabled(self, monkeypatch):
+    def test_irreducibly_large_current_message_raises_when_trim_enabled(self, monkeypatch):
         import kiro.converters_core as cc
+        from kiro.payload_guards import PayloadTooLargeError
 
         monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", True)
         monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1000)
 
-        result = cc.build_kiro_payload(
-            messages=self._oversized_request(),
-            system_prompt="",
-            model_id="auto",
-            tools=None,
-            conversation_id="conv-oversized",
-            profile_arn=None,
-        )
+        with pytest.raises(PayloadTooLargeError):
+            cc.build_kiro_payload(
+                messages=self._oversized_request(),
+                system_prompt="",
+                model_id="auto",
+                tools=None,
+                conversation_id="conv-oversized",
+                profile_arn=None,
+            )
 
-        assert result.payload["conversationState"]["conversationId"] == "conv-oversized"
+    def test_reducible_history_is_trimmed_successfully(self, monkeypatch):
+        import kiro.converters_core as cc
+
+        monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", True)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1400)
+        messages = [
+            cc.UnifiedMessage(role="user", content="old " + "x" * 2000),
+            cc.UnifiedMessage(role="assistant", content="old answer"),
+            cc.UnifiedMessage(role="user", content="recent question"),
+            cc.UnifiedMessage(role="assistant", content="recent answer"),
+            cc.UnifiedMessage(role="user", content="current"),
+        ]
+        result = cc.build_kiro_payload(messages, "", "auto", None, "conv-trim", None)
+
+        history = result.payload["conversationState"]["history"]
+        assert len(history) == 2
+        assert history[0]["userInputMessage"]["content"] == "recent question"
+        assert result.payload["conversationState"]["currentMessage"]["userInputMessage"]["content"] == "current"
 
     def test_under_limit_payload_is_untouched_when_trim_disabled(self, monkeypatch):
         import kiro.converters_core as cc

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -9,6 +9,7 @@ Tests the following endpoint:
 For OpenAI API tests, see test_routes_openai.py.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1432,6 +1433,29 @@ class TestMessagesFailoverLoop:
 
 class TestMessagesLegacyMode:
     """Tests for legacy mode (ACCOUNT_SYSTEM=false) in /v1/messages endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_uninitialized_account_is_selected_once_without_failover(self):
+        from kiro.models_anthropic import AnthropicMessagesRequest
+        from kiro.routes_anthropic import messages
+
+        account = MagicMock(auth_manager=None)
+        manager = MagicMock()
+        manager._accounts = {"legacy": account}
+        manager.get_first_account.return_value = account
+        request = MagicMock()
+        request.app.state.account_system = False
+        request.app.state.account_manager = manager
+        request_data = AnthropicMessagesRequest(
+            model="claude-sonnet-4-5", max_tokens=64, messages=[{"role": "user", "content": "hi"}], stream=False
+        )
+
+        response = await messages(request, request_data)
+
+        assert response.status_code == 503
+        assert json.loads(response.body)["error"]["message"] == "No initialized accounts available"
+        manager.get_first_account.assert_called_once_with()
+        manager.get_next_account.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_messages_legacy_get_first_account(self):

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -1374,6 +1374,30 @@ class TestChatCompletionsLegacyMode:
     """Tests for legacy mode (ACCOUNT_SYSTEM=false) in /v1/chat/completions."""
 
     @pytest.mark.asyncio
+    async def test_legacy_uninitialized_account_is_selected_once_without_failover(self):
+        from kiro.models_openai import ChatCompletionRequest
+        from kiro.routes_openai import chat_completions
+
+        account = Mock(auth_manager=None)
+        manager = Mock()
+        manager._accounts = {"legacy": account}
+        manager.get_first_account.return_value = account
+        request = Mock()
+        request.app.state.account_system = False
+        request.app.state.account_manager = manager
+        request_data = ChatCompletionRequest(
+            model="claude-sonnet-4-5", messages=[{"role": "user", "content": "hi"}], stream=False
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await chat_completions(request, request_data)
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "No initialized accounts available"
+        manager.get_first_account.assert_called_once_with()
+        manager.get_next_account.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_chat_completions_legacy_get_first_account(self):
         """
         What it does: Verifies legacy mode uses get_first_account().

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -242,32 +242,25 @@ class TestStreamKiroToAnthropic:
     """Tests for stream_kiro_to_anthropic() generator."""
 
     @pytest.mark.asyncio
-    async def test_yields_message_start_event(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_immediate_eof_has_no_clean_terminal_event(self, mock_response, mock_model_cache, mock_auth_manager):
         """
-        What it does: Yields message_start event at beginning.
-        Goal: Verify Anthropic streaming protocol.
+        What it does: Rejects an upstream stream that ends before any event.
+        Goal: Never report immediate EOF as a clean empty response.
         """
-        print("Setup: Mock empty stream...")
 
         async def mock_parse_kiro_stream(*args, **kwargs):
             return
             yield  # Make it a generator
 
-        print("Action: Streaming to Anthropic format...")
         events = []
-
         with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
-            async for event in stream_kiro_to_anthropic(
-                mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
-            ):
-                events.append(event)
+            with pytest.raises(StreamProtocolError, match="before any events"):
+                async for event in stream_kiro_to_anthropic(
+                    mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                ):
+                    events.append(event)
 
-        print(f"Received {len(events)} events")
-
-        # First event should be message_start
-        assert len(events) > 0
-        assert "event: message_start" in events[0]
-        print("✓ message_start event yielded first")
+        assert not any("event: message_stop" in event for event in events)
 
     @pytest.mark.asyncio
     async def test_yields_content_block_start_on_first_content(
@@ -1160,7 +1153,9 @@ class TestStreamingAnthropicErrorHandling:
         print("✓ GeneratorExit propagated correctly")
 
     @pytest.mark.asyncio
-    async def test_yields_error_event_on_exception(self, mock_response, mock_model_cache, mock_auth_manager):
+    async def test_serializer_exception_raises_without_error_event(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
         """
         What it does: Yields error event on exception.
         Goal: Verify error event is sent to client.
@@ -1174,23 +1169,18 @@ class TestStreamingAnthropicErrorHandling:
         print("Action: Streaming to Anthropic format with error...")
         events = []
 
-        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
-            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
-                try:
+        with pytest.raises(RuntimeError, match="Test error"):
+            with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+                with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
                     async for event in stream_kiro_to_anthropic(
                         mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
                     ):
                         events.append(event)
-                except RuntimeError:
-                    pass
 
         print(f"Received {len(events)} events")
 
-        # Should have error event
         error_events = [e for e in events if "event: error" in e]
-        assert len(error_events) >= 1
-        assert "Test error" in error_events[0]
-        print("✓ Error event yielded on exception")
+        assert error_events == []
 
     @pytest.mark.asyncio
     async def test_closes_response_in_finally(self, mock_response, mock_model_cache, mock_auth_manager):

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kiro.sse_validation import StreamProtocolError
 from kiro.streaming_core import KiroEvent
 from kiro.streaming_openai import (
     FirstTokenTimeoutError,
@@ -66,6 +67,24 @@ def mock_response():
 
 class TestStreamKiroToOpenai:
     """Tests for stream_kiro_to_openai() generator."""
+
+    @pytest.mark.asyncio
+    async def test_immediate_eof_has_no_done_marker(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            return
+            yield  # Make it an async generator.
+
+        chunks = []
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with pytest.raises(StreamProtocolError, match="before any events"):
+                async for chunk in stream_kiro_to_openai(
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                ):
+                    chunks.append(chunk)
+
+        assert "data: [DONE]\n\n" not in chunks
 
     @pytest.mark.asyncio
     async def test_yields_content_chunks(self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager):
@@ -966,12 +985,12 @@ class TestStreamingOpenaiErrorHandling:
         print("✓ FirstTokenTimeoutError propagated correctly")
 
     @pytest.mark.asyncio
-    async def test_handles_generator_exit_gracefully(
+    async def test_propagates_generator_exit(
         self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
     ):
         """
-        What it does: Handles GeneratorExit gracefully without re-raising.
-        Goal: Verify client disconnect is handled without error.
+        What it does: Propagates GeneratorExit after cleanup.
+        Goal: Prevent an incomplete stream from being reported as successful.
         """
         print("Setup: Mock stream that raises GeneratorExit...")
 
@@ -980,21 +999,17 @@ class TestStreamingOpenaiErrorHandling:
             raise GeneratorExit()
 
         print("Action: Streaming to OpenAI format with GeneratorExit...")
-        chunks = []
-
         with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
             with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=[]):
-                # GeneratorExit is caught internally and not re-raised
-                # This is correct behavior - client disconnect should be handled gracefully
-                async for chunk in stream_kiro_to_openai(
-                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
-                ):
-                    chunks.append(chunk)
+                with pytest.raises(GeneratorExit):
+                    async for _chunk in stream_kiro_to_openai(
+                        mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                    ):
+                        pass
 
-        print(f"Received {len(chunks)} chunks before disconnect")
         # Response should be closed
-        mock_response.aclose.assert_called()
-        print("✓ GeneratorExit handled gracefully")
+        mock_response.aclose.assert_awaited_once()
+        print("✓ GeneratorExit propagated after cleanup")
 
     @pytest.mark.asyncio
     async def test_propagates_other_exceptions(


### PR DESCRIPTION
## Summary
- consolidate gateway-owned account sources, internal credentials, runtime state, usage, and dashboard metadata in the existing `data/dashboard.sqlite3`
- import `credentials.json`, `state.json`, and deletion recovery data once without modifying or deleting legacy inputs
- keep external JSON and Kiro CLI SQLite credential sources read-only, persisting rotated credentials in gateway-owned overlays
- make account initialization/refresh single-flight and race-safe, delay success reporting until response completion, and reject malformed/empty streams
- deduplicate OpenAI/Anthropic account attempt loops while preserving legacy single-account behavior
- add writer-gated SQLite transactions, credential refresh leases, signed dashboard sessions, durable metrics rollups, and coordinated blue/green handoff

## Migration and compatibility
- reuses the existing `dashboard.sqlite3` filename so API keys, usage, and request history remain visible
- schema changes are additive; legacy JSON remains untouched as a recovery input
- first deployment from the pre-handoff image performs a one-time graceful cutover after the old slot saves its final JSON state
- later deployments quiesce/drain the active slot, flush state, transfer writer ownership, reload the standby, prove readiness, then flip HAProxy
- rollback is supported before handoff; the one-time migration has an explicit forward-only point after credential rotation becomes possible

## Verification
- `python -m pytest -q --tb=short`: 1874 passed
- `ruff format --check --diff . && ruff check .`: passed
- `mypy`: passed
- frontend lint, typecheck, Vitest (66 tests), and production build: passed
- Compose rendering and `bash -n deploy/bluegreen/deploy.sh`: passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves all gateway-owned state to the private SQLite store `dashboard.sqlite3` and hardens account and streaming lifecycles. External credential sources are now read-only, with a safe blue/green writer handoff and durable metrics.

- **New Features**
  - Unified account sources, credentials, runtime state, usage, and dashboard metadata in `dashboard.sqlite3`.
  - One-time import from `credentials.json`, `state.json`, and deletion recovery; legacy files remain as recovery inputs.
  - External JSON/CLI SQLite credentials are read-only; rotated tokens persist in gateway-owned overlays.
  - Account init/refresh made single-flight with leases; failover loop deduplicated while keeping legacy single-account behavior.
  - Streaming lifecycle hardened: delay success until completion; reject immediate EOF or malformed SSE.
  - Signed dashboard sessions and durable request/latency rollups; `/metrics` isolation preserved.
  - Coordinated blue/green handoff with writer-gated SQLite transactions; updated `deploy/bluegreen/deploy.sh`.
  - Compose now mounts `./data` for the unified store and requires a strong `PROXY_API_KEY`.

- **Migration**
  - Reuses existing `dashboard.sqlite3`; schema changes are additive and keep keys, usage, and history intact.
  - First start performs a one-time import and records `gateway-json-v1`; rollback is safe until writer handoff occurs.
  - Blue/green requires `HANDOFF_SECRET`; old slot drains, flushes, transfers writer, then HAProxy flips.
  - Set `PROXY_API_KEY` to a long random value (e.g., `openssl rand -hex 32`) and mount `./data:/app/data`; env validation now fails if missing.

<sup>Written for commit 27d476a59c1ab2711c13258e424eef1abf54561b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

