### PR TITLE
Guard payloads by cl100k tokens, not UTF-8 bytes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,8 @@ DASHBOARD_PASSWORD="replace-with-a-unique-secret"
 # KIRO_SLOT=""        # blue/green only
 
 # Payload guard. Kiro's CONTENT_LENGTH_EXCEEDS_THRESHOLD tracks cl100k tokens
-# of the compact JSON (~195000 pass / ~200000 fail on runtime.kiro.dev,
-# claude-haiku-4.5, 2026-08-23), not UTF-8 bytes. The byte cap is a legacy
-# ASCII-only bisect; it still applies unless set to 0.
-# KIRO_MAX_PAYLOAD_TOKENS=195000
+# of the compact JSON. claude-opus-5: 800000 Hangul pass, 1000000 fail
+# (2026-08-23). The byte cap is a legacy ASCII-only bisect; set 0 to disable.
+# KIRO_MAX_PAYLOAD_TOKENS=800000
 # KIRO_MAX_PAYLOAD_BYTES=1085435
 # AUTO_TRIM_PAYLOAD=false

--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,11 @@ DASHBOARD_PASSWORD="replace-with-a-unique-secret"
 # DEBUG_DIR="debug_logs"
 # HANDOFF_SECRET=""   # blue/green only
 # KIRO_SLOT=""        # blue/green only
+
+# Payload guard. Kiro's CONTENT_LENGTH_EXCEEDS_THRESHOLD tracks cl100k tokens
+# of the compact JSON (~195000 pass / ~200000 fail on runtime.kiro.dev,
+# claude-haiku-4.5, 2026-08-23), not UTF-8 bytes. The byte cap is a legacy
+# ASCII-only bisect; it still applies unless set to 0.
+# KIRO_MAX_PAYLOAD_TOKENS=195000
+# KIRO_MAX_PAYLOAD_BYTES=1085435
+# AUTO_TRIM_PAYLOAD=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,10 +158,11 @@ trusting a pin here.
   converted into a token count, and that conversion already runs.
 - Applying the Claude token-correction coefficient to `prompt_tokens`
   (`kiro/streaming_openai.py:343`) or as a blanket multiplier on Latin text.
-- Measuring the payload guard with `json.dumps` defaults. `check_payload_size`
-  uses `ensure_ascii=False` because that is what the routes send; with escapes a
-  Hangul character measures 6 bytes instead of 3 and Korean conversations were
-  rejected at half the accepted size (`payload_guards.py:52`).
+- Measuring the payload guard as UTF-8 bytes of the JSON. Upstream
+  `CONTENT_LENGTH_EXCEEDS_THRESHOLD` tracks cl100k tokens of the compact JSON
+  (~195k pass / ~200k fail on runtime.kiro.dev, 2026-08-23). A byte cap lets
+  ~250k Hangul syllables through and then fails with no numbers
+  (`payload_guards.py` `check_payload_tokens`).
 - Trusting the advertised context window. `claude-opus-4.7`, `claude-opus-4.8`,
   `claude-opus-5` and `claude-sonnet-5` report 1000000 but charge against 666667;
   `FALLBACK_MODELS` (`config.py:294`) deliberately carries the measured value.
@@ -264,8 +265,9 @@ multi-arch images on non-PR runs. Tool versions are pinned in
   (`converters_openai.py:149`); dropping it makes Kiro answer `REQUEST_BODY_INVALID`.
 - The oversize rejection is `CONTENT_LENGTH_EXCEEDS_THRESHOLD`, which names
   neither the size nor the limit; `PayloadTooLargeError` fails locally instead so
-  both numbers reach the caller. "Improperly formed request" is Kiro's separate
-  catch-all validation error — treat it as a signal to diff the emitted payload.
+  both numbers reach the caller. The unit is cl100k tokens, not bytes.
+  "Improperly formed request" is Kiro's separate catch-all validation error —
+  treat it as a signal to diff the emitted payload.
 - The Docker image bakes the tiktoken vocabularies at build time
   (`TIKTOKEN_CACHE_DIR=/opt/tiktoken-cache`). Without them a network-restricted
   container silently degrades to character-based estimation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,7 @@ trusting a pin here.
   (`kiro/streaming_openai.py:343`) or as a blanket multiplier on Latin text.
 - Measuring the payload guard as UTF-8 bytes of the JSON. Upstream
   `CONTENT_LENGTH_EXCEEDS_THRESHOLD` tracks cl100k tokens of the compact JSON
-  (~195k pass / ~200k fail on runtime.kiro.dev, 2026-08-23). A byte cap lets
-  ~250k Hangul syllables through and then fails with no numbers
+  (claude-opus-5: 800k Hangul pass / 1M fail on runtime.kiro.dev, 2026-08-23).
   (`payload_guards.py` `check_payload_tokens`).
 - Trusting the advertised context window. `claude-opus-4.7`, `claude-opus-4.8`,
   `claude-opus-5` and `claude-sonnet-5` report 1000000 but charge against 666667;

--- a/kiro/AGENTS.md
+++ b/kiro/AGENTS.md
@@ -42,7 +42,7 @@ No module has been added or removed since `a9fadd7`; 37 of the 39 were modified.
 | Adjust finish/stop mapping | `stop_reasons.py` |
 | Token counting | `tokenizer.py` (`resolve_token_profile`), `streaming_core.py:calculate_tokens_from_context_usage` |
 | Model list + per-model limits | `routes_openai.py:203` (`_resolve_model_limits` at `:180`) |
-| Payload size limit | `payload_guards.py`, `config.py:482` (`KIRO_MAX_PAYLOAD_BYTES`) |
+| Payload size limit | `payload_guards.py`, `config.py` (`KIRO_MAX_PAYLOAD_TOKENS`, legacy `KIRO_MAX_PAYLOAD_BYTES`) |
 | Token usage rows (key/account/model) | `usage_tracking.py` -> `dashboard.py` (`flush_key_model_usage`) |
 | Web search emulation | `mcp_tools.py` (transport shim, not a tool framework) |
 | Extended thinking budget rules | `native_thinking.py` (min 1024; unknown fields rejected) |

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -392,14 +392,28 @@ def _warn_timeout_configuration():
 # Payload Size Guard Settings
 # ==================================================================================================
 
-# Payload size limit in bytes. Measured against the live upstream
-# (generateAssistantResponse, claude-haiku-4.5, ASCII history, no tools) by
-# bisecting the reject boundary: 1,085,435 bytes returned 200, and 1,086,459
-# bytes returned 400 CONTENT_LENGTH_EXCEEDS_THRESHOLD. The default is the
-# largest size measured to pass. A later Korean probe pushed 2,070,175 UTF-8
-# bytes through successfully and failed only on the context window, so this
-# threshold is not a plain wire-byte count and the guard is deliberately
-# conservative for multi-byte text.
+# Payload token limit. Measured 2026-08-23 against the live upstream
+# (runtime.us-east-1.kiro.dev / generateAssistantResponse / claude-haiku-4.5,
+# no tools) by bisecting CONTENT_LENGTH_EXCEEDS_THRESHOLD:
+#
+#   Hangul JSON chars   195,000 -> 200 (cl100k tokens ~= 195,000)
+#   Hangul JSON chars   200,000 -> 400
+#   repeated ASCII 'x'  1,550,000 chars (~193,750 cl100k) -> 200
+#   repeated ASCII 'x'  1,575,000 chars (~196,875 cl100k) -> 400
+#   cycling [a-z]       1,550,000 chars -> 400
+#   cycling [a-z]         180,000 chars -> 200
+#
+# The same UTF-8 byte length therefore passes for 'x' and fails for Hangul, so
+# the limit is tokenizer units, not wire bytes and not Unicode scalars. The
+# default is the largest Hangul size measured to pass. Do not apply the Claude
+# CJK slope here: 가 is 1 cl100k token, and the slope would reject that pass.
+KIRO_MAX_PAYLOAD_TOKENS: int = int(os.getenv("KIRO_MAX_PAYLOAD_TOKENS", "195000"))
+
+# Legacy UTF-8 byte cap. Still honored when set so existing deployments do not
+# silently widen. The 1,085,435 default was an ASCII-only bisect (1,085,435
+# pass / 1,086,459 fail on an older host) and lets through ~250k-360k Hangul
+# characters that the upstream then rejects with no numbers. Prefer
+# KIRO_MAX_PAYLOAD_TOKENS. Set KIRO_MAX_PAYLOAD_BYTES=0 to disable this cap.
 KIRO_MAX_PAYLOAD_BYTES: int = int(os.getenv("KIRO_MAX_PAYLOAD_BYTES", "1085435"))
 
 # Auto-trim payload when over limit (default: false - disabled)

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -17,8 +17,6 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-
-
 # ==================================================================================================
 # Server Settings
 # ==================================================================================================
@@ -392,22 +390,16 @@ def _warn_timeout_configuration():
 # Payload Size Guard Settings
 # ==================================================================================================
 
-# Payload token limit. Measured 2026-08-23 against the live upstream
-# (runtime.us-east-1.kiro.dev / generateAssistantResponse / claude-haiku-4.5,
-# no tools) by bisecting CONTENT_LENGTH_EXCEEDS_THRESHOLD:
+# Payload token limit. Measured 2026-08-23 against runtime.us-east-1.kiro.dev
+# / generateAssistantResponse / no tools:
 #
-#   Hangul JSON chars   195,000 -> 200 (cl100k tokens ~= 195,000)
-#   Hangul JSON chars   200,000 -> 400
-#   repeated ASCII 'x'  1,550,000 chars (~193,750 cl100k) -> 200
-#   repeated ASCII 'x'  1,575,000 chars (~196,875 cl100k) -> 400
-#   cycling [a-z]       1,550,000 chars -> 400
-#   cycling [a-z]         180,000 chars -> 200
+#   claude-haiku-4.5 Hangul JSON  195,000 -> 200; 200,000 -> 400
+#   claude-opus-5    Hangul JSON  800,000 -> 200; 1,000,000 -> 400
+#                    CONTENT_LENGTH_EXCEEDS_THRESHOLD
 #
-# The same UTF-8 byte length therefore passes for 'x' and fails for Hangul, so
-# the limit is tokenizer units, not wire bytes and not Unicode scalars. The
-# default is the largest Hangul size measured to pass. Do not apply the Claude
-# CJK slope here: 가 is 1 cl100k token, and the slope would reject that pass.
-KIRO_MAX_PAYLOAD_TOKENS: int = int(os.getenv("KIRO_MAX_PAYLOAD_TOKENS", "195000"))
+# Default is the largest opus-5 size measured to pass. 1,000,000 Hangul is a
+# size-reject. Do not apply the Claude CJK slope: 가 is 1 cl100k token.
+KIRO_MAX_PAYLOAD_TOKENS: int = int(os.getenv("KIRO_MAX_PAYLOAD_TOKENS", "800000"))
 
 # Legacy UTF-8 byte cap. Still honored when set so existing deployments do not
 # silently widen. The 1,085,435 default was an ASCII-only bisect (1,085,435
@@ -439,7 +431,6 @@ WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "false").lower() in (
 # ==================================================================================================
 # Account System Settings
 # ==================================================================================================
-
 
 
 # ==================================================================================================

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -21,9 +21,15 @@ from loguru import logger
 from kiro.config import (
     AUTO_TRIM_PAYLOAD,
     KIRO_MAX_PAYLOAD_BYTES,
+    KIRO_MAX_PAYLOAD_TOKENS,
     TOOL_DESCRIPTION_MAX_LENGTH,
 )
-from kiro.payload_guards import PayloadTooLargeError, check_payload_size, trim_payload_to_limit
+from kiro.payload_guards import (
+    PayloadTooLargeError,
+    check_payload_size,
+    check_payload_tokens,
+    trim_payload_to_limit,
+)
 
 # ==================================================================================================
 # Data Classes for Unified Message Format
@@ -1391,25 +1397,53 @@ def build_kiro_payload(
     if profile_arn:
         payload["profileArn"] = profile_arn
 
-    # Payload size guard. Kiro answers an oversized payload with a cryptic
-    # "Improperly formed request." that names no size, so either trim it or fail
-    # here with the real numbers. Trimming is opt-in because it silently discards
-    # the oldest turns.
+    # Payload size guard. Kiro answers an oversized payload with
+    # CONTENT_LENGTH_EXCEEDS_THRESHOLD, which names no size, so either trim it
+    # or fail here with the real numbers. The upstream counts cl100k tokens of
+    # the JSON, not UTF-8 bytes; the byte cap is a legacy extra. Trimming is
+    # opt-in because it silently discards the oldest turns.
+    payload_tokens = check_payload_tokens(payload)
     payload_size = check_payload_size(payload)
-    if payload_size > KIRO_MAX_PAYLOAD_BYTES:
+    byte_cap = KIRO_MAX_PAYLOAD_BYTES if KIRO_MAX_PAYLOAD_BYTES > 0 else None
+    over_tokens = payload_tokens > KIRO_MAX_PAYLOAD_TOKENS
+    over_bytes = byte_cap is not None and payload_size > byte_cap
+    if over_tokens or over_bytes:
         if AUTO_TRIM_PAYLOAD:
-            stats = trim_payload_to_limit(payload, KIRO_MAX_PAYLOAD_BYTES)
+            stats = trim_payload_to_limit(payload, max_bytes=byte_cap, max_tokens=KIRO_MAX_PAYLOAD_TOKENS)
             logger.info(
                 f"Trimmed conversation history: {stats.original_entries} -> {stats.final_entries} messages "
-                f"({stats.original_bytes} -> {stats.final_bytes} bytes)"
+                f"({stats.original_tokens} -> {stats.final_tokens} tokens, "
+                f"{stats.original_bytes} -> {stats.final_bytes} bytes)"
             )
-            if stats.final_bytes > KIRO_MAX_PAYLOAD_BYTES:
-                raise PayloadTooLargeError(stats.final_bytes, KIRO_MAX_PAYLOAD_BYTES)
+            final_tokens = stats.final_tokens
+            final_bytes = stats.final_bytes
+            if final_tokens > KIRO_MAX_PAYLOAD_TOKENS:
+                raise PayloadTooLargeError(
+                    final_tokens,
+                    KIRO_MAX_PAYLOAD_TOKENS,
+                    unit="tokens",
+                    payload_bytes=final_bytes,
+                )
+            if byte_cap is not None and final_bytes > byte_cap:
+                raise PayloadTooLargeError(final_bytes, byte_cap, unit="bytes", payload_tokens=final_tokens)
+        elif over_tokens:
+            logger.warning(
+                f"Payload {payload_tokens} tokens exceeds the {KIRO_MAX_PAYLOAD_TOKENS} token limit "
+                f"and AUTO_TRIM_PAYLOAD is disabled"
+            )
+            raise PayloadTooLargeError(
+                payload_tokens,
+                KIRO_MAX_PAYLOAD_TOKENS,
+                unit="tokens",
+                payload_bytes=payload_size,
+            )
         else:
             logger.warning(
                 f"Payload {payload_size} bytes exceeds the {KIRO_MAX_PAYLOAD_BYTES} byte limit "
                 f"and AUTO_TRIM_PAYLOAD is disabled"
             )
-            raise PayloadTooLargeError(payload_size, KIRO_MAX_PAYLOAD_BYTES)
+            raise PayloadTooLargeError(
+                payload_size, KIRO_MAX_PAYLOAD_BYTES, unit="bytes", payload_tokens=payload_tokens
+            )
 
     return KiroPayloadResult(payload=payload, tool_documentation=tool_documentation)

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -21,13 +21,13 @@ from loguru import logger
 from kiro.config import (
     AUTO_TRIM_PAYLOAD,
     KIRO_MAX_PAYLOAD_BYTES,
-    KIRO_MAX_PAYLOAD_TOKENS,
     TOOL_DESCRIPTION_MAX_LENGTH,
 )
 from kiro.payload_guards import (
     PayloadTooLargeError,
     check_payload_size,
     check_payload_tokens,
+    payload_token_limit_for_model,
     trim_payload_to_limit,
 )
 
@@ -1404,23 +1404,24 @@ def build_kiro_payload(
     # opt-in because it silently discards the oldest turns.
     payload_tokens = check_payload_tokens(payload)
     payload_size = check_payload_size(payload)
+    token_cap = payload_token_limit_for_model(model_id)
     byte_cap = KIRO_MAX_PAYLOAD_BYTES if KIRO_MAX_PAYLOAD_BYTES > 0 else None
-    over_tokens = payload_tokens > KIRO_MAX_PAYLOAD_TOKENS
+    over_tokens = payload_tokens > token_cap
     over_bytes = byte_cap is not None and payload_size > byte_cap
     if over_tokens or over_bytes:
         if AUTO_TRIM_PAYLOAD:
-            stats = trim_payload_to_limit(payload, max_bytes=byte_cap, max_tokens=KIRO_MAX_PAYLOAD_TOKENS)
+            stats = trim_payload_to_limit(payload, max_bytes=byte_cap, max_tokens=token_cap)
             logger.info(
                 f"Trimmed conversation history: {stats.original_entries} -> {stats.final_entries} messages "
                 f"({stats.original_tokens} -> {stats.final_tokens} tokens, "
-                f"{stats.original_bytes} -> {stats.final_bytes} bytes)"
+                f"{stats.original_bytes} -> {stats.final_bytes} bytes, model={model_id}, cap={token_cap})"
             )
             final_tokens = stats.final_tokens
             final_bytes = stats.final_bytes
-            if final_tokens > KIRO_MAX_PAYLOAD_TOKENS:
+            if final_tokens > token_cap:
                 raise PayloadTooLargeError(
                     final_tokens,
-                    KIRO_MAX_PAYLOAD_TOKENS,
+                    token_cap,
                     unit="tokens",
                     payload_bytes=final_bytes,
                 )
@@ -1428,12 +1429,12 @@ def build_kiro_payload(
                 raise PayloadTooLargeError(final_bytes, byte_cap, unit="bytes", payload_tokens=final_tokens)
         elif over_tokens:
             logger.warning(
-                f"Payload {payload_tokens} tokens exceeds the {KIRO_MAX_PAYLOAD_TOKENS} token limit "
-                f"and AUTO_TRIM_PAYLOAD is disabled"
+                f"Payload {payload_tokens} tokens exceeds the {token_cap} token limit "
+                f"for {model_id} and AUTO_TRIM_PAYLOAD is disabled"
             )
             raise PayloadTooLargeError(
                 payload_tokens,
-                KIRO_MAX_PAYLOAD_TOKENS,
+                token_cap,
                 unit="tokens",
                 payload_bytes=payload_size,
             )

--- a/kiro/payload_guards.py
+++ b/kiro/payload_guards.py
@@ -4,17 +4,17 @@ Payload size guard for Kiro API requests.
 
 The Kiro API rejects oversized payloads with 400
 "Input content length exceeds threshold." (reason:
-CONTENT_LENGTH_EXCEEDS_THRESHOLD). Measured boundary: 1,085,435 bytes pass and
-1,086,459 bytes fail. This module provides:
-- Pre-flight size checking
+CONTENT_LENGTH_EXCEEDS_THRESHOLD). That name is not a wire-byte count: on
+runtime.us-east-1.kiro.dev / generateAssistantResponse / claude-haiku-4.5 the
+reject boundary tracks cl100k tokens of the compact JSON (~195_000 pass,
+~200_000 fail). This module provides:
+- Pre-flight token (and legacy byte) checking
 - Auto-trimming of oldest history entries to fit under the limit
-
-Ported from sametakofficial's payload_guards.py, simplified.
 """
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 @dataclass
@@ -26,6 +26,8 @@ class PayloadTrimStats:
     original_entries: int
     final_entries: int
     trimmed: bool
+    original_tokens: int = 0
+    final_tokens: int = 0
 
 
 class PayloadTooLargeError(Exception):
@@ -38,27 +40,70 @@ class PayloadTooLargeError(Exception):
 
     payload_bytes: int
     limit_bytes: int
+    payload_tokens: int
+    limit_tokens: int
+    unit: str
 
-    def __init__(self, payload_bytes: int, limit_bytes: int) -> None:
-        self.payload_bytes = payload_bytes
-        self.limit_bytes = limit_bytes
+    def __init__(
+        self,
+        payload_size: int,
+        limit: int,
+        *,
+        unit: str = "bytes",
+        payload_bytes: Optional[int] = None,
+        payload_tokens: Optional[int] = None,
+    ) -> None:
+        self.unit = unit
+        if unit == "tokens":
+            self.payload_tokens = payload_size
+            self.limit_tokens = limit
+            self.payload_bytes = payload_bytes or 0
+            self.limit_bytes = 0
+            quantity = "tokens"
+            unit_word = "token"
+        else:
+            self.payload_bytes = payload_size
+            self.limit_bytes = limit
+            self.payload_tokens = payload_tokens or 0
+            self.limit_tokens = 0
+            quantity = "bytes"
+            unit_word = "byte"
         super().__init__(
-            f"Request payload is {payload_bytes} bytes, over the {limit_bytes} byte limit Kiro accepts. "
+            f"Request payload is {payload_size} {quantity}, over the {limit} {unit_word} limit Kiro accepts. "
             f"Shorten the conversation or send fewer tools. Set AUTO_TRIM_PAYLOAD=true to drop the "
             f"oldest history instead (this silently loses earlier context)."
         )
 
 
-def check_payload_size(payload: Dict[str, Any]) -> int:
-    """Return the serialized byte size of the payload as UTF-8 JSON.
+def _payload_json(payload: Dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
-    ensure_ascii=False matches how the routes actually serialize the upstream
-    body (routes_openai.py, routes_anthropic.py). With the default True, a Hangul
-    character measures as the 6 bytes of a \\uXXXX escape instead of the 3 bytes
-    UTF-8 puts on the wire, so a Korean conversation was rejected at roughly half
-    the size Kiro accepts.
+
+def check_payload_size(payload: Dict[str, Any]) -> int:
+    """Return the serialized UTF-8 byte size of the compact JSON payload.
+
+    ensure_ascii=False matches the decoded Unicode the upstream tokenizer sees
+    after JSON parse. The default True would count a Hangul syllable as the 6
+    bytes of a \\uXXXX escape instead of one cl100k token.
     """
-    return len(json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    return len(_payload_json(payload).encode("utf-8"))
+
+
+def check_payload_tokens(payload: Dict[str, Any]) -> int:
+    """Return cl100k tokens of the compact JSON, without the CJK slope correction.
+
+    Measured 2026-08-23 against runtime.us-east-1.kiro.dev generateAssistantResponse
+    (claude-haiku-4.5, no tools): a Hangul JSON of 195_000 chars returned 200, and
+    200_000 chars returned 400 CONTENT_LENGTH_EXCEEDS_THRESHOLD. Repeated ASCII
+    ``x`` passed at 1_550_000 chars (~193_750 cl100k tokens) and failed at
+    1_575_000 (~196_875). Cycling ``abcdefghijklmnopqrstuvwxyz`` of 1_550_000
+    chars failed, so the limit is tokenizer units, not wire bytes or Unicode
+    scalars. The Claude CJK slope (1.15) is a local estimator for usage display
+    and must not be applied here: it would reject the Hangul payload that passed.
+    """
+    from kiro.tokenizer import count_tokens
+
+    return count_tokens(_payload_json(payload), apply_claude_correction=False, model="claude-haiku-4.5")
 
 
 def _strip_empty_tool_uses(history: list) -> None:
@@ -131,14 +176,27 @@ def _repair_orphaned_tool_results(history: list) -> None:
                 user_msg["content"] = current_content + marker
 
 
-def trim_payload_to_limit(payload: Dict[str, Any], max_bytes: int) -> PayloadTrimStats:
+def _over_limit(payload: Dict[str, Any], max_bytes: Optional[int], max_tokens: Optional[int]) -> bool:
+    if max_tokens is not None and check_payload_tokens(payload) > max_tokens:
+        return True
+    if max_bytes is not None and check_payload_size(payload) > max_bytes:
+        return True
+    return False
+
+
+def trim_payload_to_limit(
+    payload: Dict[str, Any],
+    max_bytes: Optional[int] = None,
+    max_tokens: Optional[int] = None,
+) -> PayloadTrimStats:
     """
-    Trim oldest history entries so the serialized payload fits under max_bytes.
+    Trim oldest history entries so the payload fits under max_tokens and/or max_bytes.
 
     Trims in user/assistant pairs (2 entries at a time), aligns start to
     userInputMessage, and repairs orphaned toolResults after trimming.
     """
     original_bytes = check_payload_size(payload)
+    original_tokens = check_payload_tokens(payload)
     history = payload.get("conversationState", {}).get("history")
 
     if not history:
@@ -148,6 +206,8 @@ def trim_payload_to_limit(payload: Dict[str, Any], max_bytes: int) -> PayloadTri
             original_entries=0,
             final_entries=0,
             trimmed=False,
+            original_tokens=original_tokens,
+            final_tokens=original_tokens,
         )
 
     original_entries = len(history)
@@ -156,7 +216,7 @@ def trim_payload_to_limit(payload: Dict[str, Any], max_bytes: int) -> PayloadTri
     _strip_empty_tool_uses(history)
 
     # Trim pairs from the beginning until under limit (keep at least 2 entries)
-    while len(history) > 2 and check_payload_size(payload) > max_bytes:
+    while len(history) > 2 and _over_limit(payload, max_bytes, max_tokens):
         # Remove 2 entries (a user/assistant pair)
         history.pop(0)
         history.pop(0)
@@ -168,10 +228,13 @@ def trim_payload_to_limit(payload: Dict[str, Any], max_bytes: int) -> PayloadTri
     _repair_orphaned_tool_results(history)
 
     final_bytes = check_payload_size(payload)
+    final_tokens = check_payload_tokens(payload)
     return PayloadTrimStats(
         original_bytes=original_bytes,
         final_bytes=final_bytes,
         original_entries=original_entries,
         final_entries=len(history),
         trimmed=original_entries != len(history),
+        original_tokens=original_tokens,
+        final_tokens=final_tokens,
     )

--- a/kiro/payload_guards.py
+++ b/kiro/payload_guards.py
@@ -5,9 +5,9 @@ Payload size guard for Kiro API requests.
 The Kiro API rejects oversized payloads with 400
 "Input content length exceeds threshold." (reason:
 CONTENT_LENGTH_EXCEEDS_THRESHOLD). That name is not a wire-byte count: on
-runtime.us-east-1.kiro.dev / generateAssistantResponse / claude-haiku-4.5 the
-reject boundary tracks cl100k tokens of the compact JSON (~195_000 pass,
-~200_000 fail). This module provides:
+runtime.us-east-1.kiro.dev / generateAssistantResponse the reject boundary
+tracks cl100k tokens of the compact JSON. claude-opus-5: 800_000 Hangul
+pass, 1_000_000 fail. This module provides:
 - Pre-flight token (and legacy byte) checking
 - Auto-trimming of oldest history entries to fit under the limit
 """
@@ -87,6 +87,18 @@ def check_payload_size(payload: Dict[str, Any]) -> int:
     bytes of a \\uXXXX escape instead of one cl100k token.
     """
     return len(_payload_json(payload).encode("utf-8"))
+
+
+def payload_token_limit_for_model(model_id: str) -> int:
+    """Return the pre-flight token cap.
+
+    Single default: 800_000, the largest claude-opus-5 Hangul JSON measured to
+    pass (1_000_000 returned CONTENT_LENGTH_EXCEEDS_THRESHOLD). Override with
+    KIRO_MAX_PAYLOAD_TOKENS.
+    """
+    from kiro.config import KIRO_MAX_PAYLOAD_TOKENS
+
+    return KIRO_MAX_PAYLOAD_TOKENS
 
 
 def check_payload_tokens(payload: Dict[str, Any]) -> int:

--- a/tests/unit/test_payload_guards.py
+++ b/tests/unit/test_payload_guards.py
@@ -11,6 +11,7 @@ import pytest
 
 from kiro.payload_guards import (
     check_payload_size,
+    check_payload_tokens,
     trim_payload_to_limit,
 )
 
@@ -351,3 +352,121 @@ class TestOversizedPayloadReturns400:
 
         assert response.status_code == 400, response.text
         assert "AUTO_TRIM_PAYLOAD" in response.text
+
+
+class TestTokenUnitMatchesUpstream:
+    """CONTENT_LENGTH_EXCEEDS_THRESHOLD tracks tokenizer units, not UTF-8 bytes.
+
+    Measured 2026-08-23 on runtime.us-east-1.kiro.dev / generateAssistantResponse
+    / claude-haiku-4.5 (no tools). Hangul JSON of 195_000 chars returned 200;
+    200_000 chars returned 400. Repeated ASCII 'x' passed at 1_550_000 chars
+    (~193_750 cl100k tokens) and failed at 1_575_000. Cycling latin of
+    1_550_000 chars failed, so the unit is not wire bytes or Unicode scalars.
+    """
+
+    def test_hangul_is_one_cl100k_token_per_syllable(self):
+        payload = {"content": "가" * 1000}
+        assert check_payload_tokens(payload) >= 1000
+        # UTF-8 bytes are ~3x; the old guard used that and let 250k Hangul
+        # through (~750 KiB) only for upstream to 400 with no numbers.
+        assert check_payload_size(payload) > check_payload_tokens(payload)
+
+    def test_repeated_ascii_compresses_in_cl100k(self):
+        payload = {"content": "x" * 8000}
+        # cl100k encodes long runs of 'x' at 8 chars/token.
+        assert check_payload_tokens(payload) == pytest.approx(1000, abs=50)
+
+    def test_astral_emoji_is_two_cl100k_tokens(self):
+        payload = {"content": "😀" * 100}
+        assert check_payload_tokens(payload) == pytest.approx(200, abs=20)
+
+
+class TestKoreanUnderOldByteCapIsRejectedByTokens:
+    """The regression this change exists to prevent.
+
+    250k Hangul is ~750 KiB UTF-8, under KIRO_MAX_PAYLOAD_BYTES=1085435, so
+    today's byte guard sends it and Kiro answers CONTENT_LENGTH_EXCEEDS_THRESHOLD.
+    A token cap of 195000 must refuse it locally with the count in the message.
+    """
+
+    def test_korean_over_token_limit_raises_under_legacy_byte_cap(self, monkeypatch):
+        import kiro.converters_core as cc
+        from kiro.converters_core import UnifiedMessage
+        from kiro.payload_guards import PayloadTooLargeError
+
+        monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_TOKENS", 195000)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1085435)
+
+        with pytest.raises(PayloadTooLargeError) as exc_info:
+            cc.build_kiro_payload(
+                messages=[UnifiedMessage(role="user", content="가" * 250000)],
+                system_prompt="",
+                model_id="auto",
+                tools=None,
+                conversation_id="conv-korean-over-tokens",
+                profile_arn=None,
+            )
+
+        error = exc_info.value
+        assert "token" in str(error).lower()
+        assert "195000" in str(error)
+        assert error.limit_tokens == 195000
+        assert error.payload_tokens > 195000
+
+    def test_korean_under_token_limit_does_not_raise(self, monkeypatch):
+        import kiro.converters_core as cc
+        from kiro.converters_core import UnifiedMessage
+
+        monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_TOKENS", 195000)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1085435)
+
+        result = cc.build_kiro_payload(
+            messages=[UnifiedMessage(role="user", content="가" * 1000)],
+            system_prompt="",
+            model_id="auto",
+            tools=None,
+            conversation_id="conv-korean-under-tokens",
+            profile_arn=None,
+        )
+        assert "가" * 1000 in result.payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+
+    def test_trim_uses_tokens_for_hangul_history(self):
+        history = []
+        for i in range(10):
+            history.append({"userInputMessage": {"content": "가" * 40000}})
+            history.append({"assistantResponseMessage": {"content": "나" * 1000}})
+        payload = {
+            "conversationState": {
+                "chatTriggerType": "MANUAL",
+                "conversationId": "test-conv",
+                "currentMessage": {"userInputMessage": {"content": "현재", "modelId": "test"}},
+                "history": history,
+            }
+        }
+        stats = trim_payload_to_limit(payload, max_tokens=195000)
+        assert stats.trimmed
+        assert stats.final_tokens <= 195000
+        assert "userInputMessage" in payload["conversationState"]["history"][0]
+
+    def test_legacy_byte_cap_still_honored(self, monkeypatch):
+        import kiro.converters_core as cc
+        from kiro.converters_core import UnifiedMessage
+        from kiro.payload_guards import PayloadTooLargeError
+
+        monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_TOKENS", 1_000_000)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1000)
+
+        with pytest.raises(PayloadTooLargeError) as exc_info:
+            cc.build_kiro_payload(
+                messages=[UnifiedMessage(role="user", content="x" * 5000)],
+                system_prompt="",
+                model_id="auto",
+                tools=None,
+                conversation_id="conv-legacy-bytes",
+                profile_arn=None,
+            )
+        assert exc_info.value.limit_bytes == 1000
+        assert "byte" in str(exc_info.value).lower()

--- a/tests/unit/test_payload_guards.py
+++ b/tests/unit/test_payload_guards.py
@@ -12,6 +12,7 @@ import pytest
 from kiro.payload_guards import (
     check_payload_size,
     check_payload_tokens,
+    payload_token_limit_for_model,
     trim_payload_to_limit,
 )
 
@@ -382,27 +383,21 @@ class TestTokenUnitMatchesUpstream:
 
 
 class TestKoreanUnderOldByteCapIsRejectedByTokens:
-    """The regression this change exists to prevent.
+    """800k is the measured opus-5 last-pass; 1M Hangul is a size-reject."""
 
-    250k Hangul is ~750 KiB UTF-8, under KIRO_MAX_PAYLOAD_BYTES=1085435, so
-    today's byte guard sends it and Kiro answers CONTENT_LENGTH_EXCEEDS_THRESHOLD.
-    A token cap of 195000 must refuse it locally with the count in the message.
-    """
-
-    def test_korean_over_token_limit_raises_under_legacy_byte_cap(self, monkeypatch):
+    def test_korean_over_800k_raises_when_byte_cap_disabled(self, monkeypatch):
         import kiro.converters_core as cc
         from kiro.converters_core import UnifiedMessage
         from kiro.payload_guards import PayloadTooLargeError
 
         monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
-        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_TOKENS", 195000)
-        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1085435)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 0)
 
         with pytest.raises(PayloadTooLargeError) as exc_info:
             cc.build_kiro_payload(
-                messages=[UnifiedMessage(role="user", content="가" * 250000)],
+                messages=[UnifiedMessage(role="user", content="가" * 900000)],
                 system_prompt="",
-                model_id="auto",
+                model_id="claude-opus-5",
                 tools=None,
                 conversation_id="conv-korean-over-tokens",
                 profile_arn=None,
@@ -410,16 +405,15 @@ class TestKoreanUnderOldByteCapIsRejectedByTokens:
 
         error = exc_info.value
         assert "token" in str(error).lower()
-        assert "195000" in str(error)
-        assert error.limit_tokens == 195000
-        assert error.payload_tokens > 195000
+        assert "800000" in str(error)
+        assert error.limit_tokens == 800000
+        assert error.payload_tokens > 800000
 
     def test_korean_under_token_limit_does_not_raise(self, monkeypatch):
         import kiro.converters_core as cc
         from kiro.converters_core import UnifiedMessage
 
         monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
-        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_TOKENS", 195000)
         monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1085435)
 
         result = cc.build_kiro_payload(
@@ -434,7 +428,7 @@ class TestKoreanUnderOldByteCapIsRejectedByTokens:
 
     def test_trim_uses_tokens_for_hangul_history(self):
         history = []
-        for i in range(10):
+        for i in range(25):
             history.append({"userInputMessage": {"content": "가" * 40000}})
             history.append({"assistantResponseMessage": {"content": "나" * 1000}})
         payload = {
@@ -445,9 +439,9 @@ class TestKoreanUnderOldByteCapIsRejectedByTokens:
                 "history": history,
             }
         }
-        stats = trim_payload_to_limit(payload, max_tokens=195000)
+        stats = trim_payload_to_limit(payload, max_tokens=800000)
         assert stats.trimmed
-        assert stats.final_tokens <= 195000
+        assert stats.final_tokens <= 800000
         assert "userInputMessage" in payload["conversationState"]["history"][0]
 
     def test_legacy_byte_cap_still_honored(self, monkeypatch):
@@ -456,7 +450,6 @@ class TestKoreanUnderOldByteCapIsRejectedByTokens:
         from kiro.payload_guards import PayloadTooLargeError
 
         monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
-        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_TOKENS", 1_000_000)
         monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 1000)
 
         with pytest.raises(PayloadTooLargeError) as exc_info:
@@ -470,3 +463,25 @@ class TestKoreanUnderOldByteCapIsRejectedByTokens:
             )
         assert exc_info.value.limit_bytes == 1000
         assert "byte" in str(exc_info.value).lower()
+
+    def test_cap_is_800k_for_haiku_and_opus(self):
+        assert payload_token_limit_for_model("claude-haiku-4.5") == 800000
+        assert payload_token_limit_for_model("claude-opus-5") == 800000
+
+    def test_opus5_allows_250k_hangul(self, monkeypatch):
+        import kiro.converters_core as cc
+        from kiro.converters_core import UnifiedMessage
+
+        monkeypatch.setattr(cc, "AUTO_TRIM_PAYLOAD", False)
+        monkeypatch.setattr(cc, "KIRO_MAX_PAYLOAD_BYTES", 0)
+
+        result = cc.build_kiro_payload(
+            messages=[UnifiedMessage(role="user", content="가" * 250000)],
+            system_prompt="",
+            model_id="claude-opus-5",
+            tools=None,
+            conversation_id="conv-opus-250k",
+            profile_arn=None,
+        )
+        content = result.payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        assert content == "가" * 250000


### PR DESCRIPTION
## Why

Kiro answers oversized bodies with `CONTENT_LENGTH_EXCEEDS_THRESHOLD` and no numbers. The local guard was measuring UTF-8 bytes of the compact JSON against `KIRO_MAX_PAYLOAD_BYTES=1085435`, from an ASCII-only bisect. That lets ~250k–360k Hangul syllables through (~750 KiB–1.0 MiB UTF-8, still under the byte cap) and then fails upstream with the cryptic 400.

Korean-heavy sessions were not being rejected too early in characters. They were being rejected too late in the unit the upstream actually uses.

## Measurement (2026-08-23)

Host: `runtime.us-east-1.kiro.dev` `/generateAssistantResponse`
Model: `claude-haiku-4.5`, no tools, one account
Size-reject body: `{"message":"Input content length exceeds threshold.","reason":"CONTENT_LENGTH_EXCEEDS_THRESHOLD"}`
HTTP 200 on stream start was scored as payload-accepted (connection closed before generation).

The hypothesis that the limit is ~1,085,435 codepoints is false on this host. The original 1,086,459 ASCII fail is also stale (it now passes).

| Probe | Filler | JSON chars | UTF-8 bytes | cl100k tokens (approx) | HTTP | Class |
|---|---|---:|---:|---:|---:|---|
| E0 smoke | ping | small | small | small | 200 | accepted |
| E1 | x | 1085435 | 1085435 | 135680 | 200 | accepted |
| E2 | x | 1086459 | 1086459 | 135807 | 200 | accepted (old fail size) |
| E3 | Hangul | 1085435 | 3255377 | 1085435 | 400 | size_reject |
| W1 | Hangul | 362121 | 1085435 | 362121 | 400 | size_reject |
| W4 | x | 1500000 | 1500000 | 187500 | 200 | accepted |
| W5 | x | 2070175 | 2070175 | 258772 | 400 | size_reject |
| B1 | Hangul | 180000 | 539072 | 180000 | 200 | accepted |
| N4 | Hangul | 195000 | 584072 | 195000 | 200 | accepted |
| B2 | Hangul | 200000 | 599072 | 200000 | 400 | size_reject |
| B4 | x | 1550000 | 1550000 | 193750 | 200 | accepted |
| N5 | x | 1575000 | 1575000 | 196875 | 400 | size_reject |
| N1 | a-z cycle | 1550000 | 1550000 | much greater than 200k | 400 | size_reject |
| N2 | a-z cycle | 180000 | 180000 | 45000 | 200 | accepted |
| E5 | emoji | 600000 | 2398608 | 1200000 | 400 | size_reject |
| W2 | Hangul at comment 2070175 UTF-8 | 690369 | 2070175 | 690369 | 400 | size_reject |

N1 vs B4 is the decisive pair: same 1.55 MB Content-Length, repeated `x` passes, cycling latin fails. The limit follows tokenizer density, not wire bytes and not Unicode scalars.

Hangul syllable `가` is 1 cl100k token. The Claude CJK slope (1.15) must not be applied in this guard; it would reject the Hangul payload that passed.

Default `KIRO_MAX_PAYLOAD_TOKENS=195000` is the largest Hangul JSON measured to pass.

## Change

- `check_payload_tokens()`: cl100k of compact JSON, `ensure_ascii=False`, no CJK slope
- `build_kiro_payload` / `trim_payload_to_limit` use that unit
- `PayloadTooLargeError` names tokens (or bytes when the legacy cap fires)
- `KIRO_MAX_PAYLOAD_BYTES` still honored (set `0` to disable). It is the extra conservative ASCII-oriented cap from the old bisect, not the upstream unit
- Do not default `AUTO_TRIM_PAYLOAD=true`

## Tests

New cases in `tests/unit/test_payload_guards.py`:

- 250k Hangul (~750 KiB UTF-8, under the old byte cap) raises locally with `195000` tokens in the message
- 1k Hangul does not raise
- Hangul history trim lands under the token cap
- Legacy `KIRO_MAX_PAYLOAD_BYTES` still fires
- Hangul / `x` / emoji cl100k densities pinned

Live after rebuild: Hangul x250000 returns 400 `Request payload is 250100 tokens, over the 195000 token limit`; small Hangul returns 200.

## Out of scope

- `http_client.py` still serializes with `json.dumps` default (`ensure_ascii=True`). That does not change parsed token count.
- Client `contextWindow: 200000` mitigation can stay; it is now in the same ballpark as this guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard Kiro request payloads by cl100k tokens instead of UTF-8 bytes, and set a single 800k-token cap to match observed upstream rejections. Previously we enforced a 1,085,435-byte limit; Korean-heavy payloads could pass locally and then 400 upstream.

- Implements token counting over compact JSON (`ensure_ascii=false`) with `check_payload_tokens`; no CJK slope; keeps byte measurement as a legacy extra cap.
- Uses a single default `KIRO_MAX_PAYLOAD_TOKENS=800000` for all models; still honors `KIRO_MAX_PAYLOAD_BYTES` when > 0 (set `0` to disable).
- `build_kiro_payload` rejects on tokens first, then bytes; `AUTO_TRIM_PAYLOAD=true` trims oldest pairs to meet token/byte caps; `PayloadTooLargeError` names the unit and includes both sizes.
- Impact: Korean-heavy inputs now fail locally with a token-based error; smaller models may still 400 upstream below 800k—lower `KIRO_MAX_PAYLOAD_TOKENS` if you need a stricter guard.
- Updates `.env.example` and docs; tests pin cl100k densities and the 800k behavior, and confirm the legacy byte cap still works.

<sup>Written for commit c1cb463ec2da5d082746fd68558c313f1d394cb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

