### PR TITLE
fix: fail over on transient gateway errors

### DIFF
--- a/kiro/account_errors.py
+++ b/kiro/account_errors.py
@@ -82,12 +82,13 @@ def classify_error(status_code: int, reason: Optional[str]) -> ErrorType:
     - 402: Payment required (monthly quota exceeded, billing issues)
     - 403: Token expired/invalid
     - 429: Rate limit exceeded
+    - 502/503/504: Transient upstream gateway failures
 
     FATAL errors (return to client immediately):
     - 400 + CONTENT_LENGTH_EXCEEDS_THRESHOLD: Context overflow
     - 400 + other/null reason: Malformed request
     - 422: Validation error
-    - 5xx: Kiro API server error
+    - Other 5xx: Kiro API server error
 
     Args:
         status_code: HTTP status code from Kiro API
@@ -152,9 +153,13 @@ def classify_error(status_code: int, reason: Optional[str]) -> ErrorType:
     if status_code == 422:
         return ErrorType.FATAL
 
-    # FATAL: Server errors (5xx)
-    # Note: 503 could be temporary, but we classify as FATAL for simplicity
-    # Retrying on different accounts won't help if Kiro API is down
+    # RECOVERABLE: Transient upstream gateway failures. The HTTP client has
+    # already exhausted bounded same-account retries, so let the route try a
+    # different account before returning the gateway error to the caller.
+    if status_code in (502, 503, 504):
+        return ErrorType.RECOVERABLE
+
+    # FATAL: Other server errors (5xx)
     if 500 <= status_code < 600:
         return ErrorType.FATAL
 

--- a/tests/integration/test_account_system_flow.py
+++ b/tests/integration/test_account_system_flow.py
@@ -14,6 +14,7 @@ Tests cover:
 
 import json
 import time
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +23,7 @@ from fastapi import HTTPException
 from kiro.account_errors import ErrorType
 from kiro.account_manager import Account, AccountManager, account_label
 from kiro.config import ACCOUNT_RECOVERY_TIMEOUT
+from kiro.usage_tracking import current_account_id
 
 # =============================================================================
 # Integration Tests: Full Failover Flow
@@ -849,3 +851,113 @@ class TestFailoverAttributionThroughTheRoute:
         finally:
             drain_pending_usage()
             current_account_id.set(None)
+
+
+def _transient_gateway_manager(account_a, account_b):
+    manager = MagicMock()
+    manager._accounts = {account_a.id: account_a, account_b.id: account_b}
+    manager.get_next_account = AsyncMock(side_effect=[account_a, account_b])
+    manager.report_failure = AsyncMock()
+    manager.report_success = AsyncMock()
+    return manager
+
+
+def _transient_gateway_responses(mock_httpx_response):
+    from tests.conftest import create_kiro_content_chunk, create_kiro_context_usage_chunk
+
+    failure = mock_httpx_response(status_code=502, text='{"message":"transient bad gateway"}')
+    success = mock_httpx_response(
+        status_code=200,
+        stream_chunks=[
+            create_kiro_content_chunk("recovered"),
+            create_kiro_context_usage_chunk(0.01),
+        ],
+    )
+    return failure, success
+
+
+def test_openai_502_fails_over_to_next_account(monkeypatch, mock_account, mock_httpx_response):
+    """A bodyless upstream 502 should fail over before OpenAI output starts."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from kiro import routes_openai
+
+    account_a = replace(mock_account, id="account-a")
+    account_b = replace(mock_account, id="account-b")
+    manager = _transient_gateway_manager(account_a, account_b)
+    failure, success = _transient_gateway_responses(mock_httpx_response)
+    attempts: list[str] = []
+
+    async def request_with_retry(self, *args, **kwargs):
+        account_id = current_account_id.get()
+        assert account_id is not None
+        attempts.append(account_id)
+        return failure if len(attempts) == 1 else success
+
+    monkeypatch.setattr(routes_openai.KiroHttpClient, "request_with_retry", request_with_retry)
+    app = FastAPI()
+    app.include_router(routes_openai.router)
+    app.state.account_manager = manager
+    app.state.http_client = MagicMock()
+    app.dependency_overrides[routes_openai.verify_api_key] = lambda: True
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "claude-sonnet-4.5",
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": False,
+                },
+            )
+
+        assert (response.status_code, attempts) == (200, ["account-a", "account-b"])
+        assert response.json()["choices"][0]["message"]["content"] == "recovered"
+    finally:
+        current_account_id.set(None)
+
+
+def test_anthropic_502_fails_over_to_next_account(monkeypatch, mock_account, mock_httpx_response):
+    """A bodyless upstream 502 should fail over before Anthropic output starts."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from kiro import routes_anthropic
+
+    account_a = replace(mock_account, id="account-a")
+    account_b = replace(mock_account, id="account-b")
+    manager = _transient_gateway_manager(account_a, account_b)
+    failure, success = _transient_gateway_responses(mock_httpx_response)
+    attempts: list[str] = []
+
+    async def request_with_retry(self, *args, **kwargs):
+        account_id = current_account_id.get()
+        assert account_id is not None
+        attempts.append(account_id)
+        return failure if len(attempts) == 1 else success
+
+    monkeypatch.setattr(routes_anthropic.KiroHttpClient, "request_with_retry", request_with_retry)
+    app = FastAPI()
+    app.include_router(routes_anthropic.router)
+    app.state.account_manager = manager
+    app.state.http_client = MagicMock()
+    app.dependency_overrides[routes_anthropic.verify_anthropic_api_key] = lambda: True
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/messages",
+                json={
+                    "model": "claude-sonnet-4.5",
+                    "max_tokens": 32,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": False,
+                },
+            )
+
+        assert (response.status_code, attempts) == (200, ["account-a", "account-b"])
+        assert response.json()["content"] == [{"type": "text", "text": "recovered"}]
+    finally:
+        current_account_id.set(None)

--- a/tests/unit/test_account_errors.py
+++ b/tests/unit/test_account_errors.py
@@ -11,6 +11,12 @@ Tests the classify_error() function that determines whether an error is:
 from kiro.account_errors import ErrorType, classify_error
 
 
+def test_transient_gateway_statuses_are_recoverable():
+    """Transient gateway responses should fail over after local retries."""
+    for status_code in (502, 503, 504):
+        assert classify_error(status_code, None) is ErrorType.RECOVERABLE
+
+
 class TestClassifyErrorRecoverable:
     """
     Tests for RECOVERABLE errors (account-specific issues).
@@ -170,21 +176,21 @@ class TestClassifyErrorFatal:
         print(f"Classification result: {result}")
         assert result == ErrorType.FATAL, "500 should be FATAL (server error)"
 
-    def test_classify_error_503_fatal(self):
+    def test_classify_error_501_fatal(self):
         """
-        Test that 503 (service unavailable) is FATAL.
+        Test that 501 (not implemented) is FATAL.
 
-        What it does: Verifies 503 status code classification
-        Purpose: Service unavailable affects all accounts
+        What it does: Verifies non-gateway 5xx classification
+        Purpose: Non-transient server errors should not replay across accounts
         """
-        print("\n=== Test: 503 Service Unavailable → FATAL ===")
+        print("\n=== Test: 501 Not Implemented → FATAL ===")
 
         # Act
-        result = classify_error(status_code=503, reason=None)
+        result = classify_error(status_code=501, reason=None)
 
         # Assert
         print(f"Classification result: {result}")
-        assert result == ErrorType.FATAL, "503 should be FATAL (service unavailable)"
+        assert result == ErrorType.FATAL, "501 should be FATAL (not implemented)"
 
 
 class TestClassifyErrorEdgeCases:
@@ -270,16 +276,16 @@ class TestClassifyErrorComprehensive:
             print(f"Status {code}: {result}")
             assert result == ErrorType.RECOVERABLE, f"{code} should be RECOVERABLE"
 
-    def test_all_fatal_5xx_codes(self):
+    def test_non_gateway_5xx_codes_fatal(self):
         """
-        Test that all 5xx codes are FATAL.
+        Test that non-gateway 5xx codes are FATAL.
 
-        What it does: Batch verification of server error codes
-        Purpose: Ensure all server errors are classified as FATAL
+        What it does: Batch verification of non-transient server error codes
+        Purpose: Ensure unrelated server errors are not replayed across accounts
         """
-        print("\n=== Test: All 5xx codes → FATAL ===")
+        print("\n=== Test: Non-gateway 5xx codes → FATAL ===")
 
-        server_error_codes = [500, 501, 502, 503, 504, 505]
+        server_error_codes = [500, 501, 505]
 
         for code in server_error_codes:
             result = classify_error(code, None)


### PR DESCRIPTION
## Outcome
- fail over to another account after bounded same-account retries exhaust HTTP 502/503/504
- preserve malformed-request and non-gateway 5xx behavior
- cover OpenAI and Anthropic non-streaming routes with deterministic A=502 to B=200 tests

## Verification
- RED: classification, OpenAI, and Anthropic tests each failed on the old policy
- GREEN: 3 focused contracts passed
- retry/classification/route suites: 79 passed
- full pytest: 2061 passed
- ruff format/check: passed
- mypy: passed
- live curl QA: both /v1/chat/completions and /v1/messages returned 200 after attempts account-a,account-b


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes 502/503/504 from fatal to recoverable errors so requests fail over to another account after same-account retries exhaust. Non-gateway 5xx still return the error to the caller. Adds integration tests for OpenAI and Anthropic non-streaming routes.

<sup>Written for commit 8bd4bd41b4f63423d6dd48a752394058cba4cef7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

