### PR TITLE
fix: send the profile ARN on MCP web_search requests

### DIFF
--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -137,6 +137,13 @@ async def call_kiro_mcp_api(query: str, auth_manager) -> Tuple[Optional[str], Op
             "x-amzn-codewhisperer-optout": "false",
             "Content-Type": "application/json",
         }
+        # The runtime MCP host rejects a request without the account's profile
+        # ARN. Kiro CLI sends it as a header, not in the JSON-RPC body.
+        profile_arn = getattr(auth_manager, "request_profile_arn", None) or getattr(
+            auth_manager, "profile_arn", None
+        )
+        if profile_arn:
+            headers["x-amzn-kiro-profile-arn"] = profile_arn
 
         mcp_url = f"{auth_manager.q_host}/mcp"
         logger.debug(f"Calling MCP API: {mcp_url}")
@@ -145,7 +152,10 @@ async def call_kiro_mcp_api(query: str, auth_manager) -> Tuple[Optional[str], Op
             response = await client.post(mcp_url, json=mcp_request, headers=headers)
 
             if response.status_code != 200:
-                logger.error(f"MCP API error: {response.status_code}")
+                # The body carries the only description of what was rejected;
+                # without it a 400 here is undiagnosable.
+                detail = response.text[:400].replace("\n", " ")
+                logger.error(f"MCP API error: {response.status_code} url={mcp_url} body={detail}")
                 return None, None
 
             mcp_response = response.json()


### PR DESCRIPTION
## Problem

Every `web_search` call fails. From my log:

```
22:09:38 | INFO  | streaming_anthropic:427 - Intercepted web_search tool call (Path B - MCP emulation)
22:09:39 | ERROR | mcp_tools:call_kiro_mcp_api:148 - MCP API error: 400
22:09:39 | ERROR | streaming_anthropic:449 - MCP API call failed for web_search
```

The log gives no reason, because the error path discards the response body:

```python
if response.status_code != 200:
    logger.error(f"MCP API error: {response.status_code}")
    return None, None
```

## Cause

`call_kiro_mcp_api` sends three headers and posts to `{auth_manager.q_host}/mcp`:

```python
headers = {
    "Authorization": f"Bearer {token}",
    "x-amzn-codewhisperer-optout": "false",
    "Content-Type": "application/json",
}
```

For a non-Builder-ID account `q_host` resolves to `runtime.{region}.kiro.dev`, and that host requires the account's profile ARN, which Kiro CLI sends as a header. I probed all four combinations directly against the real API with a valid token:

| target | profile ARN header | result |
| --- | --- | --- |
| `runtime.us-east-1.kiro.dev/mcp` | absent | **400** `{"message":"profileArn is required for this request.","reason":null}` |
| `runtime.us-east-1.kiro.dev/mcp` | present | 200, search results |
| `q.us-east-1.amazonaws.com/mcp` | absent | 200, search results |
| `q.us-east-1.amazonaws.com/mcp` | present | 200, search results |

So the 400 is exactly the missing header, and the runtime host is the one that enforces it.

## Change

Send the profile ARN, using the same `request_profile_arn` → `profile_arn` precedence the generation routes already use:

```python
profile_arn = getattr(auth_manager, "request_profile_arn", None) or getattr(auth_manager, "profile_arn", None)
if profile_arn:
    headers["x-amzn-kiro-profile-arn"] = profile_arn
```

Also log the response body on failure. It is the only description of what was rejected, and without it a 400 here is undiagnosable — which is why the original report was just "400".

## Tests

`pytest -q tests/unit -k "mcp or web_search or websearch"`: 39 passed.

Full suite: 2066 passed, 17 failed. The 17 are identical before and after; on Windows they are the POSIX-permission assertions in `test_debug_logger.py` / `test_debug_replay.py` / `test_debug_capture_replay.py`, one `test_config.py` host default, and one flaky `test_quota_reset_quarantine.py`. No new failures.

I did not add a unit test for the header: asserting it would mean asserting the outgoing header dict, and the probe table above is the real evidence. Happy to add one if you prefer it covered.

## Note

`q.us-east-1.amazonaws.com/mcp` answered in both cases, so it is a viable fallback if the runtime MCP host degrades. This PR does not add that fallback — it only fixes the header — but the probe suggests a two-endpoint list would make web search resilient the same way the generation path could be.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the account profile ARN on MCP `web_search` requests, fixing HTTP 400 failures against the runtime MCP host.

- Adds the `x-amzn-kiro-profile-arn` header using the same `request_profile_arn` → `profile_arn` precedence as the generation routes.
- Logs the response body on non-200 responses; it was previously discarded, leaving only the status code to debug.

<sup>Written for commit 4c91f0bf1d316ab925de58f360d4bd746e725775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

