### PR TITLE
style: reformat mcp_tools profile-arn lookup for ruff 0.16.5

### DIFF
--- a/kiro/mcp_tools.py
+++ b/kiro/mcp_tools.py
@@ -139,9 +139,7 @@ async def call_kiro_mcp_api(query: str, auth_manager) -> Tuple[Optional[str], Op
         }
         # The runtime MCP host rejects a request without the account's profile
         # ARN. Kiro CLI sends it as a header, not in the JSON-RPC body.
-        profile_arn = getattr(auth_manager, "request_profile_arn", None) or getattr(
-            auth_manager, "profile_arn", None
-        )
+        profile_arn = getattr(auth_manager, "request_profile_arn", None) or getattr(auth_manager, "profile_arn", None)
         if profile_arn:
             headers["x-amzn-kiro-profile-arn"] = profile_arn
 


### PR DESCRIPTION
PR #37 landed with a line that the pinned ruff 0.16.5 formatter rewraps, turning the `quality` job red on main. This is the formatter output, no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformats the profile-arn lookup in `kiro/mcp_tools.py` to match ruff 0.16.5, fixing the `quality` job on main. No behavior change.

<sup>Written for commit 12b678e8129640a72da1298ee8339d64857b1f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

