### PR TITLE
chore: 의존성·CI 액션 위생 점검 후 안전한 항목만 반영

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -66,10 +66,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -77,7 +77,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -r requirements-dev.txt
       
       - name: Run tests with pytest
         run: |
@@ -86,12 +86,11 @@ jobs:
       - name: Generate coverage report
         if: success()
         run: |
-          pip install pytest-cov
           pytest --cov=kiro --cov-report=xml --cov-report=term
       
       - name: Upload coverage to artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.xml
@@ -107,14 +106,14 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -122,7 +121,7 @@ jobs:
       
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -139,7 +138,7 @@ jobs:
           echo "Cleaned up test artifacts (credentials.json, state.json)"
       
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false
@@ -149,7 +148,7 @@ jobs:
           cache-to: type=gha,mode=max
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: kiro-gateway:test
           format: 'sarif'
@@ -164,7 +163,7 @@ jobs:
           exit-code: '0'  # Don't fail build, just report
       
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()  # Upload even if previous step fails
         # Reporting only, like the scanner's own exit-code: 0. Code scanning
         # ingestion needs Advanced Security, which this private repo lacks, and a
@@ -212,7 +211,7 @@ jobs:
       
       - name: Build and push Docker image
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64  # Multi-arch support (x86_64 and ARM64)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 # Quality gates. Pinned so a tool release cannot turn CI red on its own.
-ruff==0.16.0
-mypy==1.19.0
-pytest-cov==7.0.0
+ruff==0.16.5
+mypy==1.20.2
+pytest-cov==7.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 # Quality gates. Pinned so a tool release cannot turn CI red on its own.
 ruff==0.16.5
-mypy==1.20.2
+mypy==1.19.1
 pytest-cov==7.1.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
런타임 동작은 바꾸지 않고, 이미 쓰는 품질 도구 핀과 CI 액션만 현재 지원 버전으로 올렸습니다.

## 무엇을 조사했는지

이 저장소는 **pip + `requirements.txt` / `requirements-dev.txt`** 입니다. `pyproject.toml`은 ruff/mypy 설정만 있고 패키징하지 않습니다. 프론트엔드는 **Bun 1.3.7 + `bun.lock`**. Dependabot/Renovate, pre-commit, Poetry, pip-tools는 없습니다.

| 영역 | 현재 | 판단 |
|---|---|---|
| 런타임 Python | `requirements.txt` 무핀 (fastapi, httpx, tiktoken 등) | 정책 유지. 빌드 시점 최신을 받는 구조 |
| 품질 도구 | `requirements-dev.txt`에 핀 | **패치만 올림. mypy 1.20+/2.x는 보류** |
| `uv.lock` | `requires-python >= 3.14`인 빈 스텁 | **삭제** (CI/Docker/문서가 쓰지 않음) |
| Docker | `python:3.10-slim` | **보류** (제품 결정) |
| CI 액션 | v3/v4/v5 + `trivy-action@master` | **지원 메이저로 이동, Trivy는 릴리스 핀** |
| 프론트엔드 | caret + `bun.lock`, Bun 1.3.7 | **보류** (1.4 / 패키지 일괄 갱신은 제품 결정) |

## 이번 PR에서 올린 것

- `ruff` 0.16.0 → **0.16.5** (같은 마이너 패치)
- `mypy` 1.19.0 → **1.19.1** (1.19 패치. 1.20.2는 기존 타입체크를 깨서 되돌림)
- `pytest-cov` 7.0.0 → **7.1.0**
- test job이 `pytest-cov`를 무핀으로 설치하던 부분을 `requirements-dev.txt` 핀을 쓰도록 맞춤
- GitHub Actions: `checkout`/`setup-python`/`upload-artifact` **v7**, Docker 액션 **v4/v6/v7**, CodeQL upload-sarif **v4**
- `aquasecurity/trivy-action@master` → **`@v0.36.0`** (`@master`는 스캔 결과가 매번 흔들림)
- 사용하지 않는 `uv.lock` 스텁 삭제

워크플로 입력(`python-version`, `cache: pip`, buildx/login/metadata 인자)은 그대로입니다. 이 repo는 `pull_request`만 쓰므로 checkout v7의 fork `pull_request_target` 기본 거부와는 무관합니다.

## 의도적으로 보류한 것

- **Python 3.10 → 3.11+**: Dockerfile / CI / ruff·mypy `target-version`이 모두 3.10. 보안 지원은 2026-10-04에 끝나므로 별도 결정이 필요합니다.
- **mypy 1.20.2 / 2.3.x**: 1.20.2가 `kiro/kiro_errors.py`에서 `KiroErrorInfo.reason`에 `str | None`을 넘긴다고 실패합니다. 타입 게이트를 고치는 작업은 이 PR 밖입니다. 2.x는 메이저입니다.
- **런타임 패키지 핀 / uv·pip-tools 도입**: 지금 정책과 다릅니다.
- **Bun 1.4.0**, 프론트엔드 일괄 업, **HAProxy 3.2** 이미지 태그: 대시보드/엣지 동작 검증이 필요합니다.
- **Dependabot/Renovate**: 프로세스 추가라 이번 범위 밖입니다.

## 검증

로컬(Python 3.12, 도구만 핀 버전):

- `ruff format --check --diff .` — 통과
- `ruff check .` — 통과
- `mypy` (1.19.1) — 통과
- `pytest -q` — **2061 passed**

프론트엔드 lint/typecheck/test와 Docker 빌드/Trivy는 GitHub Actions `quality` / `build` job에 맡겼습니다. 새 테스트 스택은 넣지 않았습니다.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c44bb34-7150-4425-be78-4a6b85ff299e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c44bb34-7150-4425-be78-4a6b85ff299e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pinned quality tools and CI actions to currently supported versions without changing runtime behavior, and drops the unused `uv.lock` stub that claimed Python 3.14.

**Dependencies**
- Bumps `ruff` to 0.16.5 and `pytest-cov` to 7.1.0 in `requirements-dev.txt`.
- Keeps `mypy` at 1.19.1 because 1.20.2 fails the current typecheck; that failure is left for a dedicated type-gate change.
- The test job now installs `requirements-dev.txt` instead of a separate unpinned `pytest-cov`.
- CI actions move to supported majors: `actions/checkout`, `setup-python`, and `upload-artifact` v7, Docker actions v4/v6/v7, and `github/codeql-action/upload-sarif` v4; workflow inputs are unchanged.
- `aquasecurity/trivy-action` pins to `@v0.36.0` instead of `@master` so scan results stop drifting.
- This repo only triggers on `pull_request`, so checkout v7's stricter fork behavior does not apply.

**Deferred**
- Python 3.10 stays (EOL October 2026) and needs a separate decision.
- mypy 2.x, runtime package pins, Bun 1.4 plus frontend bulk update, and Dependabot/Renovate are intentionally held back.

<sup>Written for commit b093a13ddb1baae06b8e24fe1534e89cb151c2c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

