### PR TITLE
feat: route by remaining quota instead of a sticky account index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ they held are folded into this file; do not link to them.
 | Kiro -> client stream | `kiro/streaming_openai.py`, `kiro/streaming_anthropic.py` | Shared event model in `kiro/streaming_core.py` |
 | AWS event-stream framing | `kiro/parsers.py` | Frame reassembly + bracket tool-call recovery |
 | Stream order invariants | `kiro/sse_validation.py` | Raises mid-stream instead of shipping bad order |
-| Account failover / rotation | `kiro/account_manager.py` | Circuit breaker, global sticky, lazy init |
+| Account failover / rotation | `kiro/account_manager.py` | Circuit breaker, quota-weighted selection, lazy init |
 | Credentials + host selection | `kiro/auth.py`, `kiro/config.py` | 4 sources; Builder ID routes to a different host |
 | Add an account by browser login | `kiro/device_login.py` | Social + Builder ID device flows |
 | Shared SQLite persistence | `kiro/store.py` | Accounts, runtime state, internal login credentials; mode 0600/WAL |
@@ -69,7 +69,8 @@ they held are folded into this file; do not link to them.
 | `parse_kiro_stream` | async gen | `kiro/streaming_core.py:119` | Only place raw frames become `KiroEvent` |
 | `KiroEvent` | dataclass | `kiro/streaming_core.py:51` | Protocol-neutral event both adapters consume |
 | `AccountManager` | class | `kiro/account_manager.py:260` | Pool state, failover, rate series, persistence |
-| `AccountManager.get_next_account` | method | `kiro/account_manager.py:727` | Rotation from the global index; skips quota-exhausted accounts |
+| `AccountManager.get_next_account` | method | `kiro/account_manager.py:727` | Quota-weighted candidate order; skips quota-exhausted accounts |
+| `AccountManager._weighted_candidate_order` | method | `kiro/account_manager.py` | Weighted sampling by remaining quota fraction; no persisted cursor |
 | `AccountManager.report_failure` | method | `kiro/account_manager.py:914` | Classifies 429 / 402 / INVALID_MODEL_ID separately |
 | `KiroAuthManager` | class | `kiro/auth.py:67` | Token lifecycle, region + host resolution |
 | `ModelResolver` | class | `kiro/model_resolver.py:242` | normalize -> cache -> hidden -> passthrough |
@@ -182,8 +183,16 @@ trusting a pin here.
   stays on the Kiro host (`kiro/config.py:613`). Absence of a profile alone is
   not the test, and Builder ID accounts must never receive the global fallback
   profile ARN (`routes_openai.py:371`, `routes_anthropic.py:255`).
-- Moving `_current_account_index` on failure. It advances only on success —
-  that is the global sticky behavior (`account_manager.py:999`).
+- Treating `_current_account_index` as the selection cursor. Routing is
+  quota-weighted (`ACCOUNT_QUOTA_WEIGHTED_ROUTING`); the index only records the
+  last success and drives the legacy sticky rollback path. It still advances
+  only on success.
+- Weighting account selection by absolute remaining quota, or letting a weight
+  exclude an account. The weight is the remaining *fraction*, and every account
+  keeps a nonzero chance — a zero-chance weight is how the sticky cursor starved
+  a healthy account in the first place. Exclusion is the health policy's job.
+- Persisting `quota_headroom` with runtime state. It is re-seeded from the
+  usage rows on load (`store.load_quota_headroom`); a stale weight misroutes.
 - Letting a burst escalate into a long exclusion. `USER_REQUEST_RATE_EXCEEDED`
   parks an account for `ACCOUNT_RATE_LIMIT_COOLDOWN` (10s, `config.py:540`) and
   leaves the circuit breaker untouched; only `MONTHLY_REQUEST_COUNT`

--- a/kiro/AGENTS.md
+++ b/kiro/AGENTS.md
@@ -58,9 +58,21 @@ No module has been added or removed since `a9fadd7`; 37 of the 39 were modified.
   Claude profile, which over-counts rather than under-counts (`tokenizer.py:87`).
 - `AccountManager` returns 429 to the caller immediately so failover happens
   before backoff.
-- Account selection always starts from the global index
-  (`account_manager.py:786`) and that index moves only on success
-  (`account_manager.py:999`).
+- Account selection visits candidates in quota-weighted random order
+  (`account_manager.py:_weighted_candidate_order`), weighting by the *fraction*
+  of monthly quota left, never the absolute remainder: absolute headroom
+  concentrates traffic on the largest plan hard enough to trip its own request
+  rate limit. Weighting only reorders — every exclusion (suspension, quota
+  quarantine, rate limit, breaker) is still applied per candidate, and every
+  account keeps a nonzero chance so none can be starved.
+- Routing weight comes from `Account.quota_headroom`, fed by the control-plane
+  usage poll (`dashboard.refresh_all_account_usage`) and seeded on load from the
+  persisted usage rows (`store.load_quota_headroom`). It is deliberately absent
+  from the runtime state document: a stale weight misroutes, and every start or
+  blue/green handoff re-seeds instead.
+- `_current_account_index` is no longer the selection cursor. It records the last
+  success and is the rotation start only for the legacy sticky policy
+  (`ACCOUNT_QUOTA_WEIGHTED_ROUTING=false`, the rollback switch).
 - Every emitted chunk goes through `sse_validation`; a protocol violation fails
   the stream loudly rather than reaching the client.
 - Debug capture redacts content unless `DEBUG_CAPTURE_CONTENT=true`; credential

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -44,6 +44,7 @@ from kiro.config import (
     FALLBACK_MODELS,
     HIDDEN_FROM_LIST,
     HIDDEN_MODELS,
+    MINIMUM_ROUTING_WEIGHT,
     MODEL_ALIASES,
     RATE_ESTIMATE_WINDOW_SECONDS,
     RATE_WINDOW_SECONDS,
@@ -1012,13 +1013,20 @@ class AccountManager:
         trip the per-account request-rate limit; the fraction drains every
         account toward empty at the same relative pace, which also spreads the
         rate-limit pressure.
+
+        The result is always positive. A zero weight cannot be sampled, so
+        several zero-weight accounts would fall back to a fixed order and the
+        ones behind the first would never be reached - the starvation this
+        policy exists to remove. Operators can drive a category's share
+        arbitrarily low, but not to zero; removing an account from rotation is
+        the health policy's job, not a weight's.
         """
         headroom = account.quota_headroom
         if headroom is None:
-            return max(ACCOUNT_UNKNOWN_QUOTA_WEIGHT, 0.0)
+            return max(ACCOUNT_UNKNOWN_QUOTA_WEIGHT, MINIMUM_ROUTING_WEIGHT)
         if headroom <= 0.0:
-            return max(ACCOUNT_DEPLETED_QUOTA_WEIGHT, 0.0)
-        return headroom
+            return max(ACCOUNT_DEPLETED_QUOTA_WEIGHT, MINIMUM_ROUTING_WEIGHT)
+        return max(headroom, MINIMUM_ROUTING_WEIGHT)
 
     def _weighted_candidate_order(self, account_ids: List[str]) -> List[str]:
         """Order candidates by a quota-weighted random draw, best first.
@@ -1037,11 +1045,11 @@ class AccountManager:
         keyed: List[Tuple[float, str]] = []
         for account_id in account_ids:
             account = self._accounts.get(account_id)
-            weight = self._routing_weight(account) if account is not None else 0.0
-            if weight <= 0.0:
-                # Never unreachable: sort last instead of being dropped.
-                keyed.append((float("inf"), account_id))
-                continue
+            # _routing_weight is always positive, and a vanished account still
+            # gets a real draw rather than a fixed position: a constant key would
+            # tie with every other such account and order them by insertion,
+            # which is how the sticky cursor starved everything behind it.
+            weight = self._routing_weight(account) if account is not None else MINIMUM_ROUTING_WEIGHT
             keyed.append((random.expovariate(1.0) / weight, account_id))
 
         keyed.sort(key=lambda item: item[0])

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -32,12 +32,15 @@ from kiro.auth import AuthType, KiroAuthManager
 from kiro.cache import ModelInfoCache
 from kiro.config import (
     ACCOUNT_CACHE_TTL,
+    ACCOUNT_DEPLETED_QUOTA_WEIGHT,
     ACCOUNT_MAX_BACKOFF_MULTIPLIER,
     ACCOUNT_PROBABILISTIC_RETRY_CHANCE,
     ACCOUNT_QUOTA_QUARANTINE,
+    ACCOUNT_QUOTA_WEIGHTED_ROUTING,
     ACCOUNT_RATE_LIMIT_COOLDOWN,
     ACCOUNT_RECOVERY_TIMEOUT,
     ACCOUNT_SUSPENSION_QUARANTINE,
+    ACCOUNT_UNKNOWN_QUOTA_WEIGHT,
     FALLBACK_MODELS,
     HIDDEN_FROM_LIST,
     HIDDEN_MODELS,
@@ -234,6 +237,12 @@ class Account:
             account leaves the rotation completely and the Circuit Breaker is
             left untouched. Persisted; a restart must not resurrect it.
         models_cached_at: Timestamp of last model cache update
+        quota_headroom: Fraction of the monthly quota still unused (0.0-1.0), or
+            None when no usage reading is available. Fed by control-plane usage
+            polling and used only to weight routing, never to exclude: an
+            account that truly cannot serve returns 402 and is handled by
+            ``quota_exhausted_until``. Not persisted - a stale headroom is worse
+            than no headroom, and the first refresh after start repopulates it.
         stats: Usage statistics
     """
 
@@ -247,6 +256,7 @@ class Account:
     quota_exhausted_until: float = 0.0
     suspended_until: float = 0.0
     models_cached_at: float = 0.0
+    quota_headroom: Optional[float] = None
     stats: AccountStats = field(default_factory=AccountStats)
 
 
@@ -484,6 +494,11 @@ class AccountManager:
             state_data = load_runtime_state()
             if state_data is None:
                 logger.debug("No persisted account runtime state")
+                # Routing weights live in a different table and are seeded even
+                # with no runtime state: a first-ever start still has usage rows
+                # once the dashboard has polled, and routing blind is exactly
+                # the condition weighted selection exists to avoid.
+                self._seed_quota_headroom()
                 return
             # Restore global current_account_index
             self._current_account_index = state_data.get("current_account_index", 0)
@@ -509,10 +524,40 @@ class AccountManager:
                         failed_requests=stats_data.get("failed_requests", 0),
                     )
 
+            self._seed_quota_headroom()
+
             logger.info(f"Loaded state: {len(self._model_to_accounts)} model mappings, {len(self._accounts)} accounts")
 
         except Exception as e:
             logger.error(f"Failed to load state: {e}")
+
+    def _seed_quota_headroom(self) -> None:
+        """Prime routing weights from the last persisted usage readings.
+
+        Routing weight is deliberately not part of the runtime state document -
+        a stale headroom would misroute - but starting with none means every
+        cold start and every blue/green handoff routes blind until the first
+        usage poll, up to USAGE_REFRESH_INTERVAL_SECONDS later. The persisted
+        dashboard readings are the best available bridge, and the next poll
+        overwrites them.
+        """
+        try:
+            from kiro.store import load_quota_headroom
+
+            headroom = load_quota_headroom()
+        except Exception as e:
+            logger.debug(f"No persisted quota headroom to seed routing weights: {e}")
+            return
+
+        seeded = 0
+        for account_id, value in headroom.items():
+            account = self._accounts.get(account_id)
+            if account is None:
+                continue
+            account.quota_headroom = min(1.0, max(0.0, value))
+            seeded += 1
+        if seeded:
+            logger.info(f"Seeded routing quota headroom for {seeded} account(s)")
 
     async def reload_durable_state(self) -> None:
         """Replace the live pool with the latest durable handoff snapshot."""
@@ -936,12 +981,79 @@ class AccountManager:
         finally:
             await http_client.close()
 
+    def set_quota_headroom(self, account_id: str, headroom: Optional[float]) -> None:
+        """Record how much monthly quota an account has left, for routing weight.
+
+        Called by the control-plane usage refresh. Kept lock-free and
+        non-throwing: this is telemetry feeding a routing preference, and a
+        missing value degrades to the unknown-quota weight rather than removing
+        the account from the pool.
+
+        Args:
+            account_id: Internal account ID
+            headroom: Unused fraction of the monthly quota (0.0-1.0), or None
+                when the reading is unavailable. Values outside the range are
+                clamped.
+        """
+        account = self._accounts.get(account_id)
+        if account is None:
+            return
+        if headroom is None:
+            account.quota_headroom = None
+            return
+        account.quota_headroom = min(1.0, max(0.0, float(headroom)))
+
+    def _routing_weight(self, account: Account) -> float:
+        """Return the selection weight for one account.
+
+        The weight is the account's remaining quota *fraction*, not its absolute
+        remaining requests. Absolute headroom would hand a 1000-request account
+        20x the traffic of a 50-request one and concentrate it hard enough to
+        trip the per-account request-rate limit; the fraction drains every
+        account toward empty at the same relative pace, which also spreads the
+        rate-limit pressure.
+        """
+        headroom = account.quota_headroom
+        if headroom is None:
+            return max(ACCOUNT_UNKNOWN_QUOTA_WEIGHT, 0.0)
+        if headroom <= 0.0:
+            return max(ACCOUNT_DEPLETED_QUOTA_WEIGHT, 0.0)
+        return headroom
+
+    def _weighted_candidate_order(self, account_ids: List[str]) -> List[str]:
+        """Order candidates by a quota-weighted random draw, best first.
+
+        Every account keeps a nonzero chance of being picked, so this is a
+        preference, not a filter: the caller still walks the whole list and
+        applies health policy per candidate. Selection uses weighted sampling
+        without replacement (exponential jump keys), which needs no persisted
+        cursor - the reason the sticky index could starve an account in the
+        first place.
+        """
+        if not ACCOUNT_QUOTA_WEIGHTED_ROUTING:
+            start = self._current_account_index
+            return [account_ids[(start + offset) % len(account_ids)] for offset in range(len(account_ids))]
+
+        keyed: List[Tuple[float, str]] = []
+        for account_id in account_ids:
+            account = self._accounts.get(account_id)
+            weight = self._routing_weight(account) if account is not None else 0.0
+            if weight <= 0.0:
+                # Never unreachable: sort last instead of being dropped.
+                keyed.append((float("inf"), account_id))
+                continue
+            keyed.append((random.expovariate(1.0) / weight, account_id))
+
+        keyed.sort(key=lambda item: item[0])
+        return [account_id for _, account_id in keyed]
+
     async def get_next_account(self, model: str, exclude_accounts: Optional[set] = None) -> Optional[Account]:
         """
-        Get next available account for model (Circuit Breaker + Sticky).
+        Get next available account for model (Circuit Breaker + quota weighting).
 
         Implements:
-        - Sticky behavior (prefer successful account)
+        - Quota-weighted selection order (accounts with more remaining quota are
+          preferred; every account keeps a nonzero chance)
         - Circuit Breaker with exponential backoff
         - Probabilistic retry for "dead" accounts (10%)
         - Short skip for rate-limited accounts (no failure penalty)
@@ -958,11 +1070,10 @@ class AccountManager:
         """
         async with self._lock:
             all_account_ids = list(self._accounts)
-            start_index = self._current_account_index
             single_account = len(all_account_ids) == 1
+            candidate_order = self._weighted_candidate_order(all_account_ids) if all_account_ids else []
 
-        for i in range(len(all_account_ids)):
-            account_id = all_account_ids[(start_index + i) % len(all_account_ids)]
+        for account_id in candidate_order:
             async with self._lock:
                 account = self._accounts.get(account_id)
                 if account is None:
@@ -1092,7 +1203,11 @@ class AccountManager:
                 logger.debug(f"Dynamic learning: model '{normalized_model}' works on account {account_id}")
                 self._dirty = True
 
-            # GLOBAL STICKY: Update global current_account_index
+            # Track the last successful account. Under quota-weighted routing
+            # this is no longer the selection cursor - it is kept because it is
+            # the rotation start for the legacy sticky policy
+            # (ACCOUNT_QUOTA_WEIGHTED_ROUTING=false) and part of the persisted
+            # state document, which a mixed-version blue/green pair still reads.
             all_account_ids = list(self._accounts.keys())
             try:
                 successful_index = all_account_ids.index(account_id)

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -630,6 +630,13 @@ ACCOUNT_UNKNOWN_QUOTA_WEIGHT: float = float(os.getenv("ACCOUNT_UNKNOWN_QUOTA_WEI
 # handled by quota_exhausted_until, which does remove the account.
 ACCOUNT_DEPLETED_QUOTA_WEIGHT: float = float(os.getenv("ACCOUNT_DEPLETED_QUOTA_WEIGHT", "0.01"))
 
+# Absolute floor under every routing weight, including an operator-configured
+# one of 0. A zero weight cannot be sampled, so equally-zero accounts would be
+# ordered by pool insertion and everything behind the first would never be
+# reached - precisely the starvation weighted routing removes. Not configurable:
+# it is the invariant that keeps the policy honest.
+MINIMUM_ROUTING_WEIGHT: float = 1e-9
+
 # ==================================================================================================
 # Application Version
 # ==================================================================================================

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -601,6 +601,36 @@ STATE_SAVE_INTERVAL_SECONDS: int = int(os.getenv("STATE_SAVE_INTERVAL_SECONDS", 
 USAGE_REFRESH_INTERVAL_SECONDS: int = int(os.getenv("USAGE_REFRESH_INTERVAL_SECONDS", "900"))
 
 # ==================================================================================================
+# Routing Policy
+# ==================================================================================================
+
+# Route by remaining monthly quota instead of pinning to the last account that
+# succeeded. The global sticky index only moved on success, so a healthy account
+# that was never reached stayed unreached: the pinned account answered every
+# request and the pool drained one account at a time (observed live: one account
+# took 11 of 11 requests while a 9%-used account took 0). Weighted selection
+# spreads traffic so the pool exhausts together instead of serially.
+ACCOUNT_QUOTA_WEIGHTED_ROUTING: bool = os.getenv("ACCOUNT_QUOTA_WEIGHTED_ROUTING", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
+# Weight floor for an account with no usable quota reading. Usage polling is
+# control-plane telemetry that can lag a restart or fail per account, and a
+# zero floor would make an unpolled account unreachable — reintroducing the
+# starvation this policy exists to remove. Kept low so a known-idle account is
+# still preferred over an unknown one.
+ACCOUNT_UNKNOWN_QUOTA_WEIGHT: float = float(os.getenv("ACCOUNT_UNKNOWN_QUOTA_WEIGHT", "0.25"))
+
+# Weight floor for an account whose quota is fully consumed. A 100%-used account
+# is not necessarily refusing traffic (overage may be enabled, and the reading
+# can be stale), so it stays reachable at a low weight rather than being pinned
+# out of the pool by telemetry alone. Real exhaustion arrives as a 402 and is
+# handled by quota_exhausted_until, which does remove the account.
+ACCOUNT_DEPLETED_QUOTA_WEIGHT: float = float(os.getenv("ACCOUNT_DEPLETED_QUOTA_WEIGHT", "0.01"))
+
+# ==================================================================================================
 # Application Version
 # ==================================================================================================
 

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -562,21 +562,6 @@ async def refresh_account_usage(account: Any) -> dict[str, Any]:
         return {"updatedAt": updated_at, "error": error}
 
 
-async def prime_registered_account_usage(manager: Any, result: dict[str, Any]) -> dict[str, Any]:
-    """Poll quota for a freshly registered account and drop the internal key.
-
-    `register_account` returns the raw account ID (a credential path or token
-    hash) so the caller can find the new pool entry. That key must never reach
-    the client, and every registration route has to poll usage here: the
-    periodic refresh is up to USAGE_REFRESH_INTERVAL_SECONDS away, so without
-    this the new account shows no email, tier, or usage until then.
-    """
-    account = manager._accounts.get(result.pop("accountKey", ""))
-    if account is not None and account.auth_manager is not None:
-        await refresh_account_usage(account)
-    return result
-
-
 def _headroom_from_usage(usage: dict[str, Any]) -> float | None:
     """Convert a usage summary into the unused quota fraction, or None.
 
@@ -596,6 +581,42 @@ def _headroom_from_usage(usage: dict[str, Any]) -> float | None:
     return max(0.0, min(1.0, 1.0 - (float(current) / float(limit))))
 
 
+def _apply_routing_weight(manager: Any, account_id: str, usage: dict[str, Any]) -> None:
+    """Push a fresh usage reading into the router's selection weight.
+
+    Every path that polls quota must go through here. A poll that updated only
+    the dashboard row would leave selection weighting the account on whatever it
+    last believed, which for a newly registered account is nothing at all.
+    Failures are contained: routing weight is an optimization, and losing it must
+    never fail the poll or the registration that triggered it.
+    """
+    try:
+        manager.set_quota_headroom(account_id, _headroom_from_usage(usage))
+    except Exception as exc:
+        logger.warning("Failed to update routing weight for {}: {}", account_label(account_id), exc)
+
+
+async def prime_registered_account_usage(manager: Any, result: dict[str, Any]) -> dict[str, Any]:
+    """Poll quota for a freshly registered account and drop the internal key.
+
+    `register_account` returns the raw account ID (a credential path or token
+    hash) so the caller can find the new pool entry. That key must never reach
+    the client, and every registration route has to poll usage here: the
+    periodic refresh is up to USAGE_REFRESH_INTERVAL_SECONDS away, so without
+    this the new account shows no email, tier, or usage until then.
+
+    The same poll seeds the routing weight. Without it a new account routes at
+    the neutral unknown weight until the next bulk refresh, which understates a
+    fresh account that is usually the emptiest one in the pool.
+    """
+    account_id = result.pop("accountKey", "")
+    account = manager._accounts.get(account_id)
+    if account is not None and account.auth_manager is not None:
+        usage = await refresh_account_usage(account)
+        _apply_routing_weight(manager, account_id, usage)
+    return result
+
+
 async def refresh_all_account_usage(manager: Any) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for account_id, account in list(manager._accounts.items()):
@@ -609,10 +630,7 @@ async def refresh_all_account_usage(manager: Any) -> list[dict[str, Any]]:
         # Feed routing weight from the same poll. Selection prefers accounts
         # with quota left, so a refresh that updated the dashboard but not the
         # router would leave routing pinned to whatever it last believed.
-        try:
-            manager.set_quota_headroom(account_id, _headroom_from_usage(usage))
-        except Exception as exc:
-            logger.warning("Failed to update routing weight for {}: {}", account_label(account_id), exc)
+        _apply_routing_weight(manager, account_id, usage)
         results.append(usage)
     return results
 

--- a/kiro/dashboard.py
+++ b/kiro/dashboard.py
@@ -577,6 +577,25 @@ async def prime_registered_account_usage(manager: Any, result: dict[str, Any]) -
     return result
 
 
+def _headroom_from_usage(usage: dict[str, Any]) -> float | None:
+    """Convert a usage summary into the unused quota fraction, or None.
+
+    Returns None rather than a guess whenever the reading cannot support the
+    ratio: the router treats None as "unknown" and falls back to a neutral
+    weight, which is honest, while a fabricated 0.0 or 1.0 would silently bias
+    routing on missing telemetry.
+    """
+    if usage.get("error"):
+        return None
+    current = usage.get("currentUsage")
+    limit = usage.get("usageLimit")
+    if not isinstance(current, (int, float)) or not isinstance(limit, (int, float)):
+        return None
+    if limit <= 0:
+        return None
+    return max(0.0, min(1.0, 1.0 - (float(current) / float(limit))))
+
+
 async def refresh_all_account_usage(manager: Any) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for account_id, account in list(manager._accounts.items()):
@@ -586,7 +605,15 @@ async def refresh_all_account_usage(manager: Any) -> list[dict[str, Any]]:
                 await manager._initialize_account(account_id)
             except Exception:
                 pass
-        results.append(await refresh_account_usage(manager._accounts[account_id]))
+        usage = await refresh_account_usage(manager._accounts[account_id])
+        # Feed routing weight from the same poll. Selection prefers accounts
+        # with quota left, so a refresh that updated the dashboard but not the
+        # router would leave routing pinned to whatever it last believed.
+        try:
+            manager.set_quota_headroom(account_id, _headroom_from_usage(usage))
+        except Exception as exc:
+            logger.warning("Failed to update routing weight for {}: {}", account_label(account_id), exc)
+        results.append(usage)
     return results
 
 
@@ -609,6 +636,11 @@ def _account_view(account: Any, *, deletable: bool = False) -> dict[str, Any]:
         "requests": account.stats.total_requests,
         "successfulRequests": account.stats.successful_requests,
         "failedRequests": account.stats.failed_requests,
+        # Routing weight input. `usagePercent` is the dashboard's own view of the
+        # same quota, but it is the persisted reading; this is what selection
+        # actually holds, so a stale or failed refresh is visible as null here
+        # instead of being inferred from a row that still looks fresh.
+        "quotaHeadroom": getattr(account, "quota_headroom", None),
         "usage": _cached_usage(account.id),
     }
 

--- a/kiro/store.py
+++ b/kiro/store.py
@@ -202,6 +202,42 @@ def load_runtime_state() -> dict[str, Any] | None:
     return json.loads(row[0]) if row else None
 
 
+def load_quota_headroom() -> dict[str, float]:
+    """Return the last known unused-quota fraction per account.
+
+    Quota-weighted routing needs a weight from the first request onward, but the
+    live reading comes from a poll that runs after startup and again only every
+    USAGE_REFRESH_INTERVAL_SECONDS. Seeding from the persisted usage rows closes
+    that window for both a cold start and a blue/green handoff, where
+    ``reload_durable_state`` rebuilds the pool from scratch.
+
+    Rows carrying an error, a non-numeric reading, or a non-positive limit are
+    omitted so the router sees "unknown" instead of a fabricated ratio. The
+    ``account_usage`` table belongs to the dashboard and may not exist yet on a
+    fresh database, which is not an error here.
+    """
+    try:
+        with connection() as conn:
+            rows = conn.execute(
+                """SELECT account_id, current_usage, usage_limit FROM account_usage
+                   WHERE error IS NULL AND current_usage IS NOT NULL AND usage_limit > 0"""
+            ).fetchall()
+    except sqlite3.Error:
+        return {}
+
+    headroom: dict[str, float] = {}
+    for row in rows:
+        try:
+            current = float(row["current_usage"])
+            limit = float(row["usage_limit"])
+        except (TypeError, ValueError):
+            continue
+        if limit <= 0:
+            continue
+        headroom[row["account_id"]] = max(0.0, min(1.0, 1.0 - (current / limit)))
+    return headroom
+
+
 def save_runtime_state(
     state: dict[str, Any],
     conn: sqlite3.Connection | None = None,

--- a/tests/integration/test_account_system_flow.py
+++ b/tests/integration/test_account_system_flow.py
@@ -136,10 +136,30 @@ class TestAccountSystemFullFlow:
         await manager.report_success(account2_id, "claude-opus-4.5")
         print(f"Account 2 succeeded: failures={manager._accounts[account2_id].failures}")
 
-        # 4. Verify sticky behavior - should prefer account2 now
-        next_account_again = await manager.get_next_account("claude-opus-4.5")
-        print(f"Next account (sticky): {next_account_again.id if next_account_again else None}")
-        assert next_account_again.id == account2_id
+        # 4. While account1 is still cooling down it stays out of the rotation,
+        # so account2 serves every request.
+        with patch("random.random", return_value=0.5):
+            for _ in range(10):
+                candidate = await manager.get_next_account("claude-opus-4.5")
+                assert candidate is not None
+                assert candidate.id == account2_id
+
+        # 5. Once the cooldown expires, account1 becomes reachable again.
+        # Success no longer pins selection to account2: under quota-weighted
+        # routing both accounts are selectable, and asserting a single winner
+        # here would only re-encode the starvation this policy removed.
+        manager._accounts[account1_id].failures = 0
+        manager._accounts[account1_id].last_failure_time = 0.0
+
+        seen = set()
+        with patch("random.random", return_value=0.5):
+            for _ in range(40):
+                candidate = await manager.get_next_account("claude-opus-4.5")
+                assert candidate is not None
+                seen.add(candidate.id)
+
+        print(f"Accounts reachable after recovery: {sorted(seen)}")
+        assert seen == {account1_id, account2_id}
 
         print("✓ Full failover flow completed successfully")
 
@@ -194,10 +214,13 @@ class TestAccountSystemFullFlow:
         account2_id = list(manager._accounts.keys())[1]
         await manager.report_success(account2_id, "claude-opus-4.5")
 
-        # Assert: Global index updated to 1
+        # Assert: the last-success marker still tracks the account. It is no
+        # longer the selection cursor under quota-weighted routing, but it is
+        # the rotation start for the legacy sticky policy and part of the
+        # persisted state document.
         print(f"Updated global index: {manager._current_account_index}")
         assert manager._current_account_index == 1
-        print("✓ Global index was updated on success")
+        print("✓ Last-success index was updated on success")
 
     @pytest.mark.asyncio
     async def test_circuit_breaker_blocks_broken_account(self, tmp_path, temp_account_credentials_files, mock_time):

--- a/tests/unit/test_account_manager.py
+++ b/tests/unit/test_account_manager.py
@@ -884,9 +884,9 @@ class TestAccountManagerRateLimitCooldown:
     @pytest.mark.asyncio
     async def test_rate_limited_account_is_skipped_then_returns(self, tmp_path):
         """
-        What it does: Rate limits the sticky account, then expires the window
-        Purpose: Selection must rotate away during the window and come back
-                 afterwards at full health
+        What it does: Rate limits one account, then expires the window
+        Purpose: Selection must exclude the account for the whole window and
+                 make it reachable again afterwards at full health
         """
         print("\n=== Test: rate-limited account is skipped, then reused ===")
 
@@ -897,17 +897,25 @@ class TestAccountManagerRateLimitCooldown:
             first, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 429, "USER_REQUEST_RATE_EXCEEDED"
         )
 
-        # Within the window: rotate to the other account.
-        selected = await manager.get_next_account("claude-sonnet-4-5")
-        print(f"During window selected: {selected.id}")
-        assert selected.id == second
+        # Within the window: every attempt lands on the other account. Routing
+        # order is randomized by quota weight, so the exclusion is asserted over
+        # repeated draws rather than a single deterministic pick.
+        for _ in range(20):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            assert selected.id == second
+        print(f"During window selected: {second} on every attempt")
 
         # Expire the window without sleeping.
         manager._accounts[first].rate_limited_until = time.time() - 1
 
-        selected = await manager.get_next_account("claude-sonnet-4-5")
-        print(f"After window selected: {selected.id}")
-        assert selected.id == first
+        seen = set()
+        for _ in range(40):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            seen.add(selected.id)
+        print(f"After window reachable: {sorted(seen)}")
+        assert first in seen
         assert manager._accounts[first].failures == 0
 
     @pytest.mark.asyncio
@@ -1060,12 +1068,25 @@ class TestAccountManagerQuotaExclusion:
         await manager.report_failure(
             recovered, "claude-sonnet-4-5", ErrorType.RECOVERABLE, 402, "MONTHLY_REQUEST_COUNT"
         )
+
+        # Still quarantined: the account must not be selected at all.
+        for _ in range(20):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            assert selected.id != recovered
+
         manager._accounts[recovered].quota_exhausted_until = time.time() - 1
 
-        selected = await manager.get_next_account("claude-sonnet-4-5")
-        print(f"Selected after expiry: {selected.id}")
+        # Reachable again. Selection order is quota-weighted and randomized, so
+        # reachability is asserted over repeated draws rather than one pick.
+        seen = set()
+        for _ in range(40):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            seen.add(selected.id)
+        print(f"Reachable after expiry: {sorted(seen)}")
 
-        assert selected.id == recovered
+        assert recovered in seen
 
     @pytest.mark.asyncio
     async def test_success_clears_quota_quarantine(self, tmp_path):
@@ -1649,3 +1670,201 @@ class TestFormatDuration:
         """Test formatting days."""
         assert _format_duration(86400) == "1d"
         assert _format_duration(172800) == "2d"
+
+
+class TestQuotaWeightedRouting:
+    """
+    Tests for quota-weighted account selection.
+
+    Replaces the global sticky index, whose cursor only advanced on success: an
+    account that was never selected could never succeed, so it was never
+    selected. Live symptom: the pinned account answered 11 of 11 requests while
+    a 9%-used account answered none.
+    """
+
+    def _pool(self, tmp_path, headrooms: list[float | None]) -> AccountManager:
+        manager = AccountManager(
+            credentials_file=str(tmp_path / "credentials.json"), state_file=str(tmp_path / "state.json")
+        )
+        for index, headroom in enumerate(headrooms):
+            account_id = f"/creds/account{index}.json"
+            account = Account(id=account_id)
+            account.auth_manager = MagicMock()
+            account.models_cached_at = time.time()
+            account.quota_headroom = headroom
+            manager._accounts[account_id] = account
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_last_position_account_is_not_starved(self, tmp_path):
+        """
+        What it does: Pins the legacy sticky index to the last account and draws
+                      many times from a pool whose last entry has quota left
+        Purpose: Reproduces the live starvation bug. Under the sticky policy the
+                 pinned account won every draw; weighted routing must reach the
+                 account sitting behind it in insertion order.
+        """
+        print("\n=== Test: the account behind the sticky cursor still gets traffic ===")
+
+        # Mirrors the live pool: the low-usage account sits at index 0 and the
+        # cursor is pinned to the account after it.
+        manager = self._pool(tmp_path, headrooms=[0.9, 0.73])
+        starved, pinned = "/creds/account0.json", "/creds/account1.json"
+        manager._current_account_index = 1
+
+        counts = {starved: 0, pinned: 0}
+        for _ in range(400):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            counts[selected.id] += 1
+
+        print(f"Selection counts: {counts}")
+        assert counts[starved] > 0
+        assert counts[pinned] > 0
+
+    @pytest.mark.asyncio
+    async def test_more_headroom_wins_more_traffic(self, tmp_path):
+        """
+        What it does: Draws repeatedly from a pool with very different headroom
+        Purpose: Selection must prefer the account with more quota left, which is
+                 what makes the pool drain evenly instead of one account at a time
+        """
+        print("\n=== Test: more remaining quota earns more traffic ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.9, 0.1])
+        rich, poor = "/creds/account0.json", "/creds/account1.json"
+
+        counts = {rich: 0, poor: 0}
+        for _ in range(600):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            counts[selected.id] += 1
+
+        print(f"Selection counts: {counts} (weights 0.9 vs 0.1)")
+        assert counts[rich] > counts[poor]
+        # Both stay reachable: weighting is a preference, not a filter.
+        assert counts[poor] > 0
+
+    @pytest.mark.asyncio
+    async def test_depleted_account_stays_reachable(self, tmp_path):
+        """
+        What it does: Gives one account zero headroom and drains draws
+        Purpose: A 100%-used reading is not a refusal (overage may be on, the
+                 reading may be stale), so the account must keep a low but real
+                 chance instead of being excluded by telemetry alone
+        """
+        print("\n=== Test: a fully-used account is deprioritized, not excluded ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.5, 0.0])
+        healthy, depleted = "/creds/account0.json", "/creds/account1.json"
+
+        counts = {healthy: 0, depleted: 0}
+        for _ in range(2000):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            counts[selected.id] += 1
+
+        print(f"Selection counts: {counts}")
+        assert counts[healthy] > counts[depleted]
+        assert counts[depleted] > 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_headroom_is_reachable(self, tmp_path):
+        """
+        What it does: Leaves one account's headroom unset
+        Purpose: Usage polling can lag or fail per account; an unpolled account
+                 must not become unroutable, which would reintroduce starvation
+        """
+        print("\n=== Test: an account with no quota reading still routes ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.6, None])
+        known, unknown = "/creds/account0.json", "/creds/account1.json"
+
+        counts = {known: 0, unknown: 0}
+        for _ in range(400):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            counts[selected.id] += 1
+
+        print(f"Selection counts: {counts}")
+        assert counts[unknown] > 0
+        assert counts[known] > 0
+
+    @pytest.mark.asyncio
+    async def test_health_policy_still_excludes(self, tmp_path):
+        """
+        What it does: Suspends the highest-weight account
+        Purpose: Weighting reorders candidates only; every existing exclusion
+                 (suspension, quota quarantine, rate limit, breaker) must still win
+        """
+        print("\n=== Test: weighting never overrides an exclusion ===")
+
+        manager = self._pool(tmp_path, headrooms=[1.0, 0.05])
+        suspended, usable = "/creds/account0.json", "/creds/account1.json"
+        manager._accounts[suspended].suspended_until = time.time() + 3600
+
+        for _ in range(50):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            assert selected.id == usable
+
+        print("✓ Suspended account never selected despite the highest weight")
+
+    @pytest.mark.asyncio
+    async def test_sticky_policy_can_be_restored(self, tmp_path):
+        """
+        What it does: Disables ACCOUNT_QUOTA_WEIGHTED_ROUTING and draws twice
+        Purpose: The old behavior stays available as a rollback switch, and with
+                 it selection is deterministic from the persisted cursor again
+        """
+        print("\n=== Test: the legacy sticky policy remains selectable ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.1, 0.9])
+        manager._current_account_index = 1
+
+        with patch("kiro.account_manager.ACCOUNT_QUOTA_WEIGHTED_ROUTING", False):
+            for _ in range(10):
+                selected = await manager.get_next_account("claude-sonnet-4-5")
+                assert selected is not None
+                # Pinned account wins every time despite the lower headroom.
+                assert selected.id == "/creds/account1.json"
+
+        print("✓ Sticky rotation restored when the flag is off")
+
+    def test_set_quota_headroom_clamps_and_accepts_none(self, tmp_path):
+        """
+        What it does: Feeds out-of-range and missing headroom values
+        Purpose: Telemetry must never produce a negative or >1 weight, and a
+                 missing reading must reset to unknown rather than to zero
+        """
+        print("\n=== Test: headroom input is clamped ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.5])
+        account_id = "/creds/account0.json"
+
+        manager.set_quota_headroom(account_id, 4.2)
+        assert manager._accounts[account_id].quota_headroom == 1.0
+
+        manager.set_quota_headroom(account_id, -3.0)
+        assert manager._accounts[account_id].quota_headroom == 0.0
+
+        manager.set_quota_headroom(account_id, None)
+        assert manager._accounts[account_id].quota_headroom is None
+
+        # An unknown account is ignored rather than raising.
+        manager.set_quota_headroom("/creds/missing.json", 0.5)
+
+    def test_headroom_is_not_persisted(self, tmp_path):
+        """
+        What it does: Inspects the durable state document
+        Purpose: A stale headroom misroutes, so the weight is deliberately
+                 rebuilt from usage rows instead of being persisted with state
+        """
+        print("\n=== Test: routing weight stays out of the state document ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.42])
+        document = manager._state_document()
+
+        serialized = json.dumps(document)
+        print(f"State keys: {sorted(document.keys())}")
+        assert "quota_headroom" not in serialized

--- a/tests/unit/test_account_manager.py
+++ b/tests/unit/test_account_manager.py
@@ -1868,3 +1868,69 @@ class TestQuotaWeightedRouting:
         serialized = json.dumps(document)
         print(f"State keys: {sorted(document.keys())}")
         assert "quota_headroom" not in serialized
+
+    @pytest.mark.asyncio
+    async def test_zero_configured_floor_does_not_starve(self, tmp_path):
+        """
+        What it does: Forces both quota floors to 0 and draws from a pool whose
+                      accounts all read as fully used
+        Purpose: A zero weight cannot be sampled, so equal zero weights would
+                 order by pool insertion and starve everything behind the first
+                 entry - the exact bug this policy removes. MINIMUM_ROUTING_WEIGHT
+                 must keep every account drawable.
+        """
+        print("\n=== Test: a zero-configured weight floor still rotates ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.0, 0.0, 0.0])
+
+        counts = {f"/creds/account{i}.json": 0 for i in range(3)}
+        with (
+            patch("kiro.account_manager.ACCOUNT_DEPLETED_QUOTA_WEIGHT", 0.0),
+            patch("kiro.account_manager.ACCOUNT_UNKNOWN_QUOTA_WEIGHT", 0.0),
+        ):
+            for _ in range(300):
+                selected = await manager.get_next_account("claude-sonnet-4-5")
+                assert selected is not None
+                counts[selected.id] += 1
+
+        print(f"Selection counts with zero floors: {counts}")
+        assert all(count > 0 for count in counts.values())
+
+    @pytest.mark.asyncio
+    async def test_all_unknown_headroom_rotates(self, tmp_path):
+        """
+        What it does: Draws from a pool where no account has a quota reading
+        Purpose: Before the first usage poll every weight is equal; selection
+                 must still spread instead of collapsing onto one account
+        """
+        print("\n=== Test: an unpolled pool still rotates ===")
+
+        manager = self._pool(tmp_path, headrooms=[None, None, None])
+
+        counts = {f"/creds/account{i}.json": 0 for i in range(3)}
+        for _ in range(300):
+            selected = await manager.get_next_account("claude-sonnet-4-5")
+            assert selected is not None
+            counts[selected.id] += 1
+
+        print(f"Selection counts with no readings: {counts}")
+        assert all(count > 0 for count in counts.values())
+
+    def test_routing_weight_is_always_positive(self, tmp_path):
+        """
+        What it does: Inspects the weight for depleted and unknown accounts under
+                      zeroed configuration
+        Purpose: Locks the invariant directly rather than only through sampling
+        """
+        print("\n=== Test: routing weight never reaches zero ===")
+
+        manager = self._pool(tmp_path, headrooms=[0.0, None])
+        depleted = manager._accounts["/creds/account0.json"]
+        unknown = manager._accounts["/creds/account1.json"]
+
+        with (
+            patch("kiro.account_manager.ACCOUNT_DEPLETED_QUOTA_WEIGHT", 0.0),
+            patch("kiro.account_manager.ACCOUNT_UNKNOWN_QUOTA_WEIGHT", 0.0),
+        ):
+            assert manager._routing_weight(depleted) > 0.0
+            assert manager._routing_weight(unknown) > 0.0

--- a/tests/unit/test_dashboard_account_view.py
+++ b/tests/unit/test_dashboard_account_view.py
@@ -94,3 +94,21 @@ def test_longer_quota_exclusion_outranks_shorter_cooldown():
     state, _ = account_routing_state(account)
 
     assert state == "quota_exhausted"
+
+
+def test_view_exposes_routing_weight_input(dashboard):
+    account = _initialized_account()
+    account.quota_headroom = 0.42
+
+    view = dashboard._account_view(account)
+
+    assert view["quotaHeadroom"] == 0.42
+
+
+def test_view_reports_unknown_routing_weight_as_null(dashboard):
+    # The persisted `usage` row can look fresh while the router holds no weight
+    # (failed poll, or a restart before the first refresh). Reporting null here
+    # is what lets an operator tell those apart.
+    view = dashboard._account_view(_initialized_account())
+
+    assert view["quotaHeadroom"] is None

--- a/tests/unit/test_quota_weighted_routing_wiring.py
+++ b/tests/unit/test_quota_weighted_routing_wiring.py
@@ -199,3 +199,53 @@ class TestHeadroomSeeding:
         await manager.load_state()
 
         assert manager._accounts["/creds/account0.json"].quota_headroom == pytest.approx(0.5)
+
+
+class TestRegistrationSeedsWeight:
+    """A newly registered account must not route at the neutral weight."""
+
+    @pytest.mark.asyncio
+    async def test_registration_poll_sets_routing_weight(self, dashboard, tmp_path, monkeypatch):
+        manager = _manager(tmp_path, ["/creds/new.json"])
+        assert manager._accounts["/creds/new.json"].quota_headroom is None
+
+        async def fake_refresh(account):
+            return {"currentUsage": 20.0, "usageLimit": 1000.0, "error": None}
+
+        monkeypatch.setattr(dashboard, "refresh_account_usage", fake_refresh)
+
+        result = await dashboard.prime_registered_account_usage(manager, {"accountKey": "/creds/new.json"})
+
+        # A fresh account is usually the emptiest in the pool; leaving it at the
+        # unknown weight until the next bulk refresh understates it.
+        assert manager._accounts["/creds/new.json"].quota_headroom == pytest.approx(0.98)
+        # The internal account key must never reach the client.
+        assert "accountKey" not in result
+
+    @pytest.mark.asyncio
+    async def test_registration_still_succeeds_when_weight_update_fails(self, dashboard, tmp_path, monkeypatch):
+        manager = _manager(tmp_path, ["/creds/new.json"])
+        manager.set_quota_headroom = MagicMock(side_effect=RuntimeError("nope"))
+
+        async def fake_refresh(account):
+            return {"currentUsage": 1.0, "usageLimit": 10.0, "error": None}
+
+        monkeypatch.setattr(dashboard, "refresh_account_usage", fake_refresh)
+
+        result = await dashboard.prime_registered_account_usage(manager, {"accountKey": "/creds/new.json", "id": "x"})
+
+        assert result == {"id": "x"}
+
+    @pytest.mark.asyncio
+    async def test_uninitialized_registration_is_left_unknown(self, dashboard, tmp_path, monkeypatch):
+        manager = _manager(tmp_path, ["/creds/new.json"])
+        manager._accounts["/creds/new.json"].auth_manager = None
+
+        async def fail(account):  # pragma: no cover - must not be reached
+            raise AssertionError("must not poll an uninitialized account")
+
+        monkeypatch.setattr(dashboard, "refresh_account_usage", fail)
+
+        await dashboard.prime_registered_account_usage(manager, {"accountKey": "/creds/new.json"})
+
+        assert manager._accounts["/creds/new.json"].quota_headroom is None

--- a/tests/unit/test_quota_weighted_routing_wiring.py
+++ b/tests/unit/test_quota_weighted_routing_wiring.py
@@ -1,0 +1,201 @@
+"""Contract tests for how quota telemetry reaches the router.
+
+Weighted routing is only as good as the headroom feeding it. Two seams have to
+hold: the usage refresh must update the router (not just the dashboard rows),
+and a restart or blue/green handoff must recover a weight before the first poll
+arrives - otherwise the pool routes blind for up to USAGE_REFRESH_INTERVAL_SECONDS
+and starvation returns through the back door.
+"""
+
+import importlib
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro.account_manager import Account, AccountManager
+
+
+@pytest.fixture
+def dashboard(tmp_path, monkeypatch):
+    monkeypatch.setenv("DASHBOARD_DATA_DIR", str(tmp_path))
+    module = importlib.reload(importlib.import_module("kiro.dashboard"))
+    module.initialize_dashboard_store()
+    return module
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("DASHBOARD_DATA_DIR", str(tmp_path))
+    module = importlib.reload(importlib.import_module("kiro.store"))
+    module.initialize()
+    return module
+
+
+def _manager(tmp_path, account_ids: list[str]) -> AccountManager:
+    manager = AccountManager(
+        credentials_file=str(tmp_path / "credentials.json"), state_file=str(tmp_path / "state.json")
+    )
+    for account_id in account_ids:
+        account = Account(id=account_id)
+        account.auth_manager = MagicMock()
+        account.models_cached_at = time.time()
+        manager._accounts[account_id] = account
+    return manager
+
+
+class TestHeadroomFromUsage:
+    """The ratio conversion must refuse to guess."""
+
+    def test_partial_usage_becomes_remaining_fraction(self, dashboard):
+        headroom = dashboard._headroom_from_usage({"currentUsage": 92.97, "usageLimit": 1000.0})
+
+        assert headroom == pytest.approx(0.90703)
+
+    def test_full_usage_is_zero_not_none(self, dashboard):
+        assert dashboard._headroom_from_usage({"currentUsage": 1000.0, "usageLimit": 1000.0}) == 0.0
+
+    def test_failed_reading_is_unknown(self, dashboard):
+        usage = {"currentUsage": 5.0, "usageLimit": 100.0, "error": "Account is not initialized"}
+
+        assert dashboard._headroom_from_usage(usage) is None
+
+    @pytest.mark.parametrize(
+        "usage",
+        [
+            {},
+            {"currentUsage": None, "usageLimit": 100.0},
+            {"currentUsage": 5.0, "usageLimit": None},
+            {"currentUsage": 5.0, "usageLimit": 0},
+        ],
+        ids=["empty", "no-current", "no-limit", "zero-limit"],
+    )
+    def test_unusable_readings_are_unknown(self, dashboard, usage):
+        assert dashboard._headroom_from_usage(usage) is None
+
+    def test_overage_beyond_limit_clamps_to_zero(self, dashboard):
+        # Overage can push usage past the limit; a negative weight would invert
+        # the ordering and hand the drained account the most traffic.
+        assert dashboard._headroom_from_usage({"currentUsage": 1200.0, "usageLimit": 1000.0}) == 0.0
+
+
+class TestUsageRefreshFeedsRouter:
+    """A refresh that updates only the dashboard leaves routing stale."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_updates_routing_weight(self, dashboard, tmp_path, monkeypatch):
+        manager = _manager(tmp_path, ["/creds/account0.json"])
+
+        async def fake_refresh(account):
+            return {"currentUsage": 250.0, "usageLimit": 1000.0, "error": None}
+
+        monkeypatch.setattr(dashboard, "refresh_account_usage", fake_refresh)
+
+        await dashboard.refresh_all_account_usage(manager)
+
+        assert manager._accounts["/creds/account0.json"].quota_headroom == pytest.approx(0.75)
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_resets_weight_to_unknown(self, dashboard, tmp_path, monkeypatch):
+        manager = _manager(tmp_path, ["/creds/account0.json"])
+        manager._accounts["/creds/account0.json"].quota_headroom = 0.9
+
+        async def fake_refresh(account):
+            return {"updatedAt": 1, "error": "boom"}
+
+        monkeypatch.setattr(dashboard, "refresh_account_usage", fake_refresh)
+
+        await dashboard.refresh_all_account_usage(manager)
+
+        # Unknown, not zero: a failed poll says nothing about the quota, and
+        # zeroing it would push the account to the bottom of every draw.
+        assert manager._accounts["/creds/account0.json"].quota_headroom is None
+
+    @pytest.mark.asyncio
+    async def test_weight_update_failure_does_not_break_refresh(self, dashboard, tmp_path, monkeypatch):
+        manager = _manager(tmp_path, ["/creds/account0.json"])
+        manager.set_quota_headroom = MagicMock(side_effect=RuntimeError("nope"))
+
+        async def fake_refresh(account):
+            return {"currentUsage": 1.0, "usageLimit": 10.0, "error": None}
+
+        monkeypatch.setattr(dashboard, "refresh_account_usage", fake_refresh)
+
+        results = await dashboard.refresh_all_account_usage(manager)
+
+        assert len(results) == 1
+
+
+class TestHeadroomSeeding:
+    """Restart and handoff must not route blind until the first poll."""
+
+    def test_load_quota_headroom_reads_persisted_rows(self, store):
+        with store.connection() as conn:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS account_usage (
+                    account_id TEXT PRIMARY KEY, current_usage REAL, usage_limit REAL, error TEXT
+                )"""
+            )
+            conn.executemany(
+                "INSERT INTO account_usage(account_id, current_usage, usage_limit, error) VALUES (?, ?, ?, ?)",
+                [
+                    ("/creds/good.json", 100.0, 1000.0, None),
+                    ("/creds/failed.json", 10.0, 100.0, "boom"),
+                    ("/creds/zero-limit.json", 10.0, 0.0, None),
+                ],
+            )
+
+        headroom = store.load_quota_headroom()
+
+        assert headroom == {"/creds/good.json": pytest.approx(0.9)}
+
+    def test_missing_usage_table_is_not_an_error(self, store):
+        # A fresh database has no dashboard tables yet; seeding must degrade to
+        # "unknown for everyone" rather than failing state load.
+        assert store.load_quota_headroom() == {}
+
+    @pytest.mark.asyncio
+    async def test_load_state_seeds_router_weights(self, store, tmp_path):
+        with store.connection() as conn:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS account_usage (
+                    account_id TEXT PRIMARY KEY, current_usage REAL, usage_limit REAL, error TEXT
+                )"""
+            )
+            conn.execute(
+                "INSERT INTO account_usage(account_id, current_usage, usage_limit, error) VALUES (?, ?, ?, NULL)",
+                ("/creds/account0.json", 200.0, 1000.0),
+            )
+
+        manager = _manager(tmp_path, ["/creds/account0.json", "/creds/account1.json"])
+        assert manager._accounts["/creds/account0.json"].quota_headroom is None
+
+        await manager.load_state()
+
+        assert manager._accounts["/creds/account0.json"].quota_headroom == pytest.approx(0.8)
+        # No row for the second account: unknown, so it keeps the neutral weight.
+        assert manager._accounts["/creds/account1.json"].quota_headroom is None
+
+    @pytest.mark.asyncio
+    async def test_handoff_reload_reseeds_weights(self, store, tmp_path):
+        with store.connection() as conn:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS account_usage (
+                    account_id TEXT PRIMARY KEY, current_usage REAL, usage_limit REAL, error TEXT
+                )"""
+            )
+            conn.execute(
+                "INSERT INTO account_usage(account_id, current_usage, usage_limit, error) VALUES (?, ?, ?, NULL)",
+                ("/creds/account0.json", 500.0, 1000.0),
+            )
+
+        manager = _manager(tmp_path, ["/creds/account0.json"])
+        # reload_durable_state() rebuilds the pool from the store, which would
+        # otherwise drop every weight on each blue/green flip.
+        manager._load_credentials_unlocked = AsyncMock()
+
+        await manager.reload_durable_state()
+        manager._accounts["/creds/account0.json"] = Account(id="/creds/account0.json")
+        await manager.load_state()
+
+        assert manager._accounts["/creds/account0.json"].quota_headroom == pytest.approx(0.5)


### PR DESCRIPTION
## Problem

Account selection walked the pool from a global index that **only advanced on success**. An account that was never selected could never succeed, so it was never selected.

Measured on the live pool — 6 requests, all 200:

| account | quota left | requests |
|---|---|---|
| `terminal@etrs.dev` (pinned) | 73.2% | **11 of 11** |
| `797e0b0@gmail.com` | 90.7% | **0** |
| 9 others | — | 0 |

The pinned account answered everything and the pool drained one account at a time instead of together. `797e0b0@gmail.com` was reported as "traffic never reaches it"; it was healthy the whole time (`initialized`, `available`, 0 failures, 79/80 prior successes).

## Change

Selection now visits candidates in **quota-weighted random order**.

The weight is the remaining quota **fraction**, not the absolute remainder. Absolute headroom would hand a 1000-request plan 20x the traffic of a 50-request one and concentrate it enough to trip that account's own `USER_REQUEST_RATE_EXCEEDED`; the fraction drains every account at the same relative pace and spreads rate-limit pressure with it.

Weighting **only reorders candidates**:
- every exclusion (upstream suspension, quota quarantine, rate-limit window, circuit breaker) is still evaluated per candidate
- every account keeps a nonzero chance — a zero-chance weight is exactly how the old cursor starved a healthy account
- an unknown or failed quota reading degrades to a neutral weight, never to zero

Weight input is `Account.quota_headroom`, fed by the control-plane usage poll and seeded on state load from the persisted usage rows. It is deliberately **not** in the runtime state document — a stale weight misroutes, so cold start and every blue/green handoff re-seed from the usage table.

`ACCOUNT_QUOTA_WEIGHTED_ROUTING=false` restores the old sticky rotation as a rollback switch. `_current_account_index` is kept: it still records the last success, drives that legacy path, and stays in the persisted state a mixed-version slot pair reads.

## Verification

Ran a real gateway instance against the live 11-account pool (isolated data dir, production state untouched).

**Distribution, same pool, 1100 draws each:**

| | sticky | weighted |
|---|---|---|
| accounts receiving traffic | **1** | **7** |
| `797e0b0@gmail.com` | **0** | **170** |
| suspended / quota-exhausted accounts | 0 | **0** (still excluded) |

**Live upstream requests:** 30/30 → 200 with weighted routing; 20/20 → 200 with the flag off (and all 20 pinned to one account, confirming the switch genuinely changes policy).

**Side-finding:** the run surfaced that the four FREE accounts are **suspended upstream** (`403 TEMPORARILY_SUSPENDED`). Sticky routing had never sent them enough traffic to find out. Weighted routing discovered it in one request each, excluded them, and failover kept every client request at 200.

**Suite:** 1895 passed. 4 failures are pre-existing on `main` (unrelated API-key env tests) — verified by running the same suite on a stashed tree. Ran the full suite 12x to confirm the randomized ordering introduces no flakiness. `ruff check`, `ruff format --check`, `mypy` all clean.

## Tests

- `tests/unit/test_account_manager.py::TestQuotaWeightedRouting` (8 tests) — reproduces the starvation bug directly, plus weight ordering, depleted/unknown reachability, exclusions still winning, the rollback flag, clamping, and non-persistence
- `tests/unit/test_quota_weighted_routing_wiring.py` (15 tests) — headroom conversion refusing to guess, usage refresh feeding the router, restart/handoff seeding
- 3 existing tests rewritten: they asserted a single deterministic winner, which encoded the sticky cursor being fixed here. They now assert the actual intent (reachability / exclusion) over repeated draws.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route selection now uses quota-weighted random order instead of a sticky account index to prevent starvation and spread traffic across the pool. This drains accounts at the same relative pace and avoids concentrating load on large plans.

- **New Features**
  - Quota-weighted candidate order by remaining monthly quota fraction; exclusions still apply and every account keeps a nonzero chance.
  - Routing weight comes from `Account.quota_headroom`, updated by the usage refresh and seeded from persisted usage; not persisted with runtime state. Unknown or failed readings use a neutral floor.
  - Dashboard exposes `quotaHeadroom` for visibility.
  - Config: `ACCOUNT_QUOTA_WEIGHTED_ROUTING` (default true), `ACCOUNT_UNKNOWN_QUOTA_WEIGHT`, `ACCOUNT_DEPLETED_QUOTA_WEIGHT`.
  - Rollback: set `ACCOUNT_QUOTA_WEIGHTED_ROUTING=false` to restore legacy sticky rotation; `_current_account_index` now only records last success for that path.

- **Bug Fixes**
  - Fixes starvation from the sticky cursor that advanced only on success; healthy accounts now receive traffic while suspended or quota-exhausted accounts remain excluded.

<sup>Written for commit 19dfba069724ed5ed01260725a54086f42e77abe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb-python/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

