### PR TITLE
fix: clear ruff format and lint debt blocking the quality CI job

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ def validate_configuration() -> None:
         logger.error("  CONFIGURATION ERROR")
         logger.error("=" * 60)
         logger.error("  PROXY_API_KEY is required.")
-        logger.error('  Generate one:  openssl rand -hex 32')
+        logger.error("  Generate one:  openssl rand -hex 32")
         logger.error('  Then set:      PROXY_API_KEY="..." in .env')
         logger.error("=" * 60)
         logger.error("")
@@ -307,9 +307,7 @@ async def lifespan(app: FastAPI):
     all_accounts = list(app.state.account_manager._accounts.keys())
 
     if not all_accounts:
-        logger.warning(
-            "No accounts in the pool yet — open the dashboard and add one via device login"
-        )
+        logger.warning("No accounts in the pool yet — open the dashboard and add one via device login")
     else:
         # Determine start index from persisted runtime state
         start_index = app.state.account_manager._current_account_index

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,10 +87,7 @@ def setup_test_environment(tmp_path_factory):
     original_proxy_api_key = kiro.config.PROXY_API_KEY
     kiro.config.PROXY_API_KEY = "test_proxy_key_12345"
 
-    original_environ = {
-        key: os.environ.get(key)
-        for key in ("DASHBOARD_DATA_DIR", "PROXY_API_KEY")
-    }
+    original_environ = {key: os.environ.get(key) for key in ("DASHBOARD_DATA_DIR", "PROXY_API_KEY")}
     os.environ["DASHBOARD_DATA_DIR"] = str(tmp_dir / "dashboard")
     os.environ["PROXY_API_KEY"] = kiro.config.PROXY_API_KEY
     # Stash mock paths for fixtures that still seed the SQLite account store.
@@ -141,7 +138,6 @@ def seed_account_sources(entries):
 
     with connection() as conn:
         replace_account_sources(canonicalize_account_sources(entries), conn, ungated=True)
-
 
 
 @pytest.fixture

--- a/tests/integration/test_account_system_flow.py
+++ b/tests/integration/test_account_system_flow.py
@@ -50,7 +50,6 @@ class TestAccountSystemFullFlow:
 
         # Arrange: Create credentials.json with two accounts
         creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         account1_path = temp_account_credentials_files["account1"]
         account2_path = temp_account_credentials_files["account2"]
@@ -61,6 +60,7 @@ class TestAccountSystemFullFlow:
         ]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         # Create AccountManager
@@ -179,7 +179,6 @@ class TestAccountSystemFullFlow:
 
         # Arrange
         creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         account1_path = temp_account_credentials_files["account1"]
         account2_path = temp_account_credentials_files["account2"]
@@ -190,6 +189,7 @@ class TestAccountSystemFullFlow:
         ]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -238,7 +238,6 @@ class TestAccountSystemFullFlow:
 
         # Arrange
         creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         account1_path = temp_account_credentials_files["account1"]
         account2_path = temp_account_credentials_files["account2"]
@@ -249,6 +248,7 @@ class TestAccountSystemFullFlow:
         ]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -299,13 +299,13 @@ class TestAccountSystemFullFlow:
 
         # Arrange
         creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         account1_path = temp_account_credentials_files["account1"]
 
         credentials = [{"type": "json", "path": account1_path, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -362,13 +362,13 @@ class TestAccountSystemFullFlow:
 
         # Arrange
         creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         account1_path = temp_account_credentials_files["account1"]
 
         credentials = [{"type": "json", "path": account1_path, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         # First manager instance
@@ -433,13 +433,13 @@ class TestAccountSystemFullFlow:
 
         # Arrange
         creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         account1_path = temp_account_credentials_files["account1"]
 
         credentials = [{"type": "json", "path": account1_path, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -761,6 +761,7 @@ class TestFailoverAttributionThroughTheRoute:
         with open(credentials, "w") as handle:
             json_module.dump(entries, handle)
         from tests.conftest import seed_account_sources
+
         seed_account_sources(entries)
 
         manager = AccountManager()

--- a/tests/unit/test_account_manager.py
+++ b/tests/unit/test_account_manager.py
@@ -109,6 +109,7 @@ class TestAccountManagerLoadCredentials:
         credentials = [{"type": "json", "path": str(test_json), "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -138,6 +139,7 @@ class TestAccountManagerLoadCredentials:
         credentials = [{"type": "sqlite", "path": temp_sqlite_db, "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -174,6 +176,7 @@ class TestAccountManagerLoadCredentials:
         ]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         # Create state file to avoid errors
@@ -223,6 +226,7 @@ class TestAccountManagerLoadCredentials:
         credentials = [{"type": "json", "path": str(folder), "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -267,6 +271,7 @@ class TestAccountManagerLoadCredentials:
         credentials = [{"type": "json", "path": str(folder), "enabled": True}]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -305,6 +310,7 @@ class TestAccountManagerLoadCredentials:
         ]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -338,6 +344,7 @@ class TestAccountManagerLoadCredentials:
         ]
         creds_file.write_text(json.dumps(credentials))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(credentials)
 
         manager = AccountManager()
@@ -426,6 +433,7 @@ class TestAccountManagerLoadCredentials:
 
         # Arrange
         from tests.conftest import seed_account_sources
+
         seed_account_sources([])
         manager = AccountManager()
 
@@ -457,8 +465,10 @@ class TestAccountManagerLoadState:
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(sample_state_with_data))
         from kiro.store import save_runtime_state
+
         save_runtime_state(sample_state_with_data, ungated=True)
         from kiro.store import save_runtime_state
+
         save_runtime_state(sample_state_with_data, ungated=True)
 
         # Create accounts first
@@ -468,6 +478,7 @@ class TestAccountManagerLoadState:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -499,6 +510,7 @@ class TestAccountManagerLoadState:
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data))
         from kiro.store import save_runtime_state
+
         save_runtime_state(state_data, ungated=True)
 
         manager = AccountManager()
@@ -531,6 +543,7 @@ class TestAccountManagerLoadState:
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data))
         from kiro.store import save_runtime_state
+
         save_runtime_state(state_data, ungated=True)
 
         manager = AccountManager()
@@ -576,11 +589,13 @@ class TestAccountManagerLoadState:
         state_file = tmp_path / "state.json"
         state_file.write_text(json.dumps(state_data))
         from kiro.store import save_runtime_state
+
         save_runtime_state(state_data, ungated=True)
 
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -717,6 +732,7 @@ class TestAccountManagerInitializeAccount:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -765,6 +781,7 @@ class TestAccountManagerInitializeAccount:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -814,6 +831,7 @@ class TestAccountManagerGetNextAccount:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -1148,7 +1166,6 @@ class TestAccountManagerQuotaExclusion:
         """
         print("\n=== Test: quarantine is persisted across restart ===")
 
-        creds_file = tmp_path / "credentials.json"
         state_file = tmp_path / "state.json"
         account_id = "/creds/account0.json"
 
@@ -1334,6 +1351,7 @@ class TestAccountManagerReportSuccess:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -1384,6 +1402,7 @@ class TestAccountManagerReportSuccess:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -1439,6 +1458,7 @@ class TestAccountManagerReportFailure:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -1486,6 +1506,7 @@ class TestAccountManagerReportFailure:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -1584,6 +1605,7 @@ class TestAccountManagerGetFirstAccount:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()
@@ -1654,6 +1676,7 @@ class TestAccountManagerGetAllAvailableModels:
         creds_file = tmp_path / "credentials.json"
         creds_file.write_text(json.dumps([{"type": "json", "path": str(test_json), "enabled": True}]))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(json.loads(creds_file.read_text()))
 
         manager = AccountManager()

--- a/tests/unit/test_account_suspension.py
+++ b/tests/unit/test_account_suspension.py
@@ -288,6 +288,7 @@ class TestSuspensionDetectedAtInitialization:
         entries = [{"type": "json", "path": str(creds)}]
         pool.write_text(json_module.dumps(entries))
         from tests.conftest import seed_account_sources
+
         seed_account_sources(entries)
         mgr = AccountManager()
         mgr._save_state = AsyncMock()
@@ -454,7 +455,6 @@ class TestSuspensionPersistence:
 
         from kiro.store import load_runtime_state
 
-        state_file = tmp_path / "state.json"
         mgr = AccountManager()
         account = _account()
         account.suspended_until = time.time() + 3600

--- a/tests/unit/test_accounts_admin.py
+++ b/tests/unit/test_accounts_admin.py
@@ -169,6 +169,7 @@ def test_imports_legacy_recovery_record_once(tmp_path):
     )
 
     from tests.conftest import seed_account_sources
+
     seed_account_sources([])  # clear the default mock seed
     assert store.import_legacy_files("missing.json", "missing-state.json", str(recovery)) is True
     assert store.load_account_sources() == original_entries

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -2735,4 +2735,3 @@ class TestAPIRegionAutoDetectionJSON:
         print("Verification: API hosts use custom default region...")
         print(f"api_host: {manager._api_host}")
         assert "ap-south-1" in manager._api_host
-

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -885,8 +885,6 @@ class TestWebSearchConfig:
 class TestAccountSystemConfig:
     """Tests for Account System configuration constants."""
 
-
-
     def test_account_recovery_timeout_default(self, monkeypatch):
         """
         What it does: Verifies ACCOUNT_RECOVERY_TIMEOUT defaults to 60 seconds.

--- a/tests/unit/test_main_lifespan.py
+++ b/tests/unit/test_main_lifespan.py
@@ -11,17 +11,13 @@ Tests cover:
 """
 
 import asyncio
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kiro.store import load_account_sources
-
 # =============================================================================
 # Test Class: Legacy Fallback (Migration)
 # =============================================================================
-
 
 
 class TestLifespanAccountManagerInit:
@@ -43,9 +39,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 97: Create AccountManager with correct paths ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         # Track AccountManager creation
         manager_created_with = {}
@@ -104,9 +97,6 @@ class TestLifespanAccountManagerInit:
 
         # Arrange: Patch constants
 
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
-
         load_calls = {"credentials": False, "state": False}
 
         mock_manager = AsyncMock()
@@ -146,7 +136,6 @@ class TestLifespanAccountManagerInit:
         print("✓ load_credentials() and load_state() were called")
 
     @pytest.mark.asyncio
-
     async def test_lifespan_initialize_first_working_account(self, tmp_path, monkeypatch):
         """
         Test 100: Инициализация первого рабочего аккаунта
@@ -157,9 +146,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 100: Initialize first working account ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         initialized_accounts = []
 
@@ -206,9 +192,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 101: Full circle initialization attempt ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         initialized_attempts = []
 
@@ -258,9 +241,6 @@ class TestLifespanAccountManagerInit:
 
         # Arrange: Patch constants
 
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
-
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
         mock_manager.drain_unsaved_rate_observations = MagicMock(return_value=[])
@@ -289,9 +269,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 103: RuntimeError if all accounts failed ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         mock_manager = AsyncMock()
         mock_manager.load_rate_observations = MagicMock()
@@ -322,9 +299,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 104: Save initial state ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         save_state_called = False
 
@@ -371,9 +345,6 @@ class TestLifespanAccountManagerInit:
 
         # Arrange: Patch constants
 
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
-
         periodic_task_started = False
 
         mock_manager = AsyncMock()
@@ -417,9 +388,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 106: Cancel background task on shutdown ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         task_cancelled = False
 
@@ -470,9 +438,6 @@ class TestLifespanAccountManagerInit:
         print("\n=== Test 107: Final save on shutdown ===")
 
         # Arrange: Patch constants
-
-        creds_file = tmp_path / "credentials.json"
-        state_file = tmp_path / "state.json"
 
         save_calls = []
 

--- a/tests/unit/test_routes_anthropic.py
+++ b/tests/unit/test_routes_anthropic.py
@@ -9,7 +9,6 @@ Tests the following endpoint:
 For OpenAI API tests, see test_routes_openai.py.
 """
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1429,7 +1428,6 @@ class TestMessagesFailoverLoop:
 
         assert attempts == MAX_ATTEMPTS
         print("✅ MAX_ATTEMPTS prevents infinite loops")
-
 
 
 class TestMessagesNativeWebSearchAccountSelection:

--- a/tests/unit/test_routes_openai.py
+++ b/tests/unit/test_routes_openai.py
@@ -1305,6 +1305,8 @@ class TestChatCompletionsFailoverLoop:
 
         assert attempts == MAX_ATTEMPTS
         print("✅ MAX_ATTEMPTS correctly limits failover loop")
+
+
 class TestModelsEndpointMetadata:
     """The model list must carry usable, truthful metadata for both SDKs.
 


### PR DESCRIPTION
## Why

The **Lint, Format, Typecheck** job has been red on main since before #26/#27 merged: `ruff format --check` rejected 14 files, so `ruff check`, `mypy`, and all frontend steps were skipped. #26 and #27 inherited that failure without adding violations (verified by diffing per-file violation lists against main).

## What

- `ruff format` (pinned 0.16.0) across `main.py`, `tests/conftest.py`, and 9 test modules
- remove unused imports (F401): `json` in two test modules, `load_account_sources`
- remove unused `creds_file`/`state_file` bindings (F841) in lifespan/flow/suspension tests — pure `tmp_path / "..."` constructions with no side effects, statements deleted outright

No behavior change; test count unchanged.

## Verification

- `ruff format --check .` — 119 files clean
- `ruff check .` — all checks passed
- `mypy` — no issues in 42 source files
- `pytest` — 2049 passed (4 known local-env-only failures reproduce identically on pristine main and pass in CI)
- `cd frontend && bun run lint && bun run typecheck && bun run test` — eslint clean, tsc clean, 94 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the Quality CI job by fixing `ruff` format and lint failures. Previously `ruff format --check` and `ruff check` failed on main, which skipped `mypy` and frontend checks; now these issues are resolved with no behavior changes.

**Refactors**
- Applied `ruff` formatting to `main.py`, `tests/conftest.py`, and 9 test modules.
- Removed unused imports (F401) and unused tmp_path variables (F841) in tests.
- Cleaned up no-op statements and trivial style issues to satisfy `ruff` 0.16.0 without altering test logic.

<sup>Written for commit 4578f8a1dfee46d94bc2eec8c1be54e462792f65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

