### PR TITLE
(ignore)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,18 @@ DASHBOARD_PASSWORD="replace-with-a-unique-secret"
 # KIRO_MAX_PAYLOAD_TOKENS=800000
 # KIRO_MAX_PAYLOAD_BYTES=1085435
 # AUTO_TRIM_PAYLOAD=false
+
+# ==============================================================================
+# Endpoint Rotation
+# ==============================================================================
+# Rotate to alternate generation endpoints when the primary one keeps failing.
+# Only runtime.{region}.kiro.dev is verified for every credential type; the
+# alternates exist for failover and may reject some accounts. Rotation only
+# triggers on a 5xx or a transport error, so the healthy path is unchanged.
+# A 429 or a suspension 403 belongs to the account and never rotates.
+KIRO_ENDPOINT_ROTATION=false
+# Attempt order. Unknown keys are ignored. Available: runtime, codewhisperer, amazonq
+KIRO_ENDPOINT_ORDER=runtime,codewhisperer,amazonq
+# How long a failing endpoint is pushed to the back of the queue, in seconds.
+# It is never removed from the list.
+KIRO_ENDPOINT_COOLDOWN_SECONDS=30

--- a/kiro/auth.py
+++ b/kiro/auth.py
@@ -211,6 +211,7 @@ class KiroAuthManager:
         is_builder_id = self._auth_type == AuthType.AWS_SSO_OIDC and not self._profile_arn
         sso_region_for_oidc = self._sso_region or region
         self._refresh_url = get_kiro_refresh_url(sso_region_for_oidc)
+        self._api_region = final_api_region
         self._api_host = get_kiro_api_host(final_api_region, is_builder_id)
         self._q_host = get_kiro_q_host(final_api_region, is_builder_id)
 
@@ -1002,6 +1003,11 @@ class KiroAuthManager:
     def api_host(self) -> str:
         """API host for the current region."""
         return self._api_host
+
+    @property
+    def api_region(self) -> str:
+        """Region whose generation endpoint this account uses."""
+        return self._api_region
 
     @property
     def generation_url(self) -> str:

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -297,6 +297,26 @@ STREAMING_READ_TIMEOUT: float = float(os.getenv("STREAMING_READ_TIMEOUT", "300")
 FIRST_TOKEN_MAX_RETRIES: int = int(os.getenv("FIRST_TOKEN_MAX_RETRIES", "3"))
 
 # ==================================================================================================
+# Endpoint Rotation
+# ==================================================================================================
+
+# Rotate to alternate generation endpoints when the primary one keeps failing.
+# Disabled by default: only runtime.{region}.kiro.dev is verified for every
+# credential type, and the alternates may reject some accounts. Enable it to get
+# failover instead of a hard failure when the runtime host degrades.
+KIRO_ENDPOINT_ROTATION: bool = os.getenv("KIRO_ENDPOINT_ROTATION", "false").lower() in ("true", "1", "yes")
+
+# Comma-separated attempt order. Unknown keys are ignored.
+# Available: runtime, codewhisperer, amazonq
+KIRO_ENDPOINT_ORDER: list[str] = [
+    part.strip() for part in os.getenv("KIRO_ENDPOINT_ORDER", "runtime,codewhisperer,amazonq").split(",") if part.strip()
+]
+
+# How long a failing endpoint is pushed to the back of the queue, in seconds.
+# It is never removed: a cooldown must not turn a request into a hard failure.
+KIRO_ENDPOINT_COOLDOWN_SECONDS: float = float(os.getenv("KIRO_ENDPOINT_COOLDOWN_SECONDS", "30"))
+
+# ==================================================================================================
 # Debug Settings
 # ==================================================================================================
 

--- a/kiro/endpoints.py
+++ b/kiro/endpoints.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""Generation endpoint rotation.
+
+The primary endpoint is ``runtime.{region}.kiro.dev``, the one current Kiro CLI
+clients use. With a single URL there is nowhere to go when it degrades: the
+request fails outright. This module declares the known alternates and keeps the
+minimum state needed to rotate between them.
+
+State is per-process and in memory. A restart falls back to the declared order.
+
+Only ``runtime`` is verified for every credential type. The alternates exist for
+failover and may reject some accounts.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from loguru import logger
+
+GENERATE_TARGET = "AmazonCodeWhispererStreamingService.GenerateAssistantResponse"
+
+
+@dataclass(frozen=True)
+class KiroEndpoint:
+    """A generation destination and the dialect it expects."""
+
+    key: str
+    name: str
+    url_template: str
+    amz_target: Optional[str] = GENERATE_TARGET
+    content_type: str = "application/x-amz-json-1.0"
+    regional: bool = True
+
+    def url(self, region: str) -> str:
+        return self.url_template.format(region=region) if self.regional else self.url_template
+
+    def header_overrides(self) -> Dict[str, str]:
+        overrides: Dict[str, str] = {"Content-Type": self.content_type}
+        if self.amz_target:
+            overrides["x-amz-target"] = self.amz_target
+        return overrides
+
+
+# Declared order is the attempt order when no affinity is recorded.
+KIRO_ENDPOINTS: Tuple[KiroEndpoint, ...] = (
+    KiroEndpoint(
+        key="runtime",
+        name="Kiro Runtime",
+        url_template="https://runtime.{region}.kiro.dev/",
+    ),
+    KiroEndpoint(
+        key="codewhisperer",
+        name="CodeWhisperer",
+        url_template="https://codewhisperer.{region}.amazonaws.com/generateAssistantResponse",
+    ),
+    KiroEndpoint(
+        key="amazonq",
+        name="AmazonQ",
+        url_template="https://q.{region}.amazonaws.com/generateAssistantResponse",
+        amz_target="AmazonQDeveloperStreamingService.SendMessage",
+    ),
+)
+
+ENDPOINTS_BY_KEY: Dict[str, KiroEndpoint] = {endpoint.key: endpoint for endpoint in KIRO_ENDPOINTS}
+
+
+@dataclass
+class _RotationState:
+    affinity: Dict[Tuple[str, str], str] = field(default_factory=dict)
+    cooldown_until: Dict[str, float] = field(default_factory=dict)
+
+
+_state = _RotationState()
+
+
+def reset_state() -> None:
+    """Clear affinity and cooldown. Used by tests."""
+    _state.affinity.clear()
+    _state.cooldown_until.clear()
+
+
+def selected_endpoints(order: Optional[List[str]] = None) -> List[KiroEndpoint]:
+    """Resolve the configured order, ignoring unknown keys."""
+    if not order:
+        return list(KIRO_ENDPOINTS)
+    resolved: List[KiroEndpoint] = []
+    for key in order:
+        key = key.strip()
+        if not key:
+            continue
+        endpoint = ENDPOINTS_BY_KEY.get(key)
+        if endpoint is None:
+            logger.warning(f"[Endpoints] Ignoring unknown key: {key!r}")
+            continue
+        if endpoint not in resolved:
+            resolved.append(endpoint)
+    return resolved or list(KIRO_ENDPOINTS)
+
+
+def is_cooling(endpoint_key: str, now: Optional[float] = None) -> bool:
+    now = time.monotonic() if now is None else now
+    until = _state.cooldown_until.get(endpoint_key)
+    if until is None:
+        return False
+    if until <= now:
+        del _state.cooldown_until[endpoint_key]
+        return False
+    return True
+
+
+def record_failure(endpoint_key: str, cooldown_seconds: float) -> None:
+    if cooldown_seconds <= 0:
+        return
+    _state.cooldown_until[endpoint_key] = time.monotonic() + cooldown_seconds
+    logger.debug(f"[Endpoints] {endpoint_key} cooling for {cooldown_seconds:.0f}s")
+
+
+def record_success(account_key: str, model: str, endpoint_key: str) -> None:
+    _state.affinity[(account_key, model)] = endpoint_key
+    _state.cooldown_until.pop(endpoint_key, None)
+
+
+def attempt_order(
+    account_key: str,
+    model: str,
+    order: Optional[List[str]] = None,
+    cooldown_seconds: float = 0.0,
+) -> List[KiroEndpoint]:
+    """Return the endpoints in attempt order.
+
+    Affinity first, then the declared order, with cooling endpoints moved to the
+    back. Nothing is ever removed: a cooldown must not turn a request into a
+    hard failure.
+    """
+    endpoints = selected_endpoints(order)
+    preferred_key = _state.affinity.get((account_key, model))
+
+    ranked: List[KiroEndpoint] = []
+    if preferred_key and preferred_key in ENDPOINTS_BY_KEY:
+        preferred = ENDPOINTS_BY_KEY[preferred_key]
+        if preferred in endpoints and not is_cooling(preferred_key):
+            ranked.append(preferred)
+
+    ready = [e for e in endpoints if e not in ranked and not is_cooling(e.key)]
+    cooling = [e for e in endpoints if e not in ranked and is_cooling(e.key)]
+    return ranked + ready + cooling

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -15,14 +15,23 @@ with connection pooling for better resource management.
 
 import asyncio
 import json
-from typing import Optional, TypedDict
+from typing import Dict, Optional, TypedDict
 
 import httpx
 from fastapi import HTTPException
 from loguru import logger
 
 from kiro.auth import KiroAuthManager
-from kiro.config import BASE_RETRY_DELAY, FIRST_TOKEN_MAX_RETRIES, MAX_RETRIES, STREAMING_READ_TIMEOUT
+from kiro.config import (
+    BASE_RETRY_DELAY,
+    FIRST_TOKEN_MAX_RETRIES,
+    KIRO_ENDPOINT_COOLDOWN_SECONDS,
+    KIRO_ENDPOINT_ORDER,
+    KIRO_ENDPOINT_ROTATION,
+    MAX_RETRIES,
+    STREAMING_READ_TIMEOUT,
+)
+from kiro.endpoints import ENDPOINTS_BY_KEY, attempt_order, record_failure, record_success
 from kiro.kiro_errors import is_suspension_error
 from kiro.network_errors import NetworkErrorInfo, classify_network_error, get_short_error_message
 from kiro.utils import get_kiro_headers
@@ -34,6 +43,16 @@ class RequestKwargs(TypedDict, total=False):
     headers: dict
     content: bytes
     params: dict
+
+
+def _payload_model_id(json_data: Optional[dict]) -> Optional[str]:
+    """Extract modelId from a Kiro generation payload, for endpoint affinity."""
+    if not json_data:
+        return None
+    try:
+        return json_data["conversationState"]["currentMessage"]["userInputMessage"]["modelId"]
+    except (KeyError, TypeError):
+        return None
 
 
 class KiroHttpClient:
@@ -154,7 +173,7 @@ class KiroHttpClient:
                 # Propagating here could mask the original exception
                 logger.warning(f"Error closing HTTP client: {e}")
 
-    async def request_with_retry(
+    async def _attempt_endpoint(
         self,
         method: str,
         url: str,
@@ -162,6 +181,7 @@ class KiroHttpClient:
         params: Optional[dict] = None,
         stream: bool = False,
         retry_rate_limits: Optional[bool] = None,
+        header_overrides: Optional[Dict[str, str]] = None,
     ) -> httpx.Response:
         """
         Executes an HTTP request with retry logic.
@@ -203,6 +223,8 @@ class KiroHttpClient:
                 # Get current token
                 token = await self.auth_manager.get_access_token()
                 headers = get_kiro_headers(self.auth_manager, token)
+                if header_overrides:
+                    headers.update(header_overrides)
 
                 # Build request kwargs based on parameters
                 request_kwargs: RequestKwargs = {"headers": headers}
@@ -354,6 +376,84 @@ class KiroHttpClient:
                 raise HTTPException(
                     status_code=502, detail=f"Request failed after {max_retries} attempts. Unknown error."
                 )
+
+    async def request_with_retry(
+        self,
+        method: str,
+        url: str,
+        json_data: Optional[dict] = None,
+        params: Optional[dict] = None,
+        stream: bool = False,
+        retry_rate_limits: Optional[bool] = None,
+    ) -> httpx.Response:
+        """Execute the request, rotating between generation endpoints as needed.
+
+        Rotation applies only to the account's generation URL: a management call
+        such as ``/ListAvailableModels`` still goes to its own host. With
+        ``KIRO_ENDPOINT_ROTATION`` disabled the behavior is unchanged.
+
+        Only an endpoint-attributable failure rotates: a 5xx or a transport
+        error. A 429 or a suspension 403 belongs to the account and returns
+        immediately so the caller can fail over accounts; a request-level 4xx
+        such as CONTENT_LENGTH_EXCEEDS_THRESHOLD would fail the same everywhere.
+        """
+        is_generation = url == getattr(self.auth_manager, "generation_url", None)
+        if not (KIRO_ENDPOINT_ROTATION and is_generation):
+            return await self._attempt_endpoint(
+                method, url, json_data=json_data, params=params, stream=stream, retry_rate_limits=retry_rate_limits
+            )
+
+        region = self.auth_manager.api_region
+        affinity_key = self.auth_manager.profile_arn or region
+        model = _payload_model_id(json_data) or "unknown"
+        endpoints = attempt_order(
+            affinity_key, model, order=KIRO_ENDPOINT_ORDER, cooldown_seconds=KIRO_ENDPOINT_COOLDOWN_SECONDS
+        )
+
+        last_response: Optional[httpx.Response] = None
+        last_exception: Optional[Exception] = None
+
+        for position, endpoint in enumerate(endpoints):
+            endpoint_url = endpoint.url(region)
+            if position > 0:
+                logger.warning(f"[Endpoints] Rotating to {endpoint.name} ({endpoint_url})")
+            try:
+                response = await self._attempt_endpoint(
+                    method,
+                    endpoint_url,
+                    json_data=json_data,
+                    params=params,
+                    stream=stream,
+                    retry_rate_limits=retry_rate_limits,
+                    header_overrides=endpoint.header_overrides(),
+                )
+            except Exception as exc:
+                last_exception = exc
+                record_failure(endpoint.key, KIRO_ENDPOINT_COOLDOWN_SECONDS)
+                logger.warning(f"[Endpoints] {endpoint.name} transport failure: {type(exc).__name__}")
+                continue
+
+            if response.status_code == 200:
+                record_success(affinity_key, model, endpoint.key)
+                if position > 0:
+                    logger.info(f"[Endpoints] {endpoint.name} answered after rotation")
+                return response
+
+            if 500 <= response.status_code < 600:
+                last_response = response
+                record_failure(endpoint.key, KIRO_ENDPOINT_COOLDOWN_SECONDS)
+                logger.warning(f"[Endpoints] {endpoint.name} returned {response.status_code}")
+                if stream:
+                    await response.aclose()
+                continue
+
+            return response
+
+        if last_response is not None:
+            return last_response
+        if last_exception is not None:
+            raise last_exception
+        raise HTTPException(status_code=502, detail="No generation endpoint answered.")
 
     async def __aenter__(self) -> "KiroHttpClient":
         """Async context manager support."""

--- a/tests/unit/test_endpoint_rotation.py
+++ b/tests/unit/test_endpoint_rotation.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""Generation endpoint rotation tests."""
+
+import httpx
+import pytest
+
+from kiro import endpoints as ep
+from kiro.http_client import KiroHttpClient
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    ep.reset_state()
+    yield
+    ep.reset_state()
+
+
+class TestEndpointDefinitions:
+    def test_runtime_is_first_and_keeps_the_generate_target(self):
+        order = ep.selected_endpoints()
+        assert order[0].key == "runtime"
+        assert order[0].url("us-east-1") == "https://runtime.us-east-1.kiro.dev/"
+        assert order[0].header_overrides()["x-amz-target"] == ep.GENERATE_TARGET
+
+    def test_amazonq_uses_its_own_target(self):
+        amazonq = ep.ENDPOINTS_BY_KEY["amazonq"]
+        assert amazonq.header_overrides()["x-amz-target"] == "AmazonQDeveloperStreamingService.SendMessage"
+        assert amazonq.url("eu-central-1") == "https://q.eu-central-1.amazonaws.com/generateAssistantResponse"
+
+    def test_unknown_keys_are_ignored_and_never_empty(self):
+        assert [e.key for e in ep.selected_endpoints(["amazonq", "nope", "runtime"])] == ["amazonq", "runtime"]
+        assert ep.selected_endpoints(["nope"])[0].key == "runtime"
+
+
+class TestAttemptOrder:
+    def test_affinity_puts_the_working_endpoint_first(self):
+        ep.record_success("acc", "claude-opus-5", "amazonq")
+        assert ep.attempt_order("acc", "claude-opus-5")[0].key == "amazonq"
+
+    def test_affinity_is_scoped_per_account_and_model(self):
+        ep.record_success("acc", "claude-opus-5", "amazonq")
+        assert ep.attempt_order("acc", "claude-sonnet-5")[0].key == "runtime"
+        assert ep.attempt_order("other", "claude-opus-5")[0].key == "runtime"
+
+    def test_cooling_endpoint_goes_last_but_is_never_dropped(self):
+        ep.record_failure("runtime", cooldown_seconds=60)
+        order = [e.key for e in ep.attempt_order("acc", "m")]
+        assert order[-1] == "runtime", "a cooling endpoint must move to the back"
+        assert len(order) == len(ep.KIRO_ENDPOINTS), "no endpoint may be dropped"
+
+    def test_success_clears_the_cooldown(self):
+        ep.record_failure("runtime", cooldown_seconds=60)
+        assert ep.is_cooling("runtime")
+        ep.record_success("acc", "m", "runtime")
+        assert not ep.is_cooling("runtime")
+
+    def test_zero_cooldown_is_a_noop(self):
+        ep.record_failure("runtime", cooldown_seconds=0)
+        assert not ep.is_cooling("runtime")
+
+
+class _FakeAuth:
+    api_region = "us-east-1"
+    profile_arn = "arn:aws:codewhisperer:us-east-1:1:profile/TEST"
+    generation_url = "https://runtime.us-east-1.kiro.dev/"
+
+
+_GENERATION_URL = _FakeAuth.generation_url
+_PAYLOAD = {
+    "conversationState": {"currentMessage": {"userInputMessage": {"modelId": "claude-opus-5"}}}
+}
+
+
+def _client(monkeypatch, rotation=True):
+    monkeypatch.setattr("kiro.http_client.KIRO_ENDPOINT_ROTATION", rotation)
+    monkeypatch.setattr("kiro.http_client.KIRO_ENDPOINT_ORDER", ["runtime", "codewhisperer", "amazonq"])
+    monkeypatch.setattr("kiro.http_client.KIRO_ENDPOINT_COOLDOWN_SECONDS", 30.0)
+    client = KiroHttpClient.__new__(KiroHttpClient)
+    client.auth_manager = _FakeAuth()
+    return client
+
+
+def _response(status):
+    return httpx.Response(status_code=status, request=httpx.Request("POST", "https://example.invalid/"))
+
+
+@pytest.mark.asyncio
+class TestRotationBehavior:
+    async def test_rotates_past_a_5xx_and_records_the_winner(self, monkeypatch):
+        client = _client(monkeypatch)
+        seen = []
+
+        async def fake_attempt(method, url, **kwargs):
+            seen.append(url)
+            return _response(500) if "runtime" in url else _response(200)
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+
+        assert response.status_code == 200
+        assert len(seen) == 2 and "runtime" in seen[0] and "codewhisperer" in seen[1]
+        assert ep.attempt_order(_FakeAuth.profile_arn, "claude-opus-5")[0].key == "codewhisperer"
+        assert ep.is_cooling("runtime")
+
+    async def test_rotates_past_a_transport_error(self, monkeypatch):
+        client = _client(monkeypatch)
+        calls = []
+
+        async def fake_attempt(method, url, **kwargs):
+            calls.append(url)
+            if "runtime" in url:
+                raise httpx.ConnectError("boom")
+            return _response(200)
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+        assert response.status_code == 200
+        assert len(calls) == 2
+
+    async def test_429_returns_immediately_for_account_failover(self, monkeypatch):
+        client = _client(monkeypatch)
+        calls = []
+
+        async def fake_attempt(method, url, **kwargs):
+            calls.append(url)
+            return _response(429)
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+        assert response.status_code == 429
+        assert len(calls) == 1, "a 429 belongs to the account, not the endpoint"
+        assert not ep.is_cooling("runtime")
+
+    async def test_400_does_not_rotate(self, monkeypatch):
+        client = _client(monkeypatch)
+        calls = []
+
+        async def fake_attempt(method, url, **kwargs):
+            calls.append(url)
+            return _response(400)
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+        assert response.status_code == 400
+        assert len(calls) == 1, "an oversized payload would fail on every endpoint"
+
+    async def test_disabled_rotation_uses_only_the_given_url(self, monkeypatch):
+        client = _client(monkeypatch, rotation=False)
+        calls = []
+
+        async def fake_attempt(method, url, **kwargs):
+            calls.append(url)
+            return _response(500)
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+        assert response.status_code == 500
+        assert calls == [_GENERATION_URL]
+
+    async def test_management_urls_are_never_rotated(self, monkeypatch):
+        """ListAvailableModels is not generation: it must reach its own host."""
+        client = _client(monkeypatch, rotation=True)
+        calls = []
+
+        async def fake_attempt(method, url, **kwargs):
+            calls.append(url)
+            return _response(500)
+
+        client._attempt_endpoint = fake_attempt
+        management = "https://runtime.us-east-1.kiro.dev/ListAvailableModels"
+        response = await client.request_with_retry("GET", management)
+        assert response.status_code == 500
+        assert calls == [management]
+
+    async def test_last_5xx_is_returned_when_every_endpoint_fails(self, monkeypatch):
+        client = _client(monkeypatch)
+
+        async def fake_attempt(method, url, **kwargs):
+            return _response(503)
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+        assert response.status_code == 503
+
+    async def test_per_endpoint_headers_are_passed_through(self, monkeypatch):
+        client = _client(monkeypatch)
+        captured = {}
+
+        async def fake_attempt(method, url, **kwargs):
+            captured[url] = kwargs.get("header_overrides")
+            return _response(500) if "runtime" in url or "codewhisperer" in url else _response(200)
+
+        client._attempt_endpoint = fake_attempt
+        await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
+
+        amazonq_url = ep.ENDPOINTS_BY_KEY["amazonq"].url("us-east-1")
+        assert captured[amazonq_url]["x-amz-target"] == "AmazonQDeveloperStreamingService.SendMessage"


### PR DESCRIPTION
## Problem

Generation has a single destination — `auth_manager.generation_url`, the runtime host. When that host degrades there is nowhere to go: the request fails outright even though the account and the payload are fine.

The account pool already handles the *account* dimension (429, suspension 403, quota) and the retry loop handles transient 5xx on the same URL. Neither covers "this endpoint is unhealthy right now, another one would answer".

## Change

Declare the known alternates and rotate between them:

```
runtime        https://runtime.{region}.kiro.dev/                (primary)
codewhisperer  https://codewhisperer.{region}.amazonaws.com/generateAssistantResponse
amazonq        https://q.{region}.amazonaws.com/generateAssistantResponse
               x-amz-target: AmazonQDeveloperStreamingService.SendMessage
```

Each endpoint carries its own `x-amz-target` and `Content-Type`, applied through a new `header_overrides` argument on the request path.

What rotates, and what deliberately does not:

| condition | behavior | why |
| --- | --- | --- |
| 5xx | rotate | attributable to the endpoint |
| transport error | rotate | attributable to the endpoint |
| 429 | return immediately | belongs to the account; rotating first only delays account failover |
| suspension 403 | return immediately | belongs to the account |
| request 4xx (e.g. `CONTENT_LENGTH_EXCEEDS_THRESHOLD`) | return immediately | would fail identically everywhere |
| non-generation URL (`/ListAvailableModels`) | never rotates | management calls belong to their own host |

The endpoint that answered is remembered per `(profile ARN, model)` and tried first next time, so a degraded primary is not re-paid on every request. A failed endpoint is pushed to the back of the queue for a cooldown but **never removed** — a cooldown must not turn a request into a hard failure. State is in memory and per-process; a restart falls back to the declared order.

Rotation lives **inside** `request_with_retry` rather than in a new method. My first attempt added `request_with_rotation` and changed the route call sites, which broke the 10 tests in `test_routes_generation_contract.py` — their fake client implements `request_with_retry`. Keeping the existing seam means route call sites and those contract tests are untouched.

## Configuration

Disabled by default:

```dotenv
KIRO_ENDPOINT_ROTATION=false
KIRO_ENDPOINT_ORDER=runtime,codewhisperer,amazonq
KIRO_ENDPOINT_COOLDOWN_SECONDS=30
```

With it off, only the URL the caller passed is used and behavior is byte-for-byte the previous one. Unknown keys in the order are ignored, and an order that resolves to nothing falls back to the full list.

## Tests

`tests/unit/test_endpoint_rotation.py`, 16 tests:

- endpoint definitions: `runtime` first, per-endpoint `x-amz-target`, regional URL templating, unknown keys ignored, list never empty;
- attempt order: affinity puts the winner first, affinity is scoped per account *and* model, a cooling endpoint moves to the back without being dropped, success clears the cooldown, a zero cooldown is a no-op;
- rotation behavior: rotates past a 5xx and past a transport error and records the winner; 429 and request-4xx do not rotate; disabled rotation uses only the given URL; a management URL is never rotated; the last 5xx is returned when every endpoint fails; per-endpoint headers reach the request.

## Verification notes

**The alternate endpoints are not verified against the real Kiro.** I validated the rotation logic — order, affinity, cooldown, error classification — but I could not confirm that `codewhisperer` and `amazonq` accept every credential type, which is exactly why the feature ships disabled. If an alternate rejects the request, its 4xx is returned instead of the primary's 5xx.

`pytest -q`: 2060 passed, 17 failed. The 17 are identical before and after this change; on Windows they are the POSIX-permission assertions in `test_debug_logger.py` / `test_debug_replay.py` / `test_debug_capture_replay.py`, one `test_config.py` host default, and one flaky `test_quota_reset_quarantine.py`. `test_routes_generation_contract.py` and `test_endpoint_rotation.py` pass together: 26 tests.

## Open questions

1. The endpoint list and its order are my reading of what other Kiro gateways use in production. If you know a different set, or that one of these is wrong for a credential type, the list is a single tuple in `kiro/endpoints.py`.
2. Affinity and cooldown are per-process. Persisting them would survive restarts, but I did not want to add a state file without evidence it is needed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rotates generation requests to alternate endpoints when the primary returns a 5xx or fails at the transport level, so a degraded runtime host no longer hard-fails otherwise valid requests. Disabled by default; enabling adds failover via `codewhisperer` and `amazonq` alternates.

- Only 5xx and transport errors rotate; 429 and suspension 403 return immediately to let account failover work.
- Per-account/model affinity tries the last working endpoint first; cooled-down endpoints move to the back but are never dropped.
- If every endpoint fails, the last 5xx response is returned; request-level 4xx return unchanged.
- Rotation only applies to the generation URL; management calls like `/ListAvailableModels` stay on their own host.
- New env vars: `KIRO_ENDPOINT_ROTATION` (default false), `KIRO_ENDPOINT_ORDER`, `KIRO_ENDPOINT_COOLDOWN_SECONDS`.
- Alternates (`codewhisperer` and `amazonq`) are not yet verified for every credential type, so rotation ships disabled.

<sup>Written for commit d194e5cf6dfac306243f271d895cbaf917b45f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

