### PR TITLE
fix: fail over on 400 MONTHLY_REQUEST_COUNT instead of returning error

### DIFF
--- a/kiro/account_errors.py
+++ b/kiro/account_errors.py
@@ -130,6 +130,11 @@ def classify_error(status_code: int, reason: Optional[str]) -> ErrorType:
 
     # 400 errors - depends on reason
     if status_code == 400:
+        # RECOVERABLE: Monthly quota exceeded - try next account
+        # AWS sends 400 (not 402) with reason=MONTHLY_REQUEST_COUNT
+        if reason == "MONTHLY_REQUEST_COUNT":
+            return ErrorType.RECOVERABLE
+
         # RECOVERABLE: Model not available on this account (subscription level)
         # Different accounts may have different model access based on their subscription
         if reason == "INVALID_MODEL_ID":


### PR DESCRIPTION
## Problem

When an account hits its monthly quota, AWS CodeWhisperer returns:

```json
{"__type":"com.amazon.kiro.runtimeservice#ServiceQuotaExceededException","message":"You have reached the limit.","reason":"MONTHLY_REQUEST_COUNT"}
```

This arrives as **HTTP 400** (not 402). `classify_error` only special-cased `INVALID_MODEL_ID` and `CONTENT_LENGTH_EXCEEDS_THRESHOLD` in the 400 branch, so `MONTHLY_REQUEST_COUNT` fell through to the generic `return ErrorType.FATAL`.

Result: the gateway **returned the error to the client** instead of failing over to the next healthy account — even when the pool had accounts with plenty of quota remaining.

This is especially bad with sticky round-robin: the busiest account hits 100% first, and every subsequent request fails until the usage poll marks it `quota_depleted`.

## Fix

Add an explicit `RECOVERABLE` branch for `MONTHLY_REQUEST_COUNT` so the load balancer fails over immediately.

```python
if reason == "MONTHLY_REQUEST_COUNT":
    return ErrorType.RECOVERABLE
```

## Testing

```python
>>> classify_error(400, "MONTHLY_REQUEST_COUNT")
ErrorType.RECOVERABLE   # was FATAL before fix

>>> classify_error(400, "INVALID_MODEL_ID")
ErrorType.RECOVERABLE   # unchanged

>>> classify_error(400, "CONTENT_LENGTH_EXCEEDS_THRESHOLD")
ErrorType.FATAL         # unchanged

>>> classify_error(400, None)
ErrorType.FATAL         # unchanged
```

Verified on live deployment: account at 1000/1000 → next request transparently failed over to a healthy account instead of surfacing a 400.