### PR TITLE
fix: resolve actionable Trivy findings and stop shipping data/ in the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,6 +54,10 @@ pytest.ini
 # Debug logs (will be created at runtime)
 debug_logs/
 
+# Private runtime state — the unified store holds account credentials and
+# refresh tokens; baking it into an image leaks every pool account.
+data/
+
 # Manual test script
 manual_api_test.py
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -155,6 +155,12 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # SARIF output ignores the severity filter unless this is set, which is
+          # how 137 low/medium Debian will-not-fix CVEs flooded code scanning.
+          limit-severities-for-sarif: true
+          # Debian ships no fix for most base-image CVEs; only actionable
+          # findings belong in the report.
+          ignore-unfixed: true
           exit-code: '0'  # Don't fail build, just report
       
       - name: Upload Trivy results to GitHub Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     TIKTOKEN_CACHE_DIR=/opt/tiktoken-cache
 
+# Pull in Debian security updates the base image tag lags behind
+# (e.g. the util-linux TOCTOU/SUID fixes in 2.41.5-0+deb13u1).
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for security
 RUN groupadd -r kiro && useradd -r -g kiro kiro
 
@@ -17,9 +23,13 @@ RUN groupadd -r kiro && useradd -r -g kiro kiro
 WORKDIR /app
 RUN chown kiro:kiro /app
 
-# Install dependencies first (better layer caching)
+# Install dependencies first (better layer caching).
+# The pip/setuptools/wheel bundled with the base image lag behind and carry
+# known CVEs (Trivy flags the vendored copies under setuptools/_vendor too),
+# so upgrade the packaging toolchain before installing anything with it.
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir -r requirements.txt
 
 # Bake the tiktoken vocabularies into the image. tiktoken ships no BPE data: it
 # downloads it from openaipublic.blob.core.windows.net on first use and caches it


### PR DESCRIPTION
## Why

[Code scanning](https://github.com/minpeter/kiro-lb/security/code-scanning) holds 137 open Trivy alerts against the Docker image. Triage over the full set:

| Group | Count | Action |
|---|---|---|
| Bundled pip 23.0.1 / setuptools 79 (+ vendored wheel, jaraco.context) | 9 (2 critical/high) | **Fixed** — upgrade packaging toolchain in the build |
| util-linux CVE-2026-53612..53615, fixed in Debian `2.41.5-0+deb13u1` | 34 HIGH (per local rescan) | **Fixed** — `apt-get upgrade` in the build |
| Debian will-not-fix / no patched version (glibc, perl-base, coreutils, …) | ~120 | **Filtered** — `ignore-unfixed`; nothing to act on |
| Vendored inside pip 26.2.1 itself (msgpack 1.1.2, setuptools 70.3.0 metadata) | 2 HIGH | **Left open** — only a pip release fixes these |

The flood happened because `trivy-action` ignores `severity:` for SARIF output unless `limit-severities-for-sarif: true` is set, so low/medium will-not-fix CVEs were uploaded despite the CRITICAL,HIGH filter.

## Also found: credential leak path

`.dockerignore` excluded `debug_logs/` but **not `data/`**. A locally built image baked the unified store into `/app/data` — `credentials.json`, `dashboard.sqlite3` (refresh tokens), `logins/*.json`. CI builds from a clean checkout so published images never leaked; the risk was any locally built-and-pushed image. `data/` is now excluded and the existing runtime `mkdir -p data` keeps the directory available.

## Verification

- Local build + `trivy image --severity CRITICAL,HIGH --ignore-unfixed`: **0 debian, 0 node-pkg** findings; only the 2 pip-vendored HIGHs remain
- `/app/data` empty in the built image; `import kiro.*` + tiktoken cache smoke pass
- Expected effect on next main push: the docker-image SARIF upload shrinks to ~2 actionable alerts and GitHub auto-closes the rest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes actionable Trivy alerts and stops bundling `data/` into the Docker image. This closes a local-build credential leak path and limits code scanning to actionable CRITICAL/HIGH items.

**Bug Fixes**
- Previously SARIF uploads included low/medium issues; now `trivy-action` sets `limit-severities-for-sarif: true` and `ignore-unfixed: true` so only actionable CRITICAL/HIGH appear.
- Previously local images could include `/app/data`; now `.dockerignore` excludes `data/` and the app creates the directory at runtime.
- Expected result: code scanning shows only two remaining HIGHs vendored in `pip`.

**Dependencies**
- The image now runs `apt-get upgrade` to pull Debian security updates (e.g., util-linux fixes).
- The build upgrades `pip`, `setuptools`, and `wheel` before installing requirements to remove CVEs in the bundled toolchain.

<sup>Written for commit 3a6ce49efcb29239f332c8eac29a66592f4d6c81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

