### PR TITLE
perf: stop re-tokenizing the whole payload per trim iteration

### DIFF
--- a/kiro/converters_anthropic.py
+++ b/kiro/converters_anthropic.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from kiro.config import HIDDEN_MODELS, MODEL_ALIASES
 from kiro.converters_core import (
+    KiroPayloadResult,
     UnifiedMessage,
     UnifiedTool,
     build_kiro_payload,
@@ -430,7 +431,9 @@ def split_inline_system_messages(messages: List[Any]) -> tuple[List[Any], List[s
     return conversation, system_fragments
 
 
-def anthropic_to_kiro(request: AnthropicMessagesRequest, conversation_id: str, profile_arn: str) -> dict:
+def anthropic_to_kiro_with_stats(
+    request: AnthropicMessagesRequest, conversation_id: str, profile_arn: str
+) -> KiroPayloadResult:
     """
     Converts Anthropic Messages API request to Kiro API payload.
 
@@ -493,4 +496,9 @@ def anthropic_to_kiro(request: AnthropicMessagesRequest, conversation_id: str, p
         effort_from_anthropic(request.thinking, request.output_config, request.max_tokens),
     )
 
-    return result.payload
+    return result
+
+
+def anthropic_to_kiro(request: AnthropicMessagesRequest, conversation_id: str, profile_arn: str) -> dict:
+    """Return only the payload, preserving the original signature."""
+    return anthropic_to_kiro_with_stats(request, conversation_id, profile_arn).payload

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -25,8 +25,6 @@ from kiro.config import (
 )
 from kiro.payload_guards import (
     PayloadTooLargeError,
-    check_payload_size,
-    check_payload_tokens,
     measure_payload,
     payload_token_limit_for_model,
     trim_payload_to_limit,

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -27,6 +27,7 @@ from kiro.payload_guards import (
     PayloadTooLargeError,
     check_payload_size,
     check_payload_tokens,
+    measure_payload,
     payload_token_limit_for_model,
     trim_payload_to_limit,
 )
@@ -86,10 +87,15 @@ class KiroPayloadResult:
     Attributes:
         payload: The complete Kiro API payload
         tool_documentation: Documentation for tools with long descriptions (to add to system prompt)
+        input_tokens: cl100k tokens of the payload actually sent upstream, already
+            measured by the pre-flight guard. Reusing it avoids a second full
+            tokenization just to fill message_start, and it reflects the payload
+            after trimming instead of the client's pre-trim conversation.
     """
 
     payload: Dict[str, Any]
     tool_documentation: str = ""
+    input_tokens: int = 0
 
 
 # ==================================================================================================
@@ -1402,15 +1408,21 @@ def build_kiro_payload(
     # or fail here with the real numbers. The upstream counts cl100k tokens of
     # the JSON, not UTF-8 bytes; the byte cap is a legacy extra. Trimming is
     # opt-in because it silently discards the oldest turns.
-    payload_tokens = check_payload_tokens(payload)
-    payload_size = check_payload_size(payload)
+    payload_tokens, payload_size = measure_payload(payload)
     token_cap = payload_token_limit_for_model(model_id)
     byte_cap = KIRO_MAX_PAYLOAD_BYTES if KIRO_MAX_PAYLOAD_BYTES > 0 else None
     over_tokens = payload_tokens > token_cap
     over_bytes = byte_cap is not None and payload_size > byte_cap
+    sent_tokens = payload_tokens
     if over_tokens or over_bytes:
         if AUTO_TRIM_PAYLOAD:
-            stats = trim_payload_to_limit(payload, max_bytes=byte_cap, max_tokens=token_cap)
+            stats = trim_payload_to_limit(
+                payload,
+                max_bytes=byte_cap,
+                max_tokens=token_cap,
+                known_tokens=payload_tokens,
+                known_bytes=payload_size,
+            )
             logger.info(
                 f"Trimmed conversation history: {stats.original_entries} -> {stats.final_entries} messages "
                 f"({stats.original_tokens} -> {stats.final_tokens} tokens, "
@@ -1418,6 +1430,7 @@ def build_kiro_payload(
             )
             final_tokens = stats.final_tokens
             final_bytes = stats.final_bytes
+            sent_tokens = final_tokens
             if final_tokens > token_cap:
                 raise PayloadTooLargeError(
                     final_tokens,
@@ -1447,4 +1460,4 @@ def build_kiro_payload(
                 payload_size, KIRO_MAX_PAYLOAD_BYTES, unit="bytes", payload_tokens=payload_tokens
             )
 
-    return KiroPayloadResult(payload=payload, tool_documentation=tool_documentation)
+    return KiroPayloadResult(payload=payload, tool_documentation=tool_documentation, input_tokens=sent_tokens)

--- a/kiro/payload_guards.py
+++ b/kiro/payload_guards.py
@@ -79,6 +79,19 @@ def _payload_json(payload: Dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
+def measure_payload(payload: Dict[str, Any]) -> tuple[int, int]:
+    """Return (tokens, bytes) from a single serialization of the payload.
+
+    check_payload_tokens() and check_payload_size() each serialized the payload
+    independently, so the pre-flight guard paid the dump twice per request.
+    """
+    serialized = _payload_json(payload)
+    from kiro.tokenizer import count_tokens
+
+    tokens = count_tokens(serialized, apply_claude_correction=False, model="claude-haiku-4.5")
+    return tokens, len(serialized.encode("utf-8"))
+
+
 def check_payload_size(payload: Dict[str, Any]) -> int:
     """Return the serialized UTF-8 byte size of the compact JSON payload.
 
@@ -197,19 +210,79 @@ def _over_limit(payload: Dict[str, Any], max_bytes: Optional[int], max_tokens: O
     return False
 
 
+def _drop_pairs_by_estimate(
+    payload: Dict[str, Any],
+    history: list,
+    max_bytes: Optional[int],
+    max_tokens: Optional[int],
+    total_tokens: int,
+    total_bytes: int,
+) -> None:
+    """Drop old pairs using estimated cost, without any extra full pass.
+
+    The original loop called _over_limit() per iteration, and each call
+    serialized and tokenized the whole payload: 113 iterations on a 3 MB payload
+    cost ~44s before the request even left.
+
+    Each entry's byte cost comes from its own cheap serialization, and its token
+    share is prorated from the payload's real token total. Tokenizing every entry
+    would be more precise but costs another full pass; the proration is close
+    enough and the caller's exact check corrects the rest.
+
+    The 3% margin keeps a proration error from leaving the payload just above the
+    cap, which would force exact iterations - the expensive ones.
+    """
+    if not history:
+        return
+
+    entry_bytes = [len(_payload_json(entry).encode("utf-8")) + 1 for entry in history]
+    history_bytes = sum(entry_bytes)
+    if history_bytes <= 0:
+        return
+
+    tokens_per_byte = total_tokens / total_bytes if total_bytes else 0.0
+    remaining_tokens = float(total_tokens)
+    remaining_bytes = total_bytes
+
+    token_target = max_tokens * 0.97 if max_tokens is not None else None
+
+    index = 0
+    while index < len(history):
+        over_tokens = token_target is not None and remaining_tokens > token_target
+        over_bytes = max_bytes is not None and remaining_bytes > max_bytes
+        if not (over_tokens or over_bytes):
+            break
+        for _ in range(2):
+            if index < len(history):
+                remaining_tokens -= entry_bytes[index] * tokens_per_byte
+                remaining_bytes -= entry_bytes[index]
+                index += 1
+
+    if index:
+        del history[:index]
+
+
 def trim_payload_to_limit(
     payload: Dict[str, Any],
     max_bytes: Optional[int] = None,
     max_tokens: Optional[int] = None,
+    known_tokens: Optional[int] = None,
+    known_bytes: Optional[int] = None,
 ) -> PayloadTrimStats:
     """
     Trim oldest history entries so the payload fits under max_tokens and/or max_bytes.
 
     Trims in user/assistant pairs (2 entries at a time), aligns start to
     userInputMessage, and repairs orphaned toolResults after trimming.
+
+    ``known_tokens``/``known_bytes`` reuse the measurement the caller already did
+    in the pre-flight guard. Without them, measuring again costs a full
+    serialization and tokenization pass over the whole payload.
     """
-    original_bytes = check_payload_size(payload)
-    original_tokens = check_payload_tokens(payload)
+    if known_tokens is not None and known_bytes is not None:
+        original_tokens, original_bytes = known_tokens, known_bytes
+    else:
+        original_tokens, original_bytes = measure_payload(payload)
     conversation_state = payload.get("conversationState", {})
     history = conversation_state.get("history")
 
@@ -230,6 +303,10 @@ def trim_payload_to_limit(
     _strip_empty_tool_uses(history)
 
     # Trim pairs from the beginning until under limit or no history remains.
+    # The per-entry estimate handles the bulk without re-tokenizing the whole
+    # payload; the exact check below covers the tokenizer's boundary difference
+    # and normally needs no extra iteration.
+    _drop_pairs_by_estimate(payload, history, max_bytes, max_tokens, original_tokens, original_bytes)
     while history and _over_limit(payload, max_bytes, max_tokens):
         del history[:2]
 
@@ -242,8 +319,7 @@ def trim_payload_to_limit(
     if not history:
         del conversation_state["history"]
 
-    final_bytes = check_payload_size(payload)
-    final_tokens = check_payload_tokens(payload)
+    final_tokens, final_bytes = measure_payload(payload)
     return PayloadTrimStats(
         original_bytes=original_bytes,
         final_bytes=final_bytes,

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -17,7 +17,7 @@ from fastapi.security import APIKeyHeader
 from loguru import logger
 
 from kiro.config import WEB_SEARCH_ENABLED
-from kiro.converters_anthropic import anthropic_to_kiro
+from kiro.converters_anthropic import anthropic_to_kiro, anthropic_to_kiro_with_stats
 from kiro.dashboard import identify_data_api_key
 from kiro.http_client import KiroHttpClient
 from kiro.models_anthropic import (
@@ -256,9 +256,11 @@ async def messages(
             profile_arn_for_payload = auth_manager.request_profile_arn or ""
 
             try:
-                kiro_payload = await run_in_worker(
-                    anthropic_to_kiro, request_data, conversation_id, profile_arn_for_payload
+                payload_result = await run_in_worker(
+                    anthropic_to_kiro_with_stats, request_data, conversation_id, profile_arn_for_payload
                 )
+                kiro_payload = payload_result.payload
+                measured_input_tokens = payload_result.input_tokens
             except PayloadTooLargeError as e:
                 logger.error(f"Payload too large: {e}")
                 return JSONResponse(
@@ -349,6 +351,7 @@ async def messages(
                                     request_tools=tools_for_tokenizer,
                                     request_system=system_for_tokenizer,
                                     make_search_request=make_search_request,
+                                    known_input_tokens=measured_input_tokens,
                                 ):
                                     yield chunk
                                 await account_manager.report_success(account.id, request_data.model)

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -123,6 +123,7 @@ async def stream_kiro_to_anthropic(
     request_system: Optional[Any] = None,
     conversation_id: Optional[str] = None,
     make_search_request: Optional[Callable[[str, str, str], Awaitable[httpx.Response]]] = None,
+    known_input_tokens: Optional[int] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generator for converting Kiro stream to Anthropic SSE format.
@@ -162,8 +163,13 @@ async def stream_kiro_to_anthropic(
     # Accuracy: ~85-90% (acceptable trade-off for maintaining streaming capability).
     # See: https://docs.anthropic.com/en/api/messages-streaming
 
-    # Fallback estimation must cover messages/tools/system to avoid significant undercount
-    if request_messages or request_tools or request_system:
+    # Reusing the pre-flight measurement avoids a second full tokenization here,
+    # which runs before the first SSE event and delays time-to-first-byte by
+    # hundreds of ms on a large payload. It is also the better number: it
+    # reflects the payload actually sent, after trimming.
+    if known_input_tokens:
+        input_tokens = known_input_tokens
+    elif request_messages or request_tools or request_system:
         request_token_stats = estimate_request_tokens(
             messages=request_messages or [],
             tools=request_tools,
@@ -995,6 +1001,7 @@ async def stream_with_first_token_retry_anthropic(
     request_tools: Optional[list] = None,
     request_system: Optional[Any] = None,
     make_search_request: Optional[Callable[[str, str, str], Awaitable[httpx.Response]]] = None,
+    known_input_tokens: Optional[int] = None,
 ) -> AsyncGenerator[str, None]:
     """
     Streaming with automatic retry on first token timeout for Anthropic API.
@@ -1059,6 +1066,7 @@ async def stream_with_first_token_retry_anthropic(
             request_tools=request_tools,
             request_system=request_system,
             make_search_request=make_search_request,
+            known_input_tokens=known_input_tokens,
         ):
             yield chunk
 

--- a/tests/unit/test_offload.py
+++ b/tests/unit/test_offload.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import threading
 
-from kiro.converters_anthropic import anthropic_to_kiro
+from kiro.converters_anthropic import anthropic_to_kiro, anthropic_to_kiro_with_stats
 from kiro.converters_openai import build_kiro_payload
 from kiro.offload import run_in_worker
 from kiro.payload_guards import PayloadTooLargeError
@@ -69,7 +69,7 @@ class TestRoutesOffloadPayloadBuild:
                 "messages": [{"role": "user", "content": "hi"}],
             },
         )
-        assert seen.get("fn") is anthropic_to_kiro
+        assert seen.get("fn") is anthropic_to_kiro_with_stats
         assert response.status_code == 400
 
     def test_openai_chat_offloads_conversion(self, test_client, valid_proxy_api_key, monkeypatch) -> None:

--- a/tests/unit/test_offload.py
+++ b/tests/unit/test_offload.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 import threading
 
-from kiro.converters_anthropic import anthropic_to_kiro, anthropic_to_kiro_with_stats
+from kiro.converters_anthropic import anthropic_to_kiro_with_stats
 from kiro.converters_openai import build_kiro_payload
 from kiro.offload import run_in_worker
 from kiro.payload_guards import PayloadTooLargeError

--- a/tests/unit/test_trim_performance.py
+++ b/tests/unit/test_trim_performance.py
@@ -3,8 +3,6 @@
 
 import time
 
-import pytest
-
 from kiro import payload_guards as pg
 
 CHUNK = "public void onDamage(EntityDamageEvent event) { if (event.getCause() == VOID) { cancel(); } } "

--- a/tests/unit/test_trim_performance.py
+++ b/tests/unit/test_trim_performance.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""The trim must respect the cap without re-tokenizing the payload per iteration."""
+
+import time
+
+import pytest
+
+from kiro import payload_guards as pg
+
+CHUNK = "public void onDamage(EntityDamageEvent event) { if (event.getCause() == VOID) { cancel(); } } "
+
+
+def _payload(pairs: int):
+    history = []
+    for i in range(pairs):
+        history.append({"userInputMessage": {"content": CHUNK * 12, "modelId": "claude-opus-5"}})
+        history.append({"assistantResponseMessage": {"content": CHUNK * 12}})
+    return {
+        "conversationState": {
+            "conversationId": "trim-test",
+            "currentMessage": {"userInputMessage": {"content": "e agora?", "modelId": "claude-opus-5"}},
+            "history": history,
+        }
+    }
+
+
+class TestTrimCorrectness:
+    def test_result_is_under_the_token_cap(self):
+        payload = _payload(200)
+        original_tokens = pg.check_payload_tokens(payload)
+        cap = original_tokens // 3
+
+        stats = pg.trim_payload_to_limit(payload, max_bytes=None, max_tokens=cap)
+
+        assert stats.trimmed
+        assert stats.final_tokens <= cap, f"{stats.final_tokens} > {cap}"
+        assert pg.check_payload_tokens(payload) <= cap
+
+    def test_result_is_under_the_byte_cap(self):
+        payload = _payload(200)
+        cap = pg.check_payload_size(payload) // 3
+
+        stats = pg.trim_payload_to_limit(payload, max_bytes=cap, max_tokens=None)
+
+        assert stats.final_bytes <= cap
+        assert pg.check_payload_size(payload) <= cap
+
+    def test_history_starts_with_a_user_message(self):
+        payload = _payload(200)
+        cap = pg.check_payload_tokens(payload) // 4
+        pg.trim_payload_to_limit(payload, max_bytes=None, max_tokens=cap)
+        history = payload["conversationState"].get("history") or []
+        if history:
+            assert "userInputMessage" in history[0]
+
+    def test_payload_already_under_the_cap_is_untouched(self):
+        payload = _payload(4)
+        before = len(payload["conversationState"]["history"])
+        stats = pg.trim_payload_to_limit(payload, max_bytes=None, max_tokens=10_000_000)
+        assert not stats.trimmed
+        assert len(payload["conversationState"]["history"]) == before
+
+
+class TestTrimCost:
+    def test_full_payload_is_not_retokenized_per_iteration(self, monkeypatch):
+        """Replacing 100+ full passes with a handful was the point of the change."""
+        payload = _payload(200)
+        cap = pg.check_payload_tokens(payload) // 3
+
+        calls = {"n": 0}
+        real = pg.check_payload_tokens
+
+        def counting(p):
+            calls["n"] += 1
+            return real(p)
+
+        monkeypatch.setattr(pg, "check_payload_tokens", counting)
+        stats = pg.trim_payload_to_limit(payload, max_bytes=None, max_tokens=cap)
+
+        assert stats.trimmed
+        # Before: one call per removed pair (dozens). Now: the two reporting
+        # measurements plus, at most, a few exact verifications.
+        assert calls["n"] <= 6, f"{calls['n']} full tokenization passes"
+
+    def test_trim_of_a_large_history_is_quick(self):
+        payload = _payload(400)
+        cap = pg.check_payload_tokens(payload) // 4
+
+        started = time.perf_counter()
+        pg.trim_payload_to_limit(payload, max_bytes=None, max_tokens=cap)
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < 10.0, f"trim levou {elapsed:.1f}s"


### PR DESCRIPTION
## Problem

On a long conversation, `build_kiro_payload` spent tens of seconds before the request ever reached Kiro. From my own log, a 3.2 MB / 1.86M token payload being trimmed to the 800k cap:

```
20:21:32  Request to /v1/messages (model=claude-opus-5, stream=True)
20:22:16  Trimmed conversation history: 792 -> 568 messages
          (1861579 -> 799457 tokens, 3209837 -> 1542416 bytes, cap=800000)
20:22:20  POST /v1/messages 200
```

44 seconds between the request arriving and the trim finishing. Across 117 requests the median latency was 40.1s, with 65% over 30s.

## Cause

Three redundancies, all measured with the project's own tokenizer on this machine.

**1. The trim loop was O(n²).**

```python
while history and _over_limit(payload, max_bytes, max_tokens):
    del history[:2]
```

`_over_limit` calls `check_payload_tokens`, which serializes *and* tokenizes the entire payload. Dropping 792 → 566 entries is 113 iterations, each paying a full pass over ~3 MB.

**2. The pre-flight guard serialized the payload twice.** `check_payload_tokens()` and `check_payload_size()` each call `_payload_json()` independently, and `trim_payload_to_limit()` then measured the original size again from scratch.

**3. `estimate_request_tokens()` ran before the first SSE event.** In `stream_kiro_to_anthropic` it fills `input_tokens` for `message_start`, tokenizing every message again in a Python loop. Measured **401 ms** on a 2.92 MB request with 800 messages and 31 tools — paid directly against time-to-first-byte.

## Change

Per-entry byte cost is computed once and each entry's token share is prorated from the payload's real token total, so the drop loop becomes arithmetic. The exact `_over_limit` check still runs afterwards to cover the tokenizer's boundary difference; a 3% margin keeps a proration error from forcing extra exact iterations.

`measure_payload()` serializes once for both numbers, and `trim_payload_to_limit()` accepts the caller's measurement via `known_tokens`/`known_bytes`.

The guard's exact count is threaded through `KiroPayloadResult.input_tokens` and reused for `message_start`. That is also **more accurate**: the old value described the client's pre-trim conversation, so after trimming it overstated the input. In the log above it would report 1,861,579 instead of the 799,457 actually sent.

`anthropic_to_kiro()` keeps its signature and return type — 11 test call sites depend on it. The stats come from a new `anthropic_to_kiro_with_stats()`, and the original delegates to it.

## Measured effect

Trim, using the project's tokenizer:

| history | before | after | |
| --- | --- | --- | --- |
| 400 entries, 0.45 MB | 3.35 s (134 iterations) | 0.10 s | 32x |
| 792 entries, 0.89 MB | 13.22 s (265 iterations) | 0.21 s | 63x |

Full tokenization passes per trim: **4 → 1**. `message_start` cost: **401 ms → 0**.

Extrapolating the 0.89 MB case to the 3.2 MB payload from the log gives ~47 s, which matches the 44 s observed — the diagnosis accounts for the whole delay.

End to end on my machine, comparing the 117 requests before the change with the requests after:

```
before   median 40.1s   mean 29.3s   max 56.3s    65% >= 30s
after    median  7.2s   mean  8.4s   max 15.0s     0% >= 15s
```

## Tests

New `tests/unit/test_trim_performance.py`:

- the result is under the token cap, and under the byte cap;
- history still starts with a `userInputMessage`;
- a payload already under the cap is untouched;
- `check_payload_tokens` is called at most 6 times per trim, instead of once per removed pair;
- trimming a 400-pair history completes in under 10 s.

`tests/unit/test_offload.py` asserts which function is handed to `run_in_worker`, so it now names the wrapper. The contract it guards — running the CPU-bound conversion off the event loop — is unchanged.

## Verification notes

- `pytest -q`: 2050 passed, 17 failed. The 17 are identical before and after this change; on Windows they are the POSIX-permission assertions in `test_debug_logger.py` / `test_debug_replay.py` / `test_debug_capture_replay.py`, one `test_config.py` host default, and one flaky `test_quota_reset_quarantine.py`. No new failures.
- The proration in `_drop_pairs_by_estimate` is an approximation by design. The exact check after it is what guarantees the cap, and `test_trim_performance.py` asserts the cap holds. Worth a careful look during review: the 3% margin means slightly more history is dropped than strictly necessary, trading a little context for avoiding the expensive exact iterations.

## Open question

I left `check_payload_tokens` doing an exact tiktoken pass in the guard (~250 ms on 3.2 MB). Replacing it with an estimate would be faster but would turn a clear pre-flight error into an upstream `CONTENT_LENGTH_EXCEEDS_THRESHOLD`, and the measured thresholds in that module look deliberate. Happy to revisit if you would rather trade exactness there too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up payload trimming so long conversations no longer spend tens of seconds in `build_kiro_payload`; the trim loop now computes per-entry costs once instead of re-tokenizing the whole payload each iteration, and the pre-flight measurement is reused for the size guards and `message_start` `input_tokens`.

**Notes for the reviewer**

- `message_start` `input_tokens` now reflects the trimmed payload actually sent, not the client's pre-trim conversation.
- The 3% estimate margin drops slightly more history than strictly necessary; the exact post-check still guarantees the cap.
- `anthropic_to_kiro()` keeps its signature; the new `anthropic_to_kiro_with_stats()` exposes the stats, and `test_offload.py` now asserts that wrapper is offloaded.
- The guard still does an exact token pass (~250 ms on 3.2 MB); replacing it with an estimate would be faster but would turn a clear pre-flight error into an upstream `CONTENT_LENGTH_EXCEEDS_THRESHOLD`.

<sup>Written for commit eef2534f0bc4e7e519080af6aaed8fcec129d17d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

