### PR TITLE
chore: #33에서 보류한 런타임·도구 업그레이드 완료

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v7
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.7'
+          bun-version: '1.4.0'
 
       - name: Install frontend dependencies
         working-directory: frontend
@@ -68,10 +68,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v7
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
       
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 `kiro-lb` is a FastAPI gateway that exposes Kiro (Amazon Q Developer /
 CodeWhisperer) through OpenAI- and Anthropic-compatible APIs, load balances
 across a pool of Kiro accounts, and ships a React operations dashboard.
-Python 3.10 (`Dockerfile`, CI), httpx, loguru, tiktoken. **AGPL-3.0** — based on
+Python 3.12 (`Dockerfile`, CI), httpx, loguru, tiktoken. **AGPL-3.0** — based on
 `jwadow/kiro-gateway`; see `LICENSE` and `NOTICE.md` (do not relicense).
 
 ## STRUCTURE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # kiro-lb - Docker Image
 # Optimized single-stage build
 
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/docker-compose.homelab.yml
+++ b/docker-compose.homelab.yml
@@ -52,7 +52,7 @@ x-kiro-app: &kiro-app
 
 services:
   edge:
-    image: haproxy:3.2-alpine
+    image: haproxy:3.4-alpine
     container_name: kiro-lb-edge
     ports:
       - "10.10.10.10:8000:8000"

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -21,7 +21,7 @@ all wrong; trust `vite.config.ts` and `package.json`.
 
 ## CONVENTIONS
 
-- Package manager is Bun 1.3.7 (`packageManager` in `package.json`). Do not
+- Package manager is Bun 1.4.0 (`packageManager` in `package.json`). Do not
   introduce npm or pnpm lockfiles.
 - `bun run build` runs `tsc -b` first; type errors block the build by design.
   CI also runs `bun run lint` and `bun run typecheck` in the `quality` job.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,7 @@ This frontend is built with Bun, Vite, React, TypeScript, and SWC.
 
 ## Prerequisites
 
-- Bun 1.3+
+- Bun 1.4+
 
 ## Setup
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "packageManager": "bun@1.3.7",
+  "packageManager": "bun@1.4.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -307,7 +307,7 @@ class KiroAuthManager:
                             # Handle various ISO 8601 formats
                             if expires_str.endswith("Z"):
                                 expires_str = expires_str.replace("Z", "+00:00")
-                            # Python 3.10 fromisoformat supports max 6 decimal places (microseconds)
+                            # fromisoformat supports max 6 decimal places (microseconds)
                             # kiro-cli writes nanoseconds (9 digits) — truncate to 6
                             expires_str = re.sub(r"(\.\d{6})\d+", r"\1", expires_str)
                             self._expires_at = datetime.fromisoformat(expires_str)

--- a/kiro/kiro_errors.py
+++ b/kiro/kiro_errors.py
@@ -117,15 +117,14 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
         >>> print(error_info.user_message)
         "Something went wrong. (reason: UNKNOWN_REASON)"
     """
-    # Extract original message and reason from Kiro API response
-    # Handle None values explicitly (preserve empty strings)
-    original_message = error_json.get("message")
-    if original_message is None:
-        original_message = "Unknown error"
+    # Extract original message and reason from Kiro API response.
+    # Dict.get() is Any | None; coerce to str so KiroErrorInfo.reason stays str
+    # (mypy 1.20+ no longer treats Any | None as Any). Empty strings are kept.
+    extracted_message = error_json.get("message")
+    original_message: str = extracted_message if isinstance(extracted_message, str) else "Unknown error"
 
-    reason = error_json.get("reason")
-    if reason is None:
-        reason = "UNKNOWN"
+    extracted_reason = error_json.get("reason")
+    reason: str = extracted_reason if isinstance(extracted_reason, str) else "UNKNOWN"
 
     # A suspension may arrive with no reason code (legacy host), so it has to be
     # recognized from the message too before the generic branches collapse it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 # requirements.txt, quality-gate deps in requirements-dev.txt.
 
 [tool.ruff]
-# CI and the Docker image run 3.10, which is older than a typical dev machine.
-target-version = "py310"
+# CI and the Docker image run 3.12.
+target-version = "py312"
 line-length = 120
 extend-exclude = ["kiro/static", "frontend"]
 
@@ -18,7 +18,7 @@ select = ["E4", "E7", "E9", "F", "I", "W"]
 "kiro/__init__.py" = ["F401"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 files = ["kiro", "main.py"]
 ignore_missing_imports = true
 warn_redundant_casts = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 # Quality gates. Pinned so a tool release cannot turn CI red on its own.
 ruff==0.16.5
-mypy==1.19.1
+mypy==2.3.1
 pytest-cov==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Prod dependencies
-fastapi
-uvicorn[standard]
-httpx
-loguru
-python-dotenv
-tiktoken
+fastapi==0.141.1
+uvicorn[standard]==0.52.4
+httpx==0.28.1
+loguru==0.7.3
+python-dotenv==1.2.3
+tiktoken==0.14.0
 
 # Testing dependencies
-pytest
-pytest-asyncio
-hypothesis
+pytest==9.1.1
+pytest-asyncio==1.4.0
+hypothesis==6.165.10


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#33에서 의도적으로 보류한 항목을 조사한 뒤, 업그레이드에 필요한 변경만 반영했습니다. 프록시 런타임 동작은 의존성/런타임 버전 변경 외에 그대로입니다.

## 무엇을 조사했는지

| 영역 | #33 당시 | 이번 PR에서 확인한 현재 지원 버전 |
|---|---|---|
| Python | `python:3.10-slim` / CI 3.10 / ruff·mypy `py310` | 3.10 보안 지원 종료 2026-10-04. 저장소에 3.12를 막는 코드는 없음. 3.13/3.14는 올리지 않음 |
| mypy | 1.19.1 (1.20.2가 `KiroErrorInfo.reason`에서 실패) | 재현: `kiro/kiro_errors.py:177` `Argument "reason" ... "str \| Any \| None"; expected "str"`. 추출을 `str`로 고정한 뒤 **2.3.1**까지 통과 |
| 런타임 핀 | `requirements.txt` 무핀 | 각 패키지 PyPI 최신을 설치·pytest로 확인 후 핀. Poetry/uv/pip-tools는 도입하지 않음 |
| Bun | 1.3.7 + `bun.lock` | GitHub 최신 안정 **1.4.0**. `bun install`로 lockfile 재확인 (lockfileVersion 1, 패키지 버전 변동 없음) |
| HAProxy | `haproxy:3.2-alpine` | Docker Hub 현재 3.x LTS는 **3.4** (`3.4-alpine` → 3.4.4, 2026-08-28). 설정 파일은 그대로 |

이 저장소는 패키징하지 않아 classifiers/`python_requires`는 없습니다.

## 이번 PR에서 올린 것

**Python 3.10 → 3.12** (한 버전으로 통일)

- `Dockerfile`: `python:3.12-slim`
- CI `python-version`: `3.12`
- ruff `target-version`: `py312`
- mypy `python_version`: `3.12`
- `AGENTS.md` 개요

**mypy 1.19.1 → 2.3.1**

- `error_json.get("message"|"reason")`가 `Any \| None`이라 constructor에 그대로 넘어가던 것을 `isinstance(..., str)`로 `str`에 고정 (빈 문자열은 기존처럼 유지)
- ignore 주석 없음. 전체 `mypy` 통과 (43 files)

**런타임 핀** (`requirements.txt`, 2026-08-29 PyPI 최신, 설치 버전 확인)

- `fastapi==0.141.1`
- `uvicorn[standard]==0.52.4`
- `httpx==0.28.1`
- `loguru==0.7.3`
- `python-dotenv==1.2.3`
- `tiktoken==0.14.0`
- `pytest==9.1.1`
- `pytest-asyncio==1.4.0`
- `hypothesis==6.165.10`

**Bun 1.3.7 → 1.4.0**

- `frontend/package.json` `packageManager`
- CI `bun-version: '1.4.0'`
- `frontend/AGENTS.md`, `frontend/README.md`

**HAProxy `3.2-alpine` → `3.4-alpine`**

- `docker-compose.homelab.yml`만. 템플릿/설정은 변경 없음

## 의도적으로 손대지 않은 것

- Dependabot/Renovate 도입
- 프론트엔드 앱 코드·패키지 caret 일괄 갱신 (`bun install`만)
- HAProxy 설정 (`haproxy-edge.cfg.template`)
- 제품 동작 리팩터

## 패치가 다른 줄을 쓴 경우

없음. Python / mypy / Bun / HAProxy / 런타임 패키지 모두 조사한 현재 지원 버전을 그대로 씀.

## 검증

로컬(Ubuntu 24.04, Python 3.12.3, Bun 1.4.0):

- `ruff format --check --diff .` — 통과 (121 files)
- `ruff check .` — 통과
- `mypy` (2.3.1) — 통과 (43 files). `annotation-unchecked` note는 기존과 동일, 에러 없음
- `pytest -q` — **2061 passed** (1 warning: FastAPI `starlette.testclient`가 `httpx` 대신 `httpx2`를 권고. 테스트 실패 아님)
- frontend `bun run lint` — 통과
- frontend `bun run typecheck` — 통과
- frontend `bun run test` — **138 passed** (16 files)

GitHub Actions (`d221a13`, 전부 성공):

- quality (ruff / mypy / frontend lint·typecheck·test)
- test (pytest)
- build (Docker `python:3.12-slim` 이미지 + Trivy)
- Trivy, GitGuardian

## 남은 제품 결정

없음. #33에서 보류했던 항목은 이 PR에서 처리했습니다. 3.13/3.14, 프론트엔드 패키지 일괄 업, Dependabot은 여전히 범위 밖입니다.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0c2deae-f668-4bd9-bd86-954b3f76b99f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0c2deae-f668-4bd9-bd86-954b3f76b99f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the runtime and tooling upgrades deferred from #33: Python 3.10 → 3.12, mypy 1.19.1 → 2.3.1, Bun 1.3.7 → 1.4.0, HAProxy 3.2-alpine → 3.4-alpine, and pinned all `requirements.txt` packages to their current versions. Proxy runtime behavior is unchanged except for dependency versions.

**Behavior change**

- `KiroErrorInfo` message and reason extraction now coerces values to `str`; non-string values from the Kiro API fall back to `"Unknown error"` / `"UNKNOWN"` instead of being passed through.

<sup>Written for commit d221a13eb2f19f02777cbffe798d363dedfeb023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

