### PR TITLE
fix: align gateway contracts with Kiro CLI 2.19.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Operational detail lives in this file; do not relicense away from AGPL-3.0.
 | `identify_data_api_key` | function | `kiro/dashboard.py:298` | Legacy env key -> `ROOT_KEY_ID`, else hashed `klb_` key |
 | `record_token_usage` | function | `kiro/usage_tracking.py` | Attributes tokens to the calling key **and** the serving account |
 | `start_device_login` | function | `kiro/device_login.py:299` | Social vs Builder ID flows, deliberately unshared |
-| `get_kiro_api_host` / `get_kiro_q_host` | function | `kiro/config.py:613`, `:619` | Builder ID flag picks the host template |
+| `get_kiro_api_host` / `get_kiro_q_host` | function | `kiro/config.py:613`, `:619` | Runtime generation host vs legacy Builder ID Q host |
 
 Line numbers drift on every edit to these files. Grep the symbol name before
 trusting a pin here.
@@ -176,11 +176,11 @@ trusting a pin here.
   distinct names including probes like `claude-opus-99`. `kiro/metrics.py`
   normalizes, then clamps to what the pool serves and collapses the rest into
   `other`, re-aggregating in Python so no series is emitted twice.
-- Building the upstream host from region alone. A Builder ID account (SSO OIDC
-  with no profile ARN) must go to `q.{region}.amazonaws.com`; everything else
-  stays on the Kiro host (`kiro/config.py:613`). Absence of a profile alone is
-  not the test, and Builder ID accounts must never receive the global fallback
-  profile ARN (`routes_openai.py:371`, `routes_anthropic.py:255`).
+- Sending Builder ID generation to `q.{region}.amazonaws.com` or the legacy
+  `/generateAssistantResponse` path. Kiro CLI 2.19.1 sends AWS JSON RPC to
+  `runtime.{region}.kiro.dev/` and includes its request-scoped Builder ID
+  fallback profile. Keep that fallback out of persisted credentials: it is a
+  service routing value, not the account's own profile ARN.
 - Treating `_current_account_index` as the selection cursor. Routing is
   quota-weighted (`ACCOUNT_QUOTA_WEIGHTED_ROUTING`); the index only records the
   last success and drives the legacy sticky rollback path. It still advances

--- a/kiro/AGENTS.md
+++ b/kiro/AGENTS.md
@@ -162,8 +162,9 @@ No module has been added or removed since `a9fadd7`; 37 of the 39 were modified.
 - Exposing the device code or token in a device-flow response; `DeviceFlow.view`
   is the only client-facing shape (`device_login.py:82`). Registration discards
   the tokens either way (`dashboard.py:654`).
-- Giving a Builder ID account the global fallback profile ARN
-  (`routes_openai.py:371`, `routes_anthropic.py:255`).
+- Persisting Kiro CLI's Builder ID fallback profile as the account's own
+  profile. Generation and management requests use it only as a request-scoped
+  service routing value; the credential remains profile-less.
 - Adding a field to a protocol's usage object that the protocol does not define.
   `credits_used` on OpenAI is the one sanctioned extension.
 - Counting tokens with a hardcoded encoding or a blanket correction factor. Go

--- a/kiro/account_manager.py
+++ b/kiro/account_manager.py
@@ -61,12 +61,13 @@ from kiro.model_resolver import ModelResolver, normalize_model_name
 
 def _is_runtime_endpoint(auth_manager: KiroAuthManager) -> bool:
     """
-    Check if auth manager uses runtime endpoint that doesn't provide /ListAvailableModels.
+    Check if the model-list host is a runtime endpoint without that operation.
 
     Runtime endpoint pattern: https://runtime.{region}.kiro.dev
     Old endpoint pattern: https://q.{region}.amazonaws.com
 
-    Runtime endpoint does not provide /ListAvailableModels API (AWS limitation).
+    Generation always uses ``api_host`` now, including Builder ID. Model listing
+    remains on ``q_host``, so that is the host this predicate must inspect.
 
     Args:
         auth_manager: KiroAuthManager instance
@@ -75,17 +76,17 @@ def _is_runtime_endpoint(auth_manager: KiroAuthManager) -> bool:
         True if using runtime endpoint, False otherwise
 
     Examples:
-        >>> auth_manager.api_host = "https://runtime.us-east-1.kiro.dev"
+        >>> auth_manager.q_host = "https://runtime.us-east-1.kiro.dev"
         >>> _is_runtime_endpoint(auth_manager)
         True
-        >>> auth_manager.api_host = "https://runtime.eu-central-1.kiro.dev"
+        >>> auth_manager.q_host = "https://runtime.eu-central-1.kiro.dev"
         >>> _is_runtime_endpoint(auth_manager)
         True
-        >>> auth_manager.api_host = "https://q.us-east-1.amazonaws.com"
+        >>> auth_manager.q_host = "https://q.us-east-1.amazonaws.com"
         >>> _is_runtime_endpoint(auth_manager)
         False
     """
-    return "://runtime." in auth_manager.api_host
+    return "://runtime." in auth_manager.q_host
 
 
 def account_label(account_id: str) -> str:

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -11,7 +11,6 @@ Manages the lifecycle of access tokens:
 
 import asyncio
 import json
-import os
 import re
 import sqlite3
 from datetime import datetime, timedelta, timezone
@@ -23,6 +22,7 @@ import httpx
 from loguru import logger
 
 from kiro.config import (
+    KIRO_BUILDER_ID_PROFILE_ARN,
     TOKEN_REFRESH_THRESHOLD,
     get_aws_sso_oidc_url,
     get_kiro_api_host,
@@ -204,9 +204,10 @@ class KiroAuthManager:
         # - OIDC refresh: uses SSO region (for token refresh)
         # - API/Q hosts: use determined API region (for Q Developer API calls)
         #
-        # An account using SSO OIDC with no profile ARN is AWS Builder ID, which
-        # the runtime host rejects with 400 "profileArn is required for this
-        # request". Auth type and credentials are both resolved by this point.
+        # Builder ID is identified by SSO OIDC without an account-scoped profile.
+        # Current Kiro CLI still uses the runtime generation host and supplies a
+        # request-scoped service profile; q_host remains separate for legacy Q
+        # management calls.
         is_builder_id = self._auth_type == AuthType.AWS_SSO_OIDC and not self._profile_arn
         sso_region_for_oidc = self._sso_region or region
         self._refresh_url = get_kiro_refresh_url(sso_region_for_oidc)
@@ -984,6 +985,15 @@ class KiroAuthManager:
         return self._profile_arn
 
     @property
+    def request_profile_arn(self) -> Optional[str]:
+        """Profile ARN sent upstream, including Kiro CLI's Builder ID fallback."""
+        if self._profile_arn:
+            return self._profile_arn
+        if self._auth_type == AuthType.AWS_SSO_OIDC:
+            return KIRO_BUILDER_ID_PROFILE_ARN
+        return None
+
+    @property
     def region(self) -> str:
         """AWS region."""
         return self._region
@@ -992,6 +1002,11 @@ class KiroAuthManager:
     def api_host(self) -> str:
         """API host for the current region."""
         return self._api_host
+
+    @property
+    def generation_url(self) -> str:
+        """AWS JSON RPC endpoint for GenerateAssistantResponse."""
+        return f"{self._api_host}/"
 
     @property
     def q_host(self) -> str:

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -100,6 +100,11 @@ KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 # alone is not the test.
 KIRO_BUILDER_ID_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
 
+# Builder ID management and generation requests in Kiro CLI 2.19.1 carry this
+# service profile even though the local credential has no account-specific ARN.
+# Keep it request-scoped: it is not persisted as the account's own profile.
+KIRO_BUILDER_ID_PROFILE_ARN: str = "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX"
+
 # ==================================================================================================
 # Token Settings
 # ==================================================================================================

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -7,17 +7,12 @@ Loads environment variables and provides typed access to them.
 """
 
 import os
-import re
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
-
-
-
 
 # ==================================================================================================
 # Server Settings
@@ -89,15 +84,8 @@ KIRO_API_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 # Host for Q API (ListAvailableModels)
 KIRO_Q_HOST_TEMPLATE: str = "https://runtime.{region}.kiro.dev"
 
-# Host for accounts that reach Q Developer without a profile, which in practice
-# means AWS Builder ID (SSO OIDC auth that has no profile ARN). The runtime host
-# rejects those with 400 "profileArn is required for this request", and Builder ID
-# cannot obtain a profile at all: ListAvailableProfiles answers 403 and an empty
-# profileArn fails as REQUEST_BODY_INVALID.
-#
-# Social accounts are a different case: they normally carry a profile, but one
-# configured without it still belongs on the runtime host, so absence of a profile
-# alone is not the test.
+# Legacy Q management host for Builder ID accounts. Current generation requests
+# use the runtime host with the request-scoped profile below.
 KIRO_BUILDER_ID_HOST_TEMPLATE: str = "https://q.{region}.amazonaws.com"
 
 # Builder ID management and generation requests in Kiro CLI 2.19.1 carry this
@@ -431,8 +419,6 @@ WEB_SEARCH_ENABLED: bool = os.getenv("WEB_SEARCH_ENABLED", "false").lower() in (
 # Account System Settings
 # ==================================================================================================
 
-
-
 # ==================================================================================================
 # Circuit Breaker Settings
 # ==================================================================================================
@@ -599,9 +585,8 @@ def get_aws_sso_oidc_url(region: str) -> str:
 
 
 def get_kiro_api_host(region: str, is_builder_id: bool = False) -> str:
-    """Return the API host for the region, routing Builder ID to Q Developer."""
-    template = KIRO_BUILDER_ID_HOST_TEMPLATE if is_builder_id else KIRO_API_HOST_TEMPLATE
-    return template.format(region=region)
+    """Return the runtime generation host used by current Kiro CLI clients."""
+    return KIRO_API_HOST_TEMPLATE.format(region=region)
 
 
 def get_kiro_q_host(region: str, is_builder_id: bool = False) -> str:

--- a/kiro/device_login.py
+++ b/kiro/device_login.py
@@ -15,8 +15,8 @@ the polling logic is deliberately not shared:
 - Builder ID (AWS SSO OIDC) on ``oidc.{region}.amazonaws.com``. Pending is HTTP
   400 with an ``authorization_pending`` code, timings are seconds, and refreshing
   needs the client registration, so the client id and secret are stored with the
-  refresh token in SQLite. Builder ID has no profile and must use
-  ``q.{region}.amazonaws.com``.
+  refresh token in SQLite. The credential has no account-scoped profile; current
+  generation adds Kiro CLI's request-scoped service profile instead.
 
 Ported from the kiro-auth TypeScript reference.
 """

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -16,7 +16,6 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
 
-from kiro.auth import AuthType
 from kiro.config import WEB_SEARCH_ENABLED
 from kiro.converters_anthropic import anthropic_to_kiro
 from kiro.dashboard import identify_data_api_key
@@ -210,9 +209,7 @@ async def messages(
         tried_accounts: set[str] = set()  # Track tried accounts in current failover loop
 
         for _attempt in range(max_attempts):
-            account = await account_manager.get_next_account(
-                request_data.model, exclude_accounts=tried_accounts
-            )
+            account = await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
 
             if account is None or not account.auth_manager:
                 # All accounts unavailable
@@ -253,8 +250,9 @@ async def messages(
             # Generate conversation ID
             conversation_id = generate_conversation_id()
 
-            # Build payload for Kiro — profile ARN is always account-scoped.
-            profile_arn_for_payload = auth_manager.profile_arn or ""
+            # Builder ID carries Kiro CLI's request-scoped service profile even
+            # though the credential itself has no account-scoped profile ARN.
+            profile_arn_for_payload = auth_manager.request_profile_arn or ""
 
             try:
                 kiro_payload = anthropic_to_kiro(request_data, conversation_id, profile_arn_for_payload)
@@ -280,7 +278,7 @@ async def messages(
                 logger.warning(f"Failed to log Kiro request: {e}")
 
             # Create HTTP client
-            url = f"{auth_manager.api_host}/generateAssistantResponse"
+            url = auth_manager.generation_url
             logger.debug(f"Kiro API URL: {url} (account: {account.id})")
 
             if request_data.stream:

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -18,7 +18,6 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from loguru import logger
 
-from kiro.auth import AuthType
 from kiro.config import (
     APP_VERSION,
     WEB_SEARCH_ENABLED,
@@ -324,9 +323,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
         tried_accounts: set[str] = set()  # Track tried accounts in current failover loop
 
         for _attempt in range(max_attempts):
-            account = await account_manager.get_next_account(
-                request_data.model, exclude_accounts=tried_accounts
-            )
+            account = await account_manager.get_next_account(request_data.model, exclude_accounts=tried_accounts)
 
             if account is None or not account.auth_manager:
                 # All accounts unavailable
@@ -361,8 +358,9 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
             # Generate conversation ID
             conversation_id = generate_conversation_id()
 
-            # Build payload for Kiro — profile ARN is always account-scoped.
-            profile_arn_for_payload = auth_manager.profile_arn or ""
+            # Builder ID carries Kiro CLI's request-scoped service profile even
+            # though the credential itself has no account-scoped profile ARN.
+            profile_arn_for_payload = auth_manager.request_profile_arn or ""
 
             try:
                 kiro_payload = build_kiro_payload(request_data, conversation_id, profile_arn_for_payload)
@@ -380,7 +378,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                 logger.warning(f"Failed to log Kiro request: {e}")
 
             # Create HTTP client
-            url = f"{auth_manager.api_host}/generateAssistantResponse"
+            url = auth_manager.generation_url
             logger.debug(f"Kiro API URL: {url} (account: {account.id})")
 
             if request_data.stream:

--- a/kiro/usage.py
+++ b/kiro/usage.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 import re
 from typing import Any
-from urllib.parse import urlencode
 
 import httpx
 
 from kiro.account_manager import Account
+from kiro.auth import AuthType
+from kiro.config import KIRO_BUILDER_ID_PROFILE_ARN
 from kiro.utils import get_kiro_headers
 
 
@@ -48,20 +49,27 @@ async def fetch_account_usage(account: Account) -> dict[str, Any]:
 
     auth = account.auth_manager
     token = await auth.get_access_token()
-    params = {
+    params: dict[str, str] = {
         "origin": "AI_EDITOR",
-        "resourceType": "AGENTIC_REQUEST",
         "isEmailRequired": "true",
     }
-    if auth.profile_arn:
-        params["profileArn"] = auth.profile_arn
-    url = f"https://q.{_usage_region(account)}.amazonaws.com/getUsageLimits?{urlencode(params)}"
+    body: dict[str, str | bool] = {
+        "origin": "AI_EDITOR",
+        "isEmailRequired": True,
+    }
+    profile_arn = auth.profile_arn
+    if profile_arn is None and auth.auth_type == AuthType.AWS_SSO_OIDC:
+        profile_arn = KIRO_BUILDER_ID_PROFILE_ARN
+    if profile_arn:
+        params["profileArn"] = profile_arn
+        body["profileArn"] = profile_arn
+    url = f"https://management.{_usage_region(account)}.kiro.dev/"
     headers = get_kiro_headers(auth, token)
-    headers.pop("x-amz-target", None)
+    headers["x-amz-target"] = "AmazonCodeWhispererService.GetUsageLimits"
     headers["Accept"] = "application/json"
 
     async with httpx.AsyncClient(timeout=20) as client:
-        response = await client.get(url, headers=headers)
+        response = await client.post(url, params=params, json=body, headers=headers)
     response.raise_for_status()
     payload = response.json()
 

--- a/kiro/usage.py
+++ b/kiro/usage.py
@@ -14,8 +14,6 @@ from typing import Any
 import httpx
 
 from kiro.account_manager import Account
-from kiro.auth import AuthType
-from kiro.config import KIRO_BUILDER_ID_PROFILE_ARN
 from kiro.utils import get_kiro_headers
 
 
@@ -57,12 +55,12 @@ async def fetch_account_usage(account: Account) -> dict[str, Any]:
         "origin": "AI_EDITOR",
         "isEmailRequired": True,
     }
-    profile_arn = auth.profile_arn
-    if profile_arn is None and auth.auth_type == AuthType.AWS_SSO_OIDC:
-        profile_arn = KIRO_BUILDER_ID_PROFILE_ARN
+    profile_arn = auth.request_profile_arn
     if profile_arn:
         params["profileArn"] = profile_arn
         body["profileArn"] = profile_arn
+    # Kiro CLI 2.19.1 duplicates these modeled fields in the query and AWS JSON
+    # body. Preserve that observed wire contract rather than "simplifying" it.
     url = f"https://management.{_usage_region(account)}.kiro.dev/"
     headers = get_kiro_headers(auth, token)
     headers["x-amz-target"] = "AmazonCodeWhispererService.GetUsageLimits"
@@ -74,7 +72,10 @@ async def fetch_account_usage(account: Account) -> dict[str, Any]:
     payload = response.json()
 
     breakdowns = payload.get("usageBreakdownList") or []
-    breakdown = breakdowns[0] if breakdowns else {}
+    breakdown = next(
+        (entry for entry in breakdowns if entry.get("resourceType") == "AGENTIC_REQUEST"),
+        breakdowns[0] if breakdowns else {},
+    )
     subscription = payload.get("subscriptionInfo") or {}
     overage = payload.get("overageConfiguration") or {}
     # The request asks for the identity block (isEmailRequired), which is the

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -56,16 +56,20 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
     Returns:
         Dictionary with headers for HTTP request
     """
-    fingerprint = auth_manager.fingerprint
-
     return {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/x-amz-json-1.0",
         "x-amz-target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
-        "User-Agent": f"aws-sdk-js/1.0.27 ua/2.1 os/win32#10.0.19044 lang/js md/nodejs#22.21.1 api/codewhispererstreaming#1.0.27 m/E KiroIDE-0.7.45-{fingerprint}",
-        "x-amz-user-agent": f"aws-sdk-js/1.0.27 KiroIDE-0.7.45-{fingerprint}",
+        "User-Agent": (
+            "aws-sdk-rust/1.3.15 ua/2.1 api/codewhispererstreaming/0.1.17975 "
+            "os/linux lang/rust/1.92.0 md/appVersion-2.19.1 app/AmazonQ-For-CLI"
+        ),
+        "x-amz-user-agent": (
+            "aws-sdk-rust/1.3.15 ua/2.1 api/codewhispererstreaming/0.1.17975 "
+            "os/linux lang/rust/1.92.0 m/F app/AmazonQ-For-CLI"
+        ),
         "x-amzn-codewhisperer-optout": "true",
-        "x-amzn-kiro-agent-mode": "vibe",
+        "x-kiro-attempt": "1;max=3",
         "amz-sdk-invocation-id": str(uuid.uuid4()),
         "amz-sdk-request": "attempt=1; max=3",
     }

--- a/kiro/utils.py
+++ b/kiro/utils.py
@@ -46,11 +46,11 @@ def get_kiro_headers(auth_manager: "KiroAuthManager", token: str) -> dict:
 
     Includes all necessary headers for authentication and identification:
     - Authorization with Bearer token
-    - User-Agent with fingerprint
+    - Kiro CLI-compatible User-Agent and retry metadata
     - AWS CodeWhisperer specific headers
 
     Args:
-        auth_manager: Authentication manager for obtaining fingerprint
+        auth_manager: Authentication manager associated with the request
         token: Access token for authorization
 
     Returns:

--- a/tests/unit/test_account_usage_email.py
+++ b/tests/unit/test_account_usage_email.py
@@ -9,12 +9,15 @@ never does.
 
 import asyncio
 import importlib
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from httpx import AsyncClient, MockTransport, Request, Response
 
 from kiro.account_manager import Account
+from kiro.auth import AuthType
 from kiro.usage import fetch_account_usage
 
 _UPSTREAM_PAYLOAD = {
@@ -51,6 +54,7 @@ def _account_with_auth() -> Account:
         api_host="https://runtime.us-east-1.kiro.dev",
         region="us-east-1",
         fingerprint="mock-fingerprint",
+        auth_type=AuthType.KIRO_DESKTOP,
     )
     return account
 
@@ -60,7 +64,7 @@ def _fetch(payload: dict) -> dict:
     response.raise_for_status = MagicMock()
     response.json.return_value = payload
     client = AsyncMock()
-    client.get = AsyncMock(return_value=response)
+    client.post = AsyncMock(return_value=response)
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
     with patch("kiro.usage.httpx.AsyncClient", return_value=client):
@@ -69,6 +73,63 @@ def _fetch(payload: dict) -> dict:
 
 def test_upstream_email_is_normalized_into_the_usage_summary():
     assert _fetch(_UPSTREAM_PAYLOAD)["email"] == "pool-account@example.test"
+
+
+def test_usage_request_matches_latest_cli_management_contract():
+    captured = {}
+
+    def handler(request: Request) -> Response:
+        captured.update(
+            method=request.method,
+            host=request.url.host,
+            path=request.url.path,
+            query_keys=sorted(request.url.params.keys()),
+            body=json.loads(request.content) if request.content else None,
+            target=request.headers.get("x-amz-target"),
+        )
+        return Response(200, json=_UPSTREAM_PAYLOAD)
+
+    client = AsyncClient(transport=MockTransport(handler))
+    with patch("kiro.usage.httpx.AsyncClient", return_value=client):
+        usage = asyncio.run(fetch_account_usage(_account_with_auth()))
+
+    assert captured == {
+        "method": "POST",
+        "host": "management.us-east-1.kiro.dev",
+        "path": "/",
+        "query_keys": ["isEmailRequired", "origin", "profileArn"],
+        "body": {
+            "isEmailRequired": True,
+            "origin": "AI_EDITOR",
+            "profileArn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/example",
+        },
+        "target": "AmazonCodeWhispererService.GetUsageLimits",
+    }
+    assert usage["email"] == "pool-account@example.test"
+
+
+def test_builder_id_usage_request_uses_latest_cli_fallback_profile():
+    captured = {}
+
+    def handler(request: Request) -> Response:
+        captured.update(
+            query_profile=request.url.params.get("profileArn"),
+            body_profile=json.loads(request.content).get("profileArn"),
+        )
+        return Response(200, json=_UPSTREAM_PAYLOAD)
+
+    account = _account_with_auth()
+    account.auth_manager.profile_arn = None
+    account.auth_manager.api_host = "https://q.us-east-1.amazonaws.com"
+    account.auth_manager.auth_type = AuthType.AWS_SSO_OIDC
+    client = AsyncClient(transport=MockTransport(handler))
+    with patch("kiro.usage.httpx.AsyncClient", return_value=client):
+        asyncio.run(fetch_account_usage(account))
+
+    assert captured == {
+        "query_profile": "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX",
+        "body_profile": "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX",
+    }
 
 
 def test_upstream_user_id_is_not_exposed():

--- a/tests/unit/test_account_usage_email.py
+++ b/tests/unit/test_account_usage_email.py
@@ -17,7 +17,6 @@ import pytest
 from httpx import AsyncClient, MockTransport, Request, Response
 
 from kiro.account_manager import Account
-from kiro.auth import AuthType
 from kiro.usage import fetch_account_usage
 
 _UPSTREAM_PAYLOAD = {
@@ -51,10 +50,10 @@ def _account_with_auth() -> Account:
     account.auth_manager = SimpleNamespace(
         get_access_token=AsyncMock(return_value="mock-token"),
         profile_arn="arn:aws:codewhisperer:us-east-1:123456789012:profile/example",
+        request_profile_arn="arn:aws:codewhisperer:us-east-1:123456789012:profile/example",
         api_host="https://runtime.us-east-1.kiro.dev",
         region="us-east-1",
         fingerprint="mock-fingerprint",
-        auth_type=AuthType.KIRO_DESKTOP,
     )
     return account
 
@@ -120,8 +119,8 @@ def test_builder_id_usage_request_uses_latest_cli_fallback_profile():
 
     account = _account_with_auth()
     account.auth_manager.profile_arn = None
+    account.auth_manager.request_profile_arn = "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX"
     account.auth_manager.api_host = "https://q.us-east-1.amazonaws.com"
-    account.auth_manager.auth_type = AuthType.AWS_SSO_OIDC
     client = AsyncClient(transport=MockTransport(handler))
     with patch("kiro.usage.httpx.AsyncClient", return_value=client):
         asyncio.run(fetch_account_usage(account))
@@ -149,6 +148,32 @@ def test_blank_upstream_email_is_stored_as_absent():
     payload = {**_UPSTREAM_PAYLOAD, "userInfo": {"email": "", "userId": "d-1"}}
 
     assert _fetch(payload)["email"] is None
+
+
+def test_agentic_breakdown_is_selected_when_upstream_returns_multiple_resources():
+    payload = {
+        **_UPSTREAM_PAYLOAD,
+        "usageBreakdownList": [
+            {
+                "resourceType": "CREDIT",
+                "currentUsageWithPrecision": 900.0,
+                "usageLimitWithPrecision": 1000.0,
+                "unit": "CREDITS",
+            },
+            {
+                "resourceType": "AGENTIC_REQUEST",
+                "currentUsageWithPrecision": 0.0,
+                "usageLimitWithPrecision": 2000.0,
+                "unit": "INVOCATIONS",
+            },
+        ],
+    }
+
+    usage = _fetch(payload)
+
+    assert usage["resourceType"] == "AGENTIC_REQUEST"
+    assert usage["currentUsage"] == 0.0
+    assert usage["usageLimit"] == 2000.0
 
 
 def test_refreshed_email_reaches_the_account_view(dashboard):

--- a/tests/unit/test_device_login.py
+++ b/tests/unit/test_device_login.py
@@ -400,8 +400,7 @@ async def test_builder_id_expired_code_ends_the_flow():
 
 @pytest.mark.asyncio
 async def test_builder_id_approval_carries_no_profile_arn():
-    """Builder ID cannot obtain a profile, and an empty one fails the request, so
-    the account must carry none at all to reach q.amazonaws.com."""
+    """The stored credential stays profile-less; request routing adds the service profile."""
     client = _client(_Response(REGISTRATION), _Response(OIDC_AUTHORIZATION))
     with patch("kiro.device_login.httpx.AsyncClient", return_value=client):
         flow = await start_device_login("BuilderId")

--- a/tests/unit/test_device_login.py
+++ b/tests/unit/test_device_login.py
@@ -440,15 +440,15 @@ async def test_registering_builder_id_adds_a_json_account(dashboard, tmp_path):
 
 
 # =============================================================================
-# Host routing: an account with no profile must not use the runtime host
+# Host routing: Builder ID generation follows the latest Kiro CLI contract
 # =============================================================================
 
 
-def test_builder_id_host_differs_from_the_profile_host():
+def test_builder_id_keeps_q_management_host_but_uses_runtime_generation_host():
     from kiro.config import get_kiro_api_host, get_kiro_q_host
 
     assert get_kiro_api_host("us-east-1", is_builder_id=False) == "https://runtime.us-east-1.kiro.dev"
-    assert get_kiro_api_host("us-east-1", is_builder_id=True) == "https://q.us-east-1.amazonaws.com"
+    assert get_kiro_api_host("us-east-1", is_builder_id=True) == "https://runtime.us-east-1.kiro.dev"
     assert get_kiro_q_host("us-east-1", is_builder_id=True) == "https://q.us-east-1.amazonaws.com"
 
 
@@ -459,9 +459,7 @@ def test_host_selection_defaults_to_the_profile_host():
     assert get_kiro_api_host("eu-central-1") == "https://runtime.eu-central-1.kiro.dev"
 
 
-def test_builder_id_credentials_route_to_the_q_host(tmp_path):
-    """A Builder ID account sent to runtime.kiro.dev fails every request with
-    400 profileArn is required, which is what this routing prevents."""
+def test_builder_id_credentials_match_latest_cli_generation_contract(tmp_path):
     import json as _json
 
     from kiro.auth import AuthType, KiroAuthManager
@@ -484,7 +482,10 @@ def test_builder_id_credentials_route_to_the_q_host(tmp_path):
 
     assert manager.auth_type == AuthType.AWS_SSO_OIDC
     assert manager.profile_arn is None
-    assert manager.api_host == "https://q.us-east-1.amazonaws.com"
+    assert manager.api_host == "https://runtime.us-east-1.kiro.dev"
+    assert manager.q_host == "https://q.us-east-1.amazonaws.com"
+    assert manager.generation_url == "https://runtime.us-east-1.kiro.dev/"
+    assert manager.request_profile_arn == "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX"
 
 
 def test_a_social_account_without_a_profile_keeps_the_runtime_host(tmp_path):

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1122,6 +1122,19 @@ class TestKiroHttpClientConnectionCloseHeader:
         assert response.status_code == 200
 
 
+def test_generation_headers_match_latest_cli_retry_contract():
+    from kiro.utils import get_kiro_headers
+
+    auth_manager = Mock(fingerprint="test-fingerprint")
+    headers = get_kiro_headers(auth_manager, "test-token")
+
+    assert headers["x-amz-target"] == "AmazonCodeWhispererStreamingService.GenerateAssistantResponse"
+    assert headers["x-kiro-attempt"] == "1;max=3"
+    assert "x-amzn-kiro-agent-mode" not in headers
+    assert "app/AmazonQ-For-CLI" in headers["User-Agent"]
+    assert "api/codewhispererstreaming" in headers["x-amz-user-agent"]
+
+
 class TestKiroHttpClientRequestParameters:
     """Tests for request_with_retry method with params and optional json_data (Account System)."""
 

--- a/tests/unit/test_routes_generation_contract.py
+++ b/tests/unit/test_routes_generation_contract.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+
+"""Generation-request contract shared by both protocol routers."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kiro.account_manager import Account, AccountManager
+from kiro.auth import AuthType
+from kiro.cache import ModelInfoCache
+from kiro.config import FALLBACK_MODELS, KIRO_BUILDER_ID_PROFILE_ARN
+from kiro.model_resolver import ModelResolver
+
+_MODEL = "claude-sonnet-4.5"
+_RUNTIME_HOST = "https://runtime.us-east-1.kiro.dev"
+_BODIES = {
+    "openai": ("/v1/chat/completions", {"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]}),
+    "anthropic": (
+        "/v1/messages",
+        {"model": _MODEL, "max_tokens": 16, "messages": [{"role": "user", "content": "hi"}]},
+    ),
+}
+
+
+class _CapturingHttpClient:
+    """Record the final upstream call, then abort before stream handling."""
+
+    calls: list = []
+
+    def __init__(self, auth_manager, shared_client=None):
+        self.auth_manager = auth_manager
+        self.client = AsyncMock()
+
+    async def request_with_retry(
+        self,
+        method,
+        url,
+        json_data=None,
+        params=None,
+        stream=False,
+        retry_rate_limits=None,
+    ):
+        from kiro.utils import get_kiro_headers
+
+        type(self).calls.append(
+            {
+                "method": method,
+                "url": url,
+                "payload": json_data,
+                "headers": get_kiro_headers(self.auth_manager, "probe-token"),
+            }
+        )
+        raise RuntimeError("contract probe: captured the upstream request")
+
+    async def close(self):
+        return None
+
+
+def _account(account_id: str, *, profile_arn, auth_type) -> Account:
+    account = Account(id=account_id)
+    auth = AsyncMock()
+    auth.get_access_token = AsyncMock(return_value="probe-token")
+    auth.auth_type = auth_type
+    auth.profile_arn = profile_arn
+    if profile_arn:
+        auth.request_profile_arn = profile_arn
+    elif auth_type == AuthType.AWS_SSO_OIDC:
+        auth.request_profile_arn = KIRO_BUILDER_ID_PROFILE_ARN
+    else:
+        auth.request_profile_arn = None
+    auth.api_host = _RUNTIME_HOST
+    auth.generation_url = f"{_RUNTIME_HOST}/"
+    auth.q_host = _RUNTIME_HOST
+    auth.region = "us-east-1"
+    auth.fingerprint = "probe-fingerprint"
+
+    account.auth_manager = auth
+    account.model_cache = ModelInfoCache()
+    asyncio.run(account.model_cache.update(FALLBACK_MODELS))
+    account.model_resolver = ModelResolver(
+        cache=account.model_cache,
+        hidden_models={},
+        aliases={},
+        hidden_from_list=set(),
+    )
+    account.models_cached_at = float("inf")
+    return account
+
+
+@pytest.fixture
+def capture_generation_request(clean_app, valid_proxy_api_key):
+    from fastapi.testclient import TestClient
+
+    def _capture(protocol: str, account: Account) -> dict:
+        path, body = _BODIES[protocol]
+        manager = AccountManager()
+        manager._accounts = {account.id: account}
+
+        _CapturingHttpClient.calls.clear()
+        with (
+            patch("kiro.routes_openai.KiroHttpClient", _CapturingHttpClient),
+            patch("kiro.routes_anthropic.KiroHttpClient", _CapturingHttpClient),
+            patch.object(AccountManager, "load_credentials", AsyncMock(return_value=None)),
+            patch.object(AccountManager, "load_state", AsyncMock(return_value=None)),
+            patch.object(AccountManager, "_initialize_account", AsyncMock(return_value=True)),
+            patch.object(AccountManager, "save_state_periodically", AsyncMock(return_value=None)),
+            patch.object(AccountManager, "_save_state", AsyncMock(return_value=None)),
+        ):
+            with TestClient(clean_app, raise_server_exceptions=False) as client:
+                client.app.state.account_manager = manager
+                headers = (
+                    {"Authorization": f"Bearer {valid_proxy_api_key}"}
+                    if protocol == "openai"
+                    else {"x-api-key": valid_proxy_api_key}
+                )
+                client.post(path, headers=headers, json={**body, "stream": False})
+
+        assert len(_CapturingHttpClient.calls) == 1
+        return _CapturingHttpClient.calls[0]
+
+    return _capture
+
+
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+def test_generation_posts_to_the_runtime_root(capture_generation_request, protocol):
+    call = capture_generation_request(
+        protocol,
+        _account("/creds/builder.json", profile_arn=None, auth_type=AuthType.AWS_SSO_OIDC),
+    )
+
+    assert call["method"] == "POST"
+    assert call["url"] == f"{_RUNTIME_HOST}/"
+    assert "generateAssistantResponse" not in call["url"]
+
+
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+def test_builder_id_sends_the_cli_fallback_profile_without_persisting_it(capture_generation_request, protocol):
+    account = _account("/creds/builder.json", profile_arn=None, auth_type=AuthType.AWS_SSO_OIDC)
+
+    call = capture_generation_request(protocol, account)
+
+    assert call["payload"]["profileArn"] == KIRO_BUILDER_ID_PROFILE_ARN
+    assert account.auth_manager.profile_arn is None
+
+
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+def test_an_account_with_a_profile_sends_its_own(capture_generation_request, protocol):
+    own = "arn:aws:codewhisperer:us-east-1:123456789012:profile/own"
+
+    call = capture_generation_request(
+        protocol,
+        _account("/creds/social.json", profile_arn=own, auth_type=AuthType.KIRO_DESKTOP),
+    )
+
+    assert call["payload"]["profileArn"] == own
+
+
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+def test_a_profileless_account_never_receives_the_builder_id_fallback(capture_generation_request, protocol):
+    call = capture_generation_request(
+        protocol,
+        _account("/creds/noprofile.json", profile_arn=None, auth_type=AuthType.KIRO_DESKTOP),
+    )
+
+    assert "profileArn" not in call["payload"]
+
+
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+def test_generation_headers_carry_the_cli_retry_contract(capture_generation_request, protocol):
+    call = capture_generation_request(
+        protocol,
+        _account("/creds/builder.json", profile_arn=None, auth_type=AuthType.AWS_SSO_OIDC),
+    )
+    headers = call["headers"]
+
+    assert headers["x-amz-target"] == "AmazonCodeWhispererStreamingService.GenerateAssistantResponse"
+    assert headers["x-kiro-attempt"] == "1;max=3"
+    assert "x-amzn-kiro-agent-mode" not in headers
+    assert "app/AmazonQ-For-CLI" in headers["User-Agent"]
+    assert "KiroIDE" not in headers["User-Agent"]


### PR DESCRIPTION
## Summary

- align account usage polling with the Kiro CLI 2.19.1 management AWS JSON RPC contract
- route Builder ID generation through the runtime root endpoint with the CLI's request-scoped service profile
- update request identity/retry headers and preserve model-list suspension behavior
- add wire-level usage tests and cross-protocol route contract coverage for OpenAI and Anthropic

## Background

The previous gateway contract used legacy REST-like paths:

- `GET q.{region}.amazonaws.com/getUsageLimits`
- `POST q.{region}.amazonaws.com/generateAssistantResponse`

A sanitized capture of Kiro CLI 2.19.1 showed the current contracts:

- `POST management.{region}.kiro.dev/` with `AmazonCodeWhispererService.GetUsageLimits`
- `POST runtime.{region}.kiro.dev/` with `AmazonCodeWhispererStreamingService.GenerateAssistantResponse`
- Builder ID requests carry a request-scoped service profile while the stored credential remains profile-less

The capture retained only method, host, path, key names, safe protocol headers, status, and value shapes. No token, prompt, response content, credential, or raw flow is included in this PR.

## Changes

- centralize the Builder ID request profile fallback on `KiroAuthManager.request_profile_arn`
- keep generation on the runtime host while preserving the legacy Q host for model-list management
- use the AWS JSON RPC root path for both OpenAI and Anthropic generation
- align Kiro CLI user-agent and retry metadata
- select `AGENTIC_REQUEST` explicitly when usage responses contain multiple resource breakdowns
- update repository guidance to distinguish request-scoped routing values from persisted account profiles

## Verification

- 375 targeted usage/auth/http/routes/suspension tests passed
- mandatory five-lane review completed:
  - goal and constraint verification: PASS
  - hands-on QA: PASS
  - code quality review after blocker fixes: PASS
  - security review: PASS
  - git/GitHub context review: PASS
- `mypy`: no issues in 42 source files
- changed-file `ruff check` and `ruff format --check`: clean
- deployed live verification:
  - OpenAI `/v1/chat/completions`: HTTP 200, assistant response `OK.`
  - Anthropic `/v1/messages`: HTTP 200, assistant response `OK.`
  - dashboard usage refresh: populated emails with no upstream usage error

The full suite has one pre-existing collection-time clock failure in
`test_quota_reset_quarantine.py`; it reproduces on `origin/main` and passes in
isolation. This branch otherwise passed the full suite.

## Scope

This PR intentionally excludes local blue/green deployment configuration,
homelab compose changes, parser experiments, generated/session artifacts, and
temporary capture files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns our gateway with Kiro CLI 2.19.1 so usage and generation match the current AWS JSON RPC contracts. This moves usage polling to POST on the management host and routes all generation to the runtime root with a request‑scoped Builder ID service profile, preventing 400 “profileArn is required” while keeping credentials profile‑less.

- Usage: POST to management.{region}.kiro.dev/ with x-amz-target=AmazonCodeWhispererService.GetUsageLimits; duplicates origin, isEmailRequired, and optional profileArn in query and JSON; selects AGENTIC_REQUEST when multiple resources appear.
- Generation: POST to runtime.{region}.kiro.dev/ root (no /generateAssistantResponse); Builder ID sends the CLI’s fallback profile via request_profile_arn but does not persist it.
- Hosts: get_kiro_api_host always returns the runtime host; model listing stays on q.{region}.amazonaws.com; runtime detection now inspects q_host.
- Headers: match CLI UA and retry metadata; add x-kiro-attempt and amz-sdk-request; keep x-amz-target for streaming; remove x-amzn-kiro-agent-mode.
- Auth: add request_profile_arn and generation_url accessors; update device-login guidance to distinguish request-scoped routing from stored credentials.
- Tests: add wire-level management usage tests and shared OpenAI/Anthropic generation contract coverage; update host-routing and HTTP header tests.

<sup>Written for commit 4cd295630bead2c7da2d3adbf5ddadfd5b7c8caa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

