### PR TITLE
Fix duplicated tool calls, dropped images and opaque failovers

### DIFF
--- a/kiro/config.py
+++ b/kiro/config.py
@@ -113,6 +113,13 @@ MAX_RETRIES: int = 3
 # Uses exponential backoff: delay * (2 ** attempt)
 BASE_RETRY_DELAY: float = 1.0
 
+# How long to wait for the body of a failed streamed response before giving up.
+# Deliberately short and separate from STREAMING_READ_TIMEOUT: this reads an
+# error payload that is already on the wire, and the cost is paid once per
+# attempt and once per endpoint, so a hung upstream must not turn a refusal into
+# a stall.
+ERROR_BODY_READ_TIMEOUT: float = 5.0
+
 # ==================================================================================================
 # Hidden Models Configuration
 # ==================================================================================================

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -579,7 +579,11 @@ def extract_tool_results_from_content(content: Any) -> List[Dict[str, Any]]:
                 tool_results.append(
                     {
                         "content": [{"text": extract_text_content(item.get("content", "")) or "(empty result)"}],
-                        "status": "success",
+                        # Same rule as convert_tool_results_to_kiro_format. This
+                        # hardcoded "success", so a failed tool reaching the
+                        # payload through this path was presented to the model as
+                        # a working one and it carried on from a stack trace.
+                        "status": "error" if item.get("is_error") else "success",
                         "toolUseId": item.get("tool_use_id", ""),
                     }
                 )
@@ -914,6 +918,7 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
     merge_counts = {"user": 0, "assistant": 0}
     total_tool_calls_merged = 0
     total_tool_results_merged = 0
+    total_images_merged = 0
 
     for msg in messages:
         if not merged:
@@ -958,6 +963,16 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
                 last.tool_results = list(last.tool_results) + list(msg.tool_results)
                 total_tool_results_merged += len(msg.tool_results)
 
+            # Merge images, on the same concatenation rule as content and the
+            # tool lists above. Leaving them out dropped every image on the
+            # second of two merged messages, silently: nothing downstream can
+            # tell an absent image from one the client never sent. The OpenAI
+            # adapter produces exactly this shape, since flushing pending tool
+            # results emits a user turn that the next user turn merges into.
+            if msg.images:
+                last.images = list(last.images or []) + list(msg.images)
+                total_images_merged += len(msg.images)
+
             # Count merges by role
             if msg.role in merge_counts:
                 merge_counts[msg.role] += 1
@@ -978,6 +993,8 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
             extras.append(f"{total_tool_calls_merged} tool_calls")
         if total_tool_results_merged > 0:
             extras.append(f"{total_tool_results_merged} tool_results")
+        if total_images_merged > 0:
+            extras.append(f"{total_images_merged} images")
 
         if extras:
             logger.debug(f"Merged {total_merges} adjacent messages ({merge_summary}), including {', '.join(extras)}")

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -969,9 +969,16 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
             # tell an absent image from one the client never sent. The OpenAI
             # adapter produces exactly this shape, since flushing pending tool
             # results emits a user turn that the next user turn merges into.
-            if msg.images:
-                last.images = list(last.images or []) + list(msg.images)
-                total_images_merged += len(msg.images)
+            #
+            # Both representations are read, matching what build_kiro_payload
+            # does downstream. It resolves `msg.images or extract(content)`, so
+            # once the merged message holds any explicit image the content blocks
+            # stop being inspected - and anything they carried would be lost.
+            current_images = msg.images or extract_images_from_content(msg.content)
+            if current_images:
+                previous_images = last.images or extract_images_from_content(last.content)
+                last.images = list(previous_images) + list(current_images)
+                total_images_merged += len(current_images)
 
             # Count merges by role
             if msg.role in merge_counts:

--- a/kiro/converters_core.py
+++ b/kiro/converters_core.py
@@ -927,6 +927,20 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
 
         last = merged[-1]
         if msg.role == last.role:
+            # Resolved before the content merge below, because that merge moves
+            # msg's blocks into last.content: reading last.content afterwards
+            # would count those blocks twice, once as the previous images and
+            # once as the current ones, and the model would be shown - and
+            # charged for - the same picture twice.
+            #
+            # Both representations are read, matching how build_kiro_payload
+            # resolves `msg.images or extract_images_from_content(...)`
+            # downstream: once the merged message holds any explicit image the
+            # content blocks stop being inspected there, so anything carried only
+            # in a block has to be lifted out here or it is lost.
+            current_images = msg.images or extract_images_from_content(msg.content)
+            previous_images = last.images or extract_images_from_content(last.content)
+
             # Merge content
             if isinstance(last.content, list) and isinstance(msg.content, list):
                 last.content = last.content + msg.content
@@ -969,14 +983,7 @@ def merge_adjacent_messages(messages: List[UnifiedMessage]) -> List[UnifiedMessa
             # tell an absent image from one the client never sent. The OpenAI
             # adapter produces exactly this shape, since flushing pending tool
             # results emits a user turn that the next user turn merges into.
-            #
-            # Both representations are read, matching what build_kiro_payload
-            # does downstream. It resolves `msg.images or extract(content)`, so
-            # once the merged message holds any explicit image the content blocks
-            # stop being inspected - and anything they carried would be lost.
-            current_images = msg.images or extract_images_from_content(msg.content)
             if current_images:
-                previous_images = last.images or extract_images_from_content(last.content)
                 last.images = list(previous_images) + list(current_images)
                 total_images_merged += len(current_images)
 

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -59,7 +59,12 @@ def _extract_tool_results_from_openai(content: Any) -> List[Dict[str, Any]]:
                         # Kiro's toolResult has a status field and the Anthropic
                         # adapter fills it from here. Omitting the key made every
                         # failed tool read as a successful one downstream.
-                        "is_error": bool(item.get("is_error", False)),
+                        #
+                        # Compared against True rather than coerced: this block
+                        # lives inside `content`, which is typed loosely and never
+                        # validated, so bool() would read the string "false" as a
+                        # failure and report a working tool as broken.
+                        "is_error": item.get("is_error") is True,
                     }
                 )
 

--- a/kiro/converters_openai.py
+++ b/kiro/converters_openai.py
@@ -56,6 +56,10 @@ def _extract_tool_results_from_openai(content: Any) -> List[Dict[str, Any]]:
                         "type": "tool_result",
                         "tool_use_id": item.get("tool_use_id", ""),
                         "content": extract_text_content(item.get("content", "")) or "(empty result)",
+                        # Kiro's toolResult has a status field and the Anthropic
+                        # adapter fills it from here. Omitting the key made every
+                        # failed tool read as a successful one downstream.
+                        "is_error": bool(item.get("is_error", False)),
                     }
                 )
 
@@ -168,6 +172,11 @@ def convert_openai_messages_to_unified(messages: List[ChatMessage]) -> Tuple[str
                 "type": "tool_result",
                 "tool_use_id": msg.tool_call_id or "",
                 "content": extract_text_content(msg.content) or "(empty result)",
+                # OpenAI's schema has no failure flag on a tool message, but
+                # Kiro's toolResult does carry a status. The field is declared on
+                # ChatMessage so pydantic validates it; absent, False keeps the
+                # previous meaning.
+                "is_error": bool(msg.is_error),
             }
             pending_tool_results.append(tool_result)
             total_tool_results += 1

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -375,6 +375,11 @@ class KiroHttpClient:
                 error_info = classify_network_error(e)
                 last_error_info = error_info
                 last_raw_error = e
+                # The newest failure is the one that describes reality. A status
+                # recorded on an earlier attempt would otherwise be returned by
+                # the post-loop check ahead of this error, and the proxy and
+                # endpoint layers rotate on a transport error, not on a status.
+                last_response = None
 
                 # Log with user-friendly message
                 short_msg = get_short_error_message(error_info)
@@ -393,6 +398,9 @@ class KiroHttpClient:
                 error_info = classify_network_error(e)
                 last_error_info = error_info
                 last_raw_error = e
+                # See the timeout branch: a stale status must not outrank the
+                # transport failure that actually ended the attempt.
+                last_response = None
 
                 # Log with user-friendly message
                 short_msg = get_short_error_message(error_info)

--- a/kiro/http_client.py
+++ b/kiro/http_client.py
@@ -25,6 +25,7 @@ from kiro import concurrency, proxy_chain
 from kiro.auth import KiroAuthManager
 from kiro.config import (
     BASE_RETRY_DELAY,
+    ERROR_BODY_READ_TIMEOUT,
     FIRST_TOKEN_MAX_RETRIES,
     MAX_RETRIES,
     STREAMING_READ_TIMEOUT,
@@ -117,6 +118,28 @@ class KiroHttpClient:
         # rotate immediately instead of sleeping through retries on an account
         # already known to be rate-limited.
         self.retry_rate_limits = True
+
+    @staticmethod
+    async def _cache_error_body(response: httpx.Response) -> None:
+        """Read a failed streamed response so its body outlives the stream.
+
+        httpx caches what ``aread()`` returns, so a later read by the route still
+        works after the stream is closed. Failing here must not replace the real
+        status with a transport error: the status alone is still worth returning.
+
+        The read is bounded on its own rather than inheriting the stream client's
+        read timeout. That timeout exists for a model that pauses mid-generation
+        and is measured in minutes; spending it on an error body would be paid
+        once per attempt and once per endpoint before the caller sees anything,
+        turning a fast refusal into a hang.
+        """
+        try:
+            await asyncio.wait_for(response.aread(), timeout=ERROR_BODY_READ_TIMEOUT)
+        except Exception as read_error:
+            # Warning, not debug: the caller now has a response whose body cannot
+            # be decoded, which is exactly the opaque "Unknown error" this is
+            # meant to prevent, and it must not be silent.
+            logger.warning(f"Could not capture the upstream error body: {read_error}")
 
     async def _get_client(self, stream: bool = False) -> httpx.AsyncClient:
         """
@@ -287,7 +310,14 @@ class KiroHttpClient:
                     if is_suspension_error(403, text, reason):
                         logger.error("Received 403 account suspension; returning immediately for account failover")
                         return response
-                    logger.warning(f"Received 403, refreshing token (attempt {attempt + 1}/{MAX_RETRIES})")
+                    # Kept as the fallback answer. Without it, an account that
+                    # answers 403 to every attempt left every last_* slot empty
+                    # and the caller received a generic "Unknown error" 502, so
+                    # classify_error never saw the 403 and no account rotation
+                    # happened. The body is already read above, so returning this
+                    # response after the stream is closed is still decodable.
+                    last_response = response
+                    logger.warning(f"Received 403, refreshing token (attempt {attempt + 1}/{max_retries})")
                     if stream:
                         await response.aclose()
                     await self.auth_manager.force_refresh()
@@ -301,6 +331,12 @@ class KiroHttpClient:
                         logger.info("Received 429; returning immediately for account failover")
                         return response
                     last_response = response
+                    if stream:
+                        # Same reason as the 5xx branch below, and this is the
+                        # likelier path: rate limits are this gateway's most
+                        # common refusal, so losing the body here costs the
+                        # reason that decides the account failover most often.
+                        await self._cache_error_body(response)
                     if attempt >= max_retries - 1:
                         break
                     if stream:
@@ -313,6 +349,13 @@ class KiroHttpClient:
                 # 5xx - server error, wait and retry
                 if 500 <= response.status_code < 600:
                     last_response = response  # Сохраняем для возврата после exhaustion
+                    if stream:
+                        # Capture the body before discarding the stream. This
+                        # response is what gets returned once retries run out,
+                        # and reading a closed stream raises - which sent the
+                        # route down its "Unknown error" branch and threw away
+                        # the upstream reason that decides whether to fail over.
+                        await self._cache_error_body(response)
                     if attempt >= max_retries - 1:
                         break
                     if stream:
@@ -572,6 +615,10 @@ class KiroHttpClient:
                 record_failure(endpoint.key, settings.cooldown_seconds)
                 logger.warning(f"[Endpoints] {endpoint.name} returned {response.status_code}")
                 if stream:
+                    # Same rule as the per-endpoint retry loop: this response is
+                    # returned when no endpoint answers, so its body has to be
+                    # captured before the stream goes away.
+                    await self._cache_error_body(response)
                     await response.aclose()
                 continue
 

--- a/kiro/kiro_errors.py
+++ b/kiro/kiro_errors.py
@@ -54,14 +54,17 @@ def is_credential_dead_status(status_code: int) -> bool:
 def is_suspension_error(status_code: int, message: Optional[str], reason: Optional[str] = None) -> bool:
     """Report whether an upstream refusal means the account itself is locked.
 
-    Only an authorization refusal carries this meaning. The same wording in a
-    validation error would be an echo of the payload, not a verdict about the
-    account, so the status code is part of the test.
+    The reason code is conclusive on its own: the upstream sets that field, so it
+    cannot be an echo of anything the client sent, whatever status accompanies it.
+
+    The wording heuristic is what needs the status. Only an authorization refusal
+    carries this verdict; the same sentence inside a validation error is the
+    payload being quoted back, not a statement about the account.
     """
-    if status_code != 403:
-        return False
     if reason == SUSPENSION_REASON:
         return True
+    if status_code != 403:
+        return False
     if not message:
         return False
     lowered = message.lower()
@@ -87,7 +90,7 @@ class KiroErrorInfo:
     original_message: str
 
 
-def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
+def enhance_kiro_error(error_json: Dict[str, Any], status_code: Optional[int] = None) -> KiroErrorInfo:
     """
     Enhances Kiro API error with user-friendly message.
 
@@ -99,6 +102,12 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
         error_json: Parsed JSON from Kiro API error response
                    Expected format: {"message": "...", "reason": "..."}
                    The "reason" field is optional.
+        status_code: HTTP status the upstream answered with. Required to reach
+                   the suspension verdict, because that verdict is only carried
+                   by an authorization refusal - the same wording inside a
+                   validation error is an echo of the payload. Omitted, no
+                   suspension is claimed: an unknown status is not evidence,
+                   and convicting a healthy account is the worse error.
 
     Returns:
         KiroErrorInfo with enhanced message and original details
@@ -128,8 +137,9 @@ def enhance_kiro_error(error_json: Dict[str, Any]) -> KiroErrorInfo:
 
     # A suspension may arrive with no reason code (legacy host), so it has to be
     # recognized from the message too before the generic branches collapse it
-    # into "unknown error".
-    if is_suspension_error(403, original_message, error_json.get("reason")):
+    # into "unknown error". The status is forwarded rather than hardcoded: it is
+    # what separates the verdict from an echo of the request payload.
+    if status_code is not None and is_suspension_error(status_code, original_message, error_json.get("reason")):
         return KiroErrorInfo(
             reason=SUSPENSION_REASON,
             user_message=(

--- a/kiro/models_openai.py
+++ b/kiro/models_openai.py
@@ -81,6 +81,12 @@ class ChatMessage(BaseModel):
         name: Optional sender name
         tool_calls: List of tool calls (for assistant)
         tool_call_id: Tool call ID (for tool)
+        is_error: Whether a tool message reports a failure. Not part of OpenAI's
+            schema, but Kiro's toolResult carries a status and the Anthropic
+            protocol does define this flag, so a client that sends it is honoured.
+            Declared rather than read off the extra-allow bag so pydantic
+            validates it: `bool("false")` is True, which would have reported a
+            successful tool as failed.
     """
 
     role: str
@@ -90,6 +96,7 @@ class ChatMessage(BaseModel):
     tool_call_id: Optional[str] = None
     reasoning: Optional[str] = None
     reasoning_content: Optional[str] = None
+    is_error: Optional[bool] = None
 
     model_config = {"extra": "allow"}
 

--- a/kiro/parsers.py
+++ b/kiro/parsers.py
@@ -121,8 +121,18 @@ def parse_bracket_tool_calls(response_text: str) -> List[Dict[str, Any]]:
             args = json.loads(json_str)
             tool_call_id = generate_tool_call_id()
             # index will be added later when forming the final response
+            # `_bracket` records provenance, not content. Recovery exists only to
+            # rescue a call the native channel missed, so a recovered call that
+            # the native channel did report is redundant by construction. The id
+            # here is minted locally and can never match the upstream one, so
+            # provenance is the only way to tell the echo from a real call.
             tool_calls.append(
-                {"id": tool_call_id, "type": "function", "function": {"name": func_name, "arguments": json.dumps(args)}}
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "_bracket": True,
+                    "function": {"name": func_name, "arguments": json.dumps(args)},
+                }
             )
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse tool call arguments: {json_str[:100]}")
@@ -130,14 +140,47 @@ def parse_bracket_tool_calls(response_text: str) -> List[Dict[str, Any]]:
     return tool_calls
 
 
+def tool_call_signature(tool_call: Dict[str, Any]) -> str:
+    """Identify a call by what it does, independent of how it was spelled.
+
+    The native channel re-serializes arguments compactly while bracket recovery
+    reads them out of prose, so the same call routinely arrives as two different
+    strings. Comparing the raw text would miss the match; unparseable arguments
+    fall back to it because there is nothing better to compare.
+    """
+    function = tool_call.get("function") or {}
+    name = function.get("name") or ""
+    raw_arguments = function.get("arguments")
+    if not isinstance(raw_arguments, str):
+        # Only a missing value becomes the empty object. Collapsing every falsy
+        # value would make 0, [] and False share a signature with a genuinely
+        # argument-less call of the same name. `default=str` keeps an
+        # unserializable value from raising inside a live stream, where the
+        # exception would truncate the response.
+        raw_arguments = json.dumps({} if raw_arguments is None else raw_arguments, sort_keys=True, default=str)
+    try:
+        canonical = json.dumps(json.loads(raw_arguments), sort_keys=True)
+    except (TypeError, ValueError):
+        canonical = raw_arguments
+    return f"{name}-{canonical}"
+
+
 def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Removes duplicate tool calls.
 
-    Deduplication occurs by two criteria:
-    1. By id - if there are multiple tool calls with the same id, keep the one with
-       more arguments (not empty "{}")
-    2. By name+arguments - remove complete duplicates
+    Deduplication occurs by three criteria:
+    1. By id - if there are multiple tool calls with the same id, keep the one
+       whose arguments actually parse, then the one with more arguments
+    2. By name+arguments - remove complete duplicates among calls without an id
+    3. By provenance - drop a bracket-recovered call the native channel already
+       reported, matched on name and canonical arguments
+
+    Criterion 3 is deliberately narrow. Two native calls with identical payloads
+    are a legitimate parallel invocation and both survive (see
+    test_preserves_distinct_ids_with_identical_payloads); suppressing every
+    recovered call whenever a native one exists is the wider guard that once
+    discarded a genuinely different call.
 
     Args:
         tool_calls: List of tool calls
@@ -160,9 +203,19 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
             # Duplicate by id exists - keep the one with more arguments
             existing_args = existing.get("function", {}).get("arguments", "{}")
             current_args = tc.get("function", {}).get("arguments", "{}")
+            existing_broken = bool(existing.get("_parse_error"))
+            current_broken = bool(tc.get("_parse_error"))
 
+            # Whether the arguments parse outranks how many there are. A
+            # truncated copy keeps its raw text while a good one is re-serialized
+            # compactly, so the broken copy is usually the longer of the two and
+            # won on size alone - handing the client arguments it cannot decode.
+            if existing_broken != current_broken:
+                if existing_broken:
+                    logger.debug(f"Replacing unparseable tool call {tc_id} with a decodable copy")
+                    by_id[tc_id] = tc
             # Prefer non-empty arguments
-            if current_args != "{}" and (existing_args == "{}" or len(current_args) > len(existing_args)):
+            elif current_args != "{}" and (existing_args == "{}" or len(current_args) > len(existing_args)):
                 logger.debug(
                     f"Replacing tool call {tc_id} with better arguments: {len(existing_args)} -> {len(current_args)}"
                 )
@@ -176,14 +229,20 @@ def deduplicate_tool_calls(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, A
     unique = list(result_with_id)
 
     for tc in result_without_id:
-        # Protection against None in function
-        func = tc.get("function") or {}
-        func_name = func.get("name") or ""
-        func_args = func.get("arguments") or "{}"
-        key = f"{func_name}-{func_args}"
+        key = tool_call_signature(tc)
         if key not in seen:
             seen.add(key)
             unique.append(tc)
+
+    # Drop recovered echoes of calls the native channel already delivered.
+    native_signatures = {tool_call_signature(tc) for tc in unique if not tc.get("_bracket")}
+    if native_signatures:
+        deduplicated = [
+            tc for tc in unique if not (tc.get("_bracket") and tool_call_signature(tc) in native_signatures)
+        ]
+        if len(deduplicated) != len(unique):
+            logger.debug(f"Dropped {len(unique) - len(deduplicated)} bracket echo(es) of native tool call(s)")
+            unique = deduplicated
 
     if len(tool_calls) != len(unique):
         logger.debug(f"Deduplicated tool calls: {len(tool_calls)} -> {len(unique)}")

--- a/kiro/routes_anthropic.py
+++ b/kiro/routes_anthropic.py
@@ -436,7 +436,7 @@ async def messages(
                         error_json = json.loads(error_text)
                         from kiro.kiro_errors import enhance_kiro_error
 
-                        error_info = enhance_kiro_error(error_json)
+                        error_info = enhance_kiro_error(error_json, status_code=response.status_code)
                         error_reason = error_info.reason
                         upstream_message = error_info.original_message or error_text
                         last_error_message = error_info.user_message

--- a/kiro/routes_openai.py
+++ b/kiro/routes_openai.py
@@ -529,7 +529,7 @@ async def chat_completions(request: Request, request_data: ChatCompletionRequest
                         error_json = json.loads(error_text)
                         from kiro.kiro_errors import enhance_kiro_error
 
-                        error_info = enhance_kiro_error(error_json)
+                        error_info = enhance_kiro_error(error_json, status_code=response.status_code)
                         error_reason = error_info.reason
                         upstream_message = error_info.original_message or error_text
                         last_error_message = error_info.user_message

--- a/kiro/stop_reasons.py
+++ b/kiro/stop_reasons.py
@@ -22,6 +22,8 @@ _OPENAI: dict[str, str] = {
     "TOOL_USE": "tool_calls",
     "CONTENT_FILTERED": "content_filter",
     "CONTENT_FILTER": "content_filter",
+    "GUARDRAIL_INTERVENED": "content_filter",
+    "MODEL_CONTEXT_WINDOW_EXCEEDED": "length",
 }
 
 # Upstream value (normalized to upper case) -> Anthropic stop_reason.
@@ -35,9 +37,28 @@ _ANTHROPIC: dict[str, str] = {
     "TOOL_USE": "tool_use",
     "CONTENT_FILTERED": "refusal",
     "CONTENT_FILTER": "refusal",
+    "GUARDRAIL_INTERVENED": "refusal",
+    "MODEL_CONTEXT_WINDOW_EXCEEDED": "max_tokens",
 }
 
+# Two members of the upstream StopReason enum are deliberately absent from both
+# maps: MALFORMED_MODEL_OUTPUT and MALFORMED_TOOL_USE. Neither protocol has a
+# value for "the model emitted garbage", and every candidate misleads in its own
+# direction - max_tokens sends the client to raise a budget that was never the
+# problem, end_turn calls a broken turn complete. An unmapped reason leaves the
+# caller's own inference in place, which is the honest option here.
+
 #: Upstream reasons that mean the turn ended early rather than naturally.
+#: Membership here is stronger than the maps above: both serializers let it
+#: outrank a delivered tool call, so a reason only belongs once it is known to
+#: mean the *output* was cut short.
+#: GUARDRAIL_INTERVENED is excluded because it ends the turn for content, not
+#: length, and already maps to content_filter/refusal.
+#: MODEL_CONTEXT_WINDOW_EXCEEDED is excluded because it is not established that
+#: it describes cut-off output rather than an oversized input; its mapping
+#: already reports the limit, and adding it here would additionally suppress a
+#: tool call the model did deliver and invite an auto-continue client to resend
+#: an even larger context.
 TRUNCATING_REASONS = frozenset({"MAX_TOKENS", "MAX_TOKEN", "LENGTH"})
 
 

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -187,6 +187,9 @@ async def stream_kiro_to_anthropic(
     text_block_index: Optional[int] = None
     pending_content: List[str] = []
     tool_blocks: List[Dict[str, Any]] = []
+    # Signatures of calls the gateway answered itself, which therefore never
+    # appear in tool_blocks but are just as delivered as the ones that do.
+    intercepted_signatures: set[str] = set()
     upstream_stop_reason: Optional[str] = None
     received_upstream_event = False
 
@@ -520,6 +523,14 @@ async def stream_kiro_to_anthropic(
                         )
                         current_block_index += 1
 
+                        # This call was answered here, so it never joins
+                        # tool_blocks. Record its signature anyway: bracket
+                        # recovery has to see it as already delivered, or an echo
+                        # of it becomes a tool_use block the client runs itself,
+                        # performing the same search a second time.
+                        intercepted_signatures.add(
+                            tool_call_signature({"function": {"name": tool_name, "arguments": json.dumps(tool_input)}})
+                        )
                         summary = generate_search_summary(query, results)
                         pending_response = await make_search_request(tool_id, query, summary)
                         upstream_stop_reason = None
@@ -610,7 +621,7 @@ async def stream_kiro_to_anthropic(
         native_signatures = {
             tool_call_signature({"function": {"name": block["name"], "arguments": json.dumps(block["input"])}})
             for block in tool_blocks
-        }
+        } | intercepted_signatures
         bracket_tool_calls = [
             tool_call
             for tool_call in parse_bracket_tool_calls(full_content)

--- a/kiro/streaming_anthropic.py
+++ b/kiro/streaming_anthropic.py
@@ -21,7 +21,7 @@ import httpx
 from loguru import logger
 
 from kiro.config import FIRST_TOKEN_MAX_RETRIES, FIRST_TOKEN_TIMEOUT
-from kiro.parsers import parse_bracket_tool_calls
+from kiro.parsers import parse_bracket_tool_calls, tool_call_signature
 from kiro.sse_validation import (
     StreamProtocolError,
     begin_anthropic_stream,
@@ -589,8 +589,33 @@ async def stream_kiro_to_anthropic(
             yield format_sse_event("message_start", message_start_data)
             message_started = True
 
-        # Check for bracket-style tool calls in full content
-        bracket_tool_calls = parse_bracket_tool_calls(full_content)
+        # Flush buffered prose before recovering any bracket call. Prose that
+        # arrived while a thinking block was open was never emitted, and the
+        # narration introduces the tool call, so emitting the tool first puts
+        # text after a `stop_reason: tool_use` block - an order the real API
+        # never produces. Only a reasoning turn buffers, which is why the
+        # inversion appeared exclusively with thinking enabled.
+        if pending_content:
+            for pending_chunk in flush_pending_content(True):
+                yield pending_chunk
+
+        # Check for bracket-style tool calls in full content. Recovery exists to
+        # rescue a call the native channel missed, so an echo of one it already
+        # delivered has to be dropped: this path ran no deduplication at all, and
+        # the recovered id is minted locally, so the echo became a second
+        # tool_use block that the client executes as a separate call.
+        # Redundancy is matched on name and canonical arguments, never on the
+        # mere presence of a native call - that wider rule has already discarded
+        # a genuinely different call once.
+        native_signatures = {
+            tool_call_signature({"function": {"name": block["name"], "arguments": json.dumps(block["input"])}})
+            for block in tool_blocks
+        }
+        bracket_tool_calls = [
+            tool_call
+            for tool_call in parse_bracket_tool_calls(full_content)
+            if tool_call_signature(tool_call) not in native_signatures
+        ]
         if bracket_tool_calls:
             # Close thinking block if open
             if thinking_block_started and thinking_block_index is not None:
@@ -642,10 +667,6 @@ async def stream_kiro_to_anthropic(
 
                 tool_blocks.append({"id": tool_id, "name": tool_name, "input": tool_input})
                 current_block_index += 1
-
-        if pending_content:
-            for pending_chunk in flush_pending_content(True):
-                yield pending_chunk
 
         # Close thinking block if still open
         if thinking_block_started and thinking_block_index is not None:

--- a/kiro/streaming_core.py
+++ b/kiro/streaming_core.py
@@ -300,9 +300,16 @@ async def collect_stream_to_result(
     bracket_tool_calls = parse_bracket_tool_calls(full_content_for_bracket_tools)
     if bracket_tool_calls:
         result.tool_calls = deduplicate_tool_calls(result.tool_calls + bracket_tool_calls)
+        # Only calls that survived deduplication may join the timeline. Keying
+        # this on the id alone let an echo through every time: a recovered id is
+        # minted locally, so it is never present in the native timeline, and the
+        # block was appended even after deduplication had already dropped the
+        # call - leaving content_blocks and tool_calls describing different turns.
+        surviving_ids = {tool_call.get("id") for tool_call in result.tool_calls}
         timeline_tool_ids = {block["tool"].get("id") for block in result.content_blocks if block["type"] == "tool_use"}
         for tool_call in bracket_tool_calls:
-            if tool_call.get("id") not in timeline_tool_ids:
+            tool_call_id = tool_call.get("id")
+            if tool_call_id in surviving_ids and tool_call_id not in timeline_tool_ids:
                 result.content_blocks.append(
                     {
                         "type": "tool_use",

--- a/tests/unit/test_account_suspension.py
+++ b/tests/unit/test_account_suspension.py
@@ -51,19 +51,54 @@ class TestSuspensionDetection:
         assert is_suspension_error(403, _SUSPENDED_BODY_RUNTIME["message"]) is True
 
     def test_enhance_kiro_error_labels_the_runtime_suspension(self):
-        info = enhance_kiro_error(_SUSPENDED_BODY_RUNTIME)
+        info = enhance_kiro_error(_SUSPENDED_BODY_RUNTIME, status_code=403)
 
         assert info.reason == SUSPENSION_REASON
         assert "suspended" in info.user_message.lower()
 
     def test_enhance_kiro_error_labels_the_suspension(self):
-        info = enhance_kiro_error(_SUSPENDED_BODY)
+        info = enhance_kiro_error(_SUSPENDED_BODY, status_code=403)
 
         assert info.reason == SUSPENSION_REASON
         assert "suspended" in info.user_message.lower()
 
+    def test_enhance_kiro_error_does_not_label_a_400_echo_as_a_suspension(self):
+        """The status guard must survive the trip through enhance_kiro_error.
+
+        `is_suspension_error` takes the status precisely so payload wording cannot
+        be mistaken for a verdict about the account, but this function used to
+        pass a hardcoded 403 and defeated that guard. A validation error whose
+        message echoes prompt text containing the suspension wording then made
+        the gateway report a healthy account as locked, and hand back
+        reason=TEMPORARILY_SUSPENDED.
+        """
+        echoed = {"message": _SUSPENDED_BODY["message"], "reason": None}
+
+        info = enhance_kiro_error(echoed, status_code=400)
+
+        assert info.reason != SUSPENSION_REASON
+        assert "suspended by kiro" not in info.user_message.lower()
+
+    def test_enhance_kiro_error_without_a_status_does_not_claim_suspension(self):
+        """An unknown status is not evidence, so it must not convict the account."""
+        info = enhance_kiro_error(_SUSPENDED_BODY)
+
+        assert info.reason != SUSPENSION_REASON
+
     def test_plain_403_is_not_a_suspension(self):
         assert is_suspension_error(403, "Improperly formed request.") is False
+
+    def test_reason_code_is_conclusive_on_any_status(self):
+        """The reason field is set by the upstream, so it cannot be a payload echo.
+
+        Gating it on 403 like the wording heuristic would let a suspension
+        arriving with any other status slip through, leaving the account in
+        rotation burning attempts on a verdict it already reported.
+        """
+        assert is_suspension_error(500, None, SUSPENSION_REASON) is True
+        assert enhance_kiro_error({"message": "nope", "reason": SUSPENSION_REASON}, status_code=500).reason == (
+            SUSPENSION_REASON
+        )
 
     def test_suspension_wording_on_another_status_is_not_a_suspension(self):
         # Only an authorization refusal carries this meaning; the same words in a

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -1244,6 +1244,31 @@ class TestMergeAdjacentMessages:
         assert len(result[0].images) == 1
         assert result[0].images[0]["data"] == TEST_IMAGE_BASE64
 
+    def test_merges_images_across_mixed_representations(self):
+        """An image can live in `images` or inside a content block; both must survive.
+
+        `build_kiro_payload` reads `msg.images or extract_images_from_content(...)`,
+        so once the merged message has any explicit image the content blocks are
+        never inspected and whatever they carried is dropped. Neither adapter
+        produces this mix today - both populate `images` whenever content holds
+        one - but the merge is reachable from the core directly, and losing an
+        image silently is the failure this whole area exists to prevent.
+        """
+        messages = [
+            UnifiedMessage(role="user", content="", images=[{"media_type": "image/png", "data": "explicit"}]),
+            UnifiedMessage(
+                role="user",
+                content=[
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "in_content"}}
+                ],
+            ),
+        ]
+
+        result = merge_adjacent_messages(messages)
+
+        assert len(result) == 1
+        assert [image["data"] for image in result[0].images] == ["explicit", "in_content"]
+
     def test_merges_images_from_both_messages_in_order(self):
         """
         What it does: Verifies images from both merged messages are concatenated.

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -1269,6 +1269,34 @@ class TestMergeAdjacentMessages:
         assert len(result) == 1
         assert [image["data"] for image in result[0].images] == ["explicit", "in_content"]
 
+    def test_merges_content_block_images_without_duplicating_them(self):
+        """Content is merged before images are, so the fallback must not re-read it.
+
+        When neither message sets `images`, both lists come from content blocks -
+        and by the time the image merge runs, `last.content` already holds the
+        later message's blocks. Extracting from it there counts those blocks once
+        as the previous images and once as the current ones, so the model receives
+        the same picture twice and pays for it twice.
+        """
+        messages = [
+            UnifiedMessage(
+                role="user",
+                content=[{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "first"}}],
+            ),
+            UnifiedMessage(
+                role="user",
+                content=[
+                    {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "second"}},
+                    {"type": "text", "text": "e agora?"},
+                ],
+            ),
+        ]
+
+        result = merge_adjacent_messages(messages)
+
+        assert len(result) == 1
+        assert [image["data"] for image in result[0].images] == ["first", "second"]
+
     def test_merges_images_from_both_messages_in_order(self):
         """
         What it does: Verifies images from both merged messages are concatenated.

--- a/tests/unit/test_converters_core.py
+++ b/tests/unit/test_converters_core.py
@@ -1216,6 +1216,52 @@ class TestMergeAdjacentMessages:
         assert result[0].tool_results is not None
         assert len(result[0].tool_results) == 2
 
+    def test_merges_images_from_the_later_message(self):
+        """
+        What it does: Verifies images on the second of two merged messages survive.
+        Purpose: The merge carried content, tool_calls, reasoning and tool_results
+        across but never images, so the later message's images were dropped with
+        no log. Every other function in the pipeline propagates them explicitly
+        (strip_all_tool_content, normalize_message_roles), which is what made the
+        omission invisible.
+        """
+        print("Setup: Two user messages, only the second carrying an image...")
+        messages = [
+            UnifiedMessage(role="user", content="look at this"),
+            UnifiedMessage(
+                role="user",
+                content="what is it?",
+                images=[{"media_type": "image/jpeg", "data": TEST_IMAGE_BASE64}],
+            ),
+        ]
+
+        print("Action: Merging messages...")
+        result = merge_adjacent_messages(messages)
+
+        print(f"Result images: {result[0].images}")
+        assert len(result) == 1
+        assert result[0].images is not None
+        assert len(result[0].images) == 1
+        assert result[0].images[0]["data"] == TEST_IMAGE_BASE64
+
+    def test_merges_images_from_both_messages_in_order(self):
+        """
+        What it does: Verifies images from both merged messages are concatenated.
+        Purpose: Merging is a concatenation for content and tool lists; images
+        must follow the same rule rather than one side winning.
+        """
+        print("Setup: Two user messages, each carrying an image...")
+        messages = [
+            UnifiedMessage(role="user", content="first", images=[{"media_type": "image/jpeg", "data": "first_data"}]),
+            UnifiedMessage(role="user", content="second", images=[{"media_type": "image/png", "data": "second_data"}]),
+        ]
+
+        print("Action: Merging messages...")
+        result = merge_adjacent_messages(messages)
+
+        assert len(result) == 1
+        assert [image["data"] for image in result[0].images] == ["first_data", "second_data"]
+
 
 # ==================================================================================================
 # Tests for ensure_first_message_is_user
@@ -2684,6 +2730,26 @@ class TestExtractToolResults:
         assert len(result) == 2
         assert result[0]["toolUseId"] == "call_1"
         assert result[1]["toolUseId"] == "call_2"
+
+    def test_reports_a_failed_tool_result_as_an_error(self):
+        """
+        What it does: Verifies is_error on the block becomes status="error".
+        Purpose: This function hardcoded status="success" while
+        convert_tool_results_to_kiro_format, thirty lines away, derived it from
+        is_error. Two functions filling the same Kiro field by different rules
+        meant a stack trace reached the model labelled as a successful result.
+        """
+        print("Setup: tool_result block flagged as an error...")
+        content = [
+            {"type": "tool_result", "tool_use_id": "call_boom", "content": "Traceback...", "is_error": True},
+            {"type": "tool_result", "tool_use_id": "call_ok", "content": "fine"},
+        ]
+
+        print("Action: Extracting tool results...")
+        result = extract_tool_results_from_content(content)
+
+        print(f"Result: {result}")
+        assert [item["status"] for item in result] == ["error", "success"]
 
 
 # ==================================================================================================

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -123,6 +123,28 @@ class TestConvertOpenAIMessagesToUnified:
         print(f"Unified tool_results: {unified[0].tool_results}")
         assert unified[0].tool_results[0]["is_error"] is True
 
+    def test_a_non_boolean_is_error_does_not_mark_a_result_as_failed(self):
+        """Only a real boolean may flip the Kiro status.
+
+        An inline tool_result block lives inside `content`, which is typed
+        loosely and never validated, so `bool()` on it turned the string "false"
+        - and any other non-empty value - into a failure, reporting a working
+        tool as broken. The tool-message path is validated by pydantic instead.
+        """
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[
+                    {"type": "tool_result", "tool_use_id": "c1", "content": "tudo certo", "is_error": "false"},
+                    {"type": "tool_result", "tool_use_id": "c2", "content": "falhou", "is_error": True},
+                ],
+            )
+        ]
+
+        _system_prompt, unified = convert_openai_messages_to_unified(messages)
+
+        assert [result["is_error"] for result in unified[0].tool_results] == [False, True]
+
     def test_converts_multiple_tool_messages(self):
         """
         What it does: Verifies conversion of multiple consecutive tool messages.

--- a/tests/unit/test_converters_openai.py
+++ b/tests/unit/test_converters_openai.py
@@ -82,6 +82,47 @@ class TestConvertOpenAIMessagesToUnified:
         assert len(unified[0].tool_results) == 1
         assert unified[0].tool_results[0]["tool_use_id"] == "call_123"
 
+    def test_marks_a_failed_tool_message_as_an_error(self):
+        """
+        What it does: Verifies is_error on a tool message survives conversion.
+        Purpose: Kiro's toolResult carries a status field and the Anthropic
+        adapter fills it, but this path never set is_error at all, so
+        convert_tool_results_to_kiro_format always reported "success". A tool
+        that failed was handed to the model as one that worked.
+        """
+        print("Setup: Tool message flagged as an error...")
+        messages = [
+            ChatMessage(role="tool", content="Traceback...", tool_call_id="call_boom", is_error=True),
+            ChatMessage(role="tool", content="fine", tool_call_id="call_ok"),
+        ]
+
+        print("Action: Converting messages...")
+        _system_prompt, unified = convert_openai_messages_to_unified(messages)
+
+        print(f"Unified tool_results: {unified[0].tool_results}")
+        assert [result.get("is_error") for result in unified[0].tool_results] == [True, False]
+
+    def test_marks_a_failed_tool_result_block_as_an_error(self):
+        """
+        What it does: Verifies is_error on an inline tool_result block survives.
+        Purpose: Some clients send Anthropic-shaped tool_result blocks inside an
+        OpenAI user message; those blocks do define is_error, and dropping it
+        loses the same fact as the tool-message path above.
+        """
+        print("Setup: User message carrying a failed tool_result block...")
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[{"type": "tool_result", "tool_use_id": "call_boom", "content": "boom", "is_error": True}],
+            )
+        ]
+
+        print("Action: Converting messages...")
+        _system_prompt, unified = convert_openai_messages_to_unified(messages)
+
+        print(f"Unified tool_results: {unified[0].tool_results}")
+        assert unified[0].tool_results[0]["is_error"] is True
+
     def test_converts_multiple_tool_messages(self):
         """
         What it does: Verifies conversion of multiple consecutive tool messages.
@@ -208,6 +249,7 @@ class TestConvertOpenAIMessagesToUnified:
                 "type": "tool_result",
                 "tool_use_id": "call_echo",
                 "content": "MULTITURN_ALPHA",
+                "is_error": False,
             }
         ]
         assert unified[3].content == "Reply with TOOL_CONTINUATION_OK"

--- a/tests/unit/test_endpoint_rotation.py
+++ b/tests/unit/test_endpoint_rotation.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Generation endpoint rotation tests."""
 
+from unittest.mock import AsyncMock, Mock
+
 import httpx
 import pytest
 
@@ -260,6 +262,37 @@ class TestRotationBehavior:
         client._attempt_endpoint = fake_attempt
         response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD)
         assert response.status_code == 503
+
+    async def test_exhausted_5xx_stream_is_returned_with_a_readable_body(self, monkeypatch):
+        """The rotation layer must capture the error body before closing the stream.
+
+        This is the same defect as in the per-endpoint retry loop: the 5xx was
+        stored as the fallback answer and then closed, so the route's
+        `await response.aread()` raised and its except branch replaced the
+        upstream reason with "Unknown error" - losing exactly the text that
+        decides whether the account should fail over.
+        """
+        client = _client(monkeypatch)
+        events: list[str] = []
+
+        def make_response():
+            response = Mock(status_code=503)
+            response.aread = AsyncMock(side_effect=lambda: (events.append("read"), b'{"message":"down"}')[1])
+            response.aclose = AsyncMock(side_effect=lambda: events.append("close"))
+            return response
+
+        async def fake_attempt(method, url, **kwargs):
+            return make_response()
+
+        client._attempt_endpoint = fake_attempt
+        response = await client.request_with_retry("POST", _GENERATION_URL, _PAYLOAD, stream=True)
+
+        assert response.status_code == 503
+        assert events, "the error body was never read"
+        assert events[0] == "read"
+        assert all(events[index] != "close" or events[index - 1] == "read" for index in range(1, len(events))), (
+            f"a response was closed before its body was read: {events}"
+        )
 
     async def test_exhausted_transport_error_reaches_the_rotation_layer(self, monkeypatch):
         """Regression: _attempt_endpoint converted an exhausted transport error

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1298,3 +1298,90 @@ class TestStreamRetryCleanup:
         first_response.aclose.assert_awaited_once()
         success_response.aclose.assert_not_awaited()
         assert events == ["send", "close-first", "send"]
+
+
+class _AsyncBytes(httpx.AsyncByteStream):
+    """Minimal async stream so a test can build an unread httpx streaming response."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    async def __aiter__(self):
+        yield self._payload
+
+
+class TestExhaustedRetriesReachTheCaller:
+    """What the caller receives once same-account retries are spent."""
+
+    @pytest.mark.asyncio
+    async def test_a_403_that_never_clears_is_returned_for_classification(self, mock_auth_manager_for_http):
+        """A 403 surviving every refresh must reach the route, not become a 502.
+
+        The 403 branch refreshed and continued without recording the response, so
+        an account answering 403 to every attempt left every `last_*` slot empty
+        and fell through to the generic "Unknown error" HTTPException.
+        `classify_error(403)` - which returns RECOVERABLE - never ran, so there
+        was no report_failure and no account rotation: one unlucky account failed
+        the whole request behind an opaque 502.
+        """
+        http_client = KiroHttpClient(mock_auth_manager_for_http)
+
+        forbidden = AsyncMock()
+        forbidden.status_code = 403
+        forbidden.aread = AsyncMock(return_value=b'{"message": "Forbidden", "reason": null}')
+
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=forbidden)
+
+        with patch.object(http_client, "_get_client", return_value=mock_client):
+            with patch("kiro.http_client.get_kiro_headers", return_value={}):
+                response = await http_client.request_with_retry("POST", "https://api.example.com/test", {"a": 1})
+
+        assert response.status_code == 403
+        assert mock_auth_manager_for_http.force_refresh.await_count >= 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [503, 429])
+    async def test_an_exhausted_error_stream_still_carries_its_body(self, status_code, mock_auth_manager_for_http):
+        """The error body must survive the stream being discarded.
+
+        A streamed 429/5xx was stored as `last_response` and then closed, and
+        that same closed response was returned once retries ran out. The route's
+        `await response.aread()` then raised, its except branch substituted
+        "Unknown error", and the upstream's real reason - the thing that decides
+        whether to fail over - was lost.
+
+        Driven through a real httpx.Response rather than a mock, so the assertion
+        is that the body is genuinely decodable afterwards; a helper that read the
+        bytes and dropped them would satisfy a call-order check but not this.
+        """
+        http_client = KiroHttpClient(mock_auth_manager_for_http)
+        body = b'{"message":"upstream refused","reason":"MONTHLY_REQUEST_COUNT"}'
+        responses: list[httpx.Response] = []
+
+        def make_response():
+            response = httpx.Response(
+                status_code=status_code,
+                stream=_AsyncBytes(body),
+                request=httpx.Request("POST", "https://example.invalid"),
+            )
+            responses.append(response)
+            return response
+
+        mock_client = Mock()
+        mock_client.build_request.return_value = Mock()
+        mock_client.send = AsyncMock(side_effect=lambda *a, **k: make_response())
+
+        with (
+            patch.object(http_client, "_get_client", return_value=mock_client),
+            patch("kiro.http_client.get_kiro_headers", return_value={}),
+            patch("kiro.http_client.asyncio.sleep", new=AsyncMock()),
+        ):
+            response = await http_client.request_with_retry(
+                "POST", "https://example.invalid", stream=True, retry_rate_limits=True
+            )
+
+        assert response.status_code == status_code
+        # The whole point: readable after the stream was closed and discarded.
+        assert response.json()["reason"] == "MONTHLY_REQUEST_COUNT"

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1342,6 +1342,42 @@ class TestExhaustedRetriesReachTheCaller:
         assert mock_auth_manager_for_http.force_refresh.await_count >= 1
 
     @pytest.mark.asyncio
+    async def test_a_later_transport_failure_outranks_an_earlier_http_refusal(self, mock_auth_manager_for_http):
+        """The last thing that happened is what the caller must act on.
+
+        Recording the 403 so it can be classified made it linger: a transport
+        failure on a later attempt left the stale 403 in `last_response`, and the
+        post-loop check returns a response before it raises, so the proxy and
+        endpoint layers - which rotate on a transport error and not on a status -
+        were handed a 403 that no longer described reality and never rotated.
+        """
+        http_client = KiroHttpClient(mock_auth_manager_for_http)
+
+        forbidden = AsyncMock()
+        forbidden.status_code = 403
+        forbidden.aread = AsyncMock(return_value=b'{"message": "Forbidden", "reason": null}')
+
+        attempts = {"count": 0}
+
+        async def request(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                return forbidden
+            raise httpx.ConnectError("connection refused")
+
+        mock_client = AsyncMock()
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=request)
+
+        with (
+            patch.object(http_client, "_get_client", return_value=mock_client),
+            patch("kiro.http_client.get_kiro_headers", return_value={}),
+            patch("kiro.http_client.asyncio.sleep", new=AsyncMock()),
+        ):
+            with pytest.raises(httpx.ConnectError):
+                await http_client._attempt_endpoint("POST", "https://api.example.com/test", {"a": 1})
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("status_code", [503, 429])
     async def test_an_exhausted_error_stream_still_carries_its_body(self, status_code, mock_auth_manager_for_http):
         """The error body must survive the stream being discarded.

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -381,6 +381,80 @@ class TestDeduplicateToolCalls:
         call_1 = next(tc for tc in result if tc["id"] == "call_1")
         assert call_1["function"]["arguments"] == '{"x": 1}'
 
+    def test_bracket_recovery_of_an_already_native_call_is_dropped(self):
+        """A bracket echo of a call the native channel already reported must not double.
+
+        Bracket recovery mints a fresh id, so the id pass can never match the
+        native call, and the name+arguments pass only ever looked at id-less
+        entries. The echo therefore survived as a second call and the client
+        executed the same edit twice.
+        """
+        tool_calls = [
+            {"id": "toolu_native", "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'}},
+            {
+                "id": "call_bracket",
+                "_bracket": True,
+                "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'},
+            },
+        ]
+
+        result = deduplicate_tool_calls(tool_calls)
+
+        assert [call["id"] for call in result] == ["toolu_native"]
+
+    def test_bracket_call_the_native_channel_missed_survives(self):
+        """Only a provably redundant echo is suppressed, never a different call.
+
+        Dropping every bracket call whenever any native call exists is the wider
+        guard this project has already shipped once: it discarded a genuinely
+        different call. Redundancy has to be proven by name and arguments.
+        """
+        tool_calls = [
+            {"id": "toolu_native", "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'}},
+            {"id": "call_bracket", "_bracket": True, "function": {"name": "Bash", "arguments": '{"command": "ls"}'}},
+        ]
+
+        result = deduplicate_tool_calls(tool_calls)
+
+        assert [call["id"] for call in result] == ["toolu_native", "call_bracket"]
+
+    def test_bracket_duplicate_is_matched_despite_key_order_and_spacing(self):
+        """The native channel compacts its arguments; the echo comes from raw text.
+
+        Comparing the JSON strings verbatim would let the same call through twice
+        purely because the model spelled the object differently in prose.
+        """
+        tool_calls = [
+            {"id": "toolu_native", "function": {"name": "Edit", "arguments": '{"a":1,"b":2}'}},
+            {"id": "call_bracket", "_bracket": True, "function": {"name": "Edit", "arguments": '{"b": 2, "a": 1}'}},
+        ]
+
+        result = deduplicate_tool_calls(tool_calls)
+
+        assert [call["id"] for call in result] == ["toolu_native"]
+
+    def test_prefers_the_parseable_argument_over_the_longer_truncated_one(self):
+        """Length is the wrong tiebreaker when one copy failed to parse.
+
+        The parser compacts arguments that parse and leaves the truncated ones
+        raw, so the broken copy is routinely the longer one and won on size
+        alone - handing the client the arguments that cannot be decoded.
+        """
+        tool_calls = [
+            {
+                "id": "toolu_cut",
+                "function": {"name": "Write", "arguments": '{"path":"/tmp/x","content":"a very long unterminated'},
+                "_parse_error": {"type": "invalid_tool_arguments", "message": "boom"},
+            },
+            {"id": "toolu_cut", "function": {"name": "Write", "arguments": '{"path":"/tmp/x"}'}},
+        ]
+
+        result = deduplicate_tool_calls(tool_calls)
+
+        assert len(result) == 1
+        assert result[0]["function"]["arguments"] == '{"path":"/tmp/x"}'
+        assert "_parse_error" not in result[0]
+
 
 class TestAwsEventStreamParserInitialization:
     """Tests for AwsEventStreamParser initialization."""

--- a/tests/unit/test_stream_integrity.py
+++ b/tests/unit/test_stream_integrity.py
@@ -63,6 +63,11 @@ def test_blank_stop_reason_is_ignored():
         ("TOOL_USE", "tool_calls", "tool_use"),
         ("CONTENT_FILTERED", "content_filter", "refusal"),
         ("end_turn", "stop", "end_turn"),
+        # Both are in the upstream StopReason enum and were absent from the maps,
+        # so a filtered or context-exhausted turn was reported as a clean finish -
+        # the single failure mode this module exists to prevent.
+        ("GUARDRAIL_INTERVENED", "content_filter", "refusal"),
+        ("MODEL_CONTEXT_WINDOW_EXCEEDED", "length", "max_tokens"),
     ],
 )
 def test_known_reasons_map_to_both_protocols(upstream, openai, anthropic):
@@ -77,10 +82,38 @@ def test_unknown_reason_does_not_invent_a_value():
     assert normalize(None) is None
 
 
+def test_malformed_output_reasons_stay_unmapped():
+    """Neither protocol has a value for "the model emitted garbage".
+
+    Mapping these onto max_tokens would tell the client to retry with a bigger
+    budget, and onto end_turn would call a broken turn complete. Both are wrong
+    in a different direction, so the caller keeps its own inference and the
+    absence is deliberate rather than an oversight.
+    """
+    for reason in ("MALFORMED_MODEL_OUTPUT", "MALFORMED_TOOL_USE"):
+        assert to_openai_finish_reason(reason) is None
+        assert to_anthropic_stop_reason(reason) is None
+
+
 def test_truncation_is_detected_from_upstream_reason():
     assert is_truncated("MAX_TOKENS")
     assert not is_truncated("END_TURN")
     assert not is_truncated(None)
+
+
+def test_only_output_truncation_outranks_a_delivered_tool_call():
+    """Membership in TRUNCATING_REASONS suppresses tool calls, so it stays narrow.
+
+    Both serializers test truncation before tool calls, so anything listed here
+    hides a tool_use block the model actually delivered. A guardrail block ends
+    the turn for content, not length, and a context-window refusal is not known
+    to describe cut-off output rather than an oversized input - so neither is
+    listed, and their mappings already tell the client the turn was not clean.
+    """
+    assert not is_truncated("GUARDRAIL_INTERVENED")
+    assert not is_truncated("MODEL_CONTEXT_WINDOW_EXCEEDED")
+    assert to_anthropic_stop_reason("MODEL_CONTEXT_WINDOW_EXCEEDED") == "max_tokens"
+    assert to_openai_finish_reason("GUARDRAIL_INTERVENED") == "content_filter"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -645,6 +645,163 @@ class TestStreamKiroToAnthropic:
         print("✓ Bracket tool calls handled correctly")
 
     @pytest.mark.asyncio
+    async def test_bracket_tool_call_emits_buffered_prose_before_the_tool_block(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """Prose buffered behind an open thinking block must precede the tool it introduces.
+
+        Prose that arrives while a thinking block is open is held in a buffer, so
+        the only thing that can emit it is a flush. The bracket-recovery path ran
+        before that flush, which put the narration after the tool_use block - an
+        order the real API never produces for a `stop_reason: tool_use` turn.
+        Without thinking the same upstream stream came out in the right order,
+        which is what made this specific to a reasoning turn.
+        """
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(type="thinking", thinking_content="the user wants an edit")
+            yield KiroEvent(type="content", content="Vou editar o arquivo. ")
+            yield KiroEvent(type="content", content='[Called Edit with args: {"file_path": "a.py"}]')
+
+        bracket_tool_calls = [
+            {"id": "call_bracket", "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'}}
+        ]
+
+        chunks: list[str] = []
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=bracket_tool_calls):
+                async for chunk in stream_kiro_to_anthropic(
+                    mock_response, "claude-opus-5", mock_model_cache, mock_auth_manager
+                ):
+                    chunks.append(chunk)
+
+        events = parse_sse_events(chunks)
+        assert_valid_content_event_order(events)
+        starts = [event for event in events if event["type"] == "content_block_start"]
+        assert [event["content_block"]["type"] for event in starts] == ["thinking", "text", "tool_use"]
+        assert [event["index"] for event in starts] == [0, 1, 2]
+        # The buffered narration must survive the reordering, not just move.
+        assert "".join(
+            event["delta"]["text"]
+            for event in events
+            if event["type"] == "content_block_delta" and event["delta"]["type"] == "text_delta"
+        ) == ('Vou editar o arquivo. [Called Edit with args: {"file_path": "a.py"}]')
+
+    @pytest.mark.asyncio
+    async def test_bracket_echo_of_a_native_tool_call_is_not_emitted_twice(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """A model that calls a tool natively and also echoes it must not run it twice.
+
+        This path never ran the recovered calls through deduplication at all, so
+        an echo became a second tool_use block with its own id. The client has no
+        way to tell it apart from a real parallel call and executes the same edit
+        again.
+        """
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "toolu_native", "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'}},
+            )
+            yield KiroEvent(type="content", content='[Called Edit with args: {"file_path": "a.py"}]')
+            yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
+
+        echo = [
+            {
+                "id": "call_bracket",
+                "_bracket": True,
+                "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'},
+            }
+        ]
+
+        chunks: list[str] = []
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=echo):
+                async for chunk in stream_kiro_to_anthropic(
+                    mock_response, "claude-opus-5", mock_model_cache, mock_auth_manager
+                ):
+                    chunks.append(chunk)
+
+        events = parse_sse_events(chunks)
+        assert_valid_content_event_order(events)
+        tool_starts = [
+            event
+            for event in events
+            if event["type"] == "content_block_start" and event["content_block"]["type"] == "tool_use"
+        ]
+        assert [event["content_block"]["id"] for event in tool_starts] == ["toolu_native"]
+
+    @pytest.mark.asyncio
+    async def test_bracket_call_absent_from_the_native_channel_is_still_recovered(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """Suppression must be limited to the echo, never to a different call."""
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "toolu_native", "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'}},
+            )
+            yield KiroEvent(type="content", content='[Called Bash with args: {"command": "ls"}]')
+            yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
+
+        recovered = [
+            {"id": "call_bracket", "_bracket": True, "function": {"name": "Bash", "arguments": '{"command": "ls"}'}}
+        ]
+
+        chunks: list[str] = []
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=recovered):
+                async for chunk in stream_kiro_to_anthropic(
+                    mock_response, "claude-opus-5", mock_model_cache, mock_auth_manager
+                ):
+                    chunks.append(chunk)
+
+        events = parse_sse_events(chunks)
+        assert_valid_content_event_order(events)
+        tool_starts = [
+            event
+            for event in events
+            if event["type"] == "content_block_start" and event["content_block"]["type"] == "tool_use"
+        ]
+        assert [event["content_block"]["name"] for event in tool_starts] == ["Edit", "Bash"]
+
+    @pytest.mark.asyncio
+    async def test_upstream_truncation_outranks_a_delivered_tool_call(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """An explicit upstream MAX_TOKENS stays `max_tokens`, even with a tool block sent.
+
+        This pins a deliberate asymmetry that reads like a bug. `content_was_truncated`
+        is inferred locally from missing completion signals, so it defers to a
+        delivered tool call; `is_truncated(upstream_stop_reason)` is the upstream
+        stating why it stopped, so it does not. Reporting `tool_use` here would
+        claim the turn finished by calling a tool when generation was actually cut
+        off mid-turn, hiding the calls the model never got to emit.
+        """
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={"id": "toolu_edit", "function": {"name": "Edit", "arguments": "{}"}},
+            )
+            yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
+            yield KiroEvent(type="stop_reason", stop_reason="MAX_TOKENS")
+
+        chunks: list[str] = []
+        with patch("kiro.streaming_anthropic.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=[]):
+                async for chunk in stream_kiro_to_anthropic(
+                    mock_response, "claude-opus-5", mock_model_cache, mock_auth_manager
+                ):
+                    chunks.append(chunk)
+
+        events = parse_sse_events(chunks)
+        message_delta = next(event for event in events if event["type"] == "message_delta")
+        assert message_delta["delta"]["stop_reason"] == "max_tokens"
+
+    @pytest.mark.asyncio
     async def test_closes_response_on_completion(self, mock_response, mock_model_cache, mock_auth_manager):
         """
         What it does: Closes response on completion.

--- a/tests/unit/test_streaming_anthropic.py
+++ b/tests/unit/test_streaming_anthropic.py
@@ -733,6 +733,75 @@ class TestStreamKiroToAnthropic:
         assert [event["content_block"]["id"] for event in tool_starts] == ["toolu_native"]
 
     @pytest.mark.asyncio
+    async def test_bracket_echo_of_an_intercepted_web_search_is_not_re_emitted(
+        self, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """An intercepted web_search is served locally and never joins tool_blocks.
+
+        The redundancy check reads the native signatures out of `tool_blocks`, and
+        the interception path returns before appending to it, so an echo of the
+        very call that was just answered looked unseen and became a `tool_use`
+        block the client would execute itself - a second, real search.
+        """
+
+        async def first_then_followup(*args, **kwargs):
+            if first_then_followup.calls == 0:
+                first_then_followup.calls += 1
+                yield KiroEvent(
+                    type="tool_use",
+                    tool_use={
+                        "id": "toolu_ws",
+                        "function": {"name": "web_search", "arguments": '{"query": "kiro news"}'},
+                    },
+                )
+                yield KiroEvent(type="content", content='[Called web_search with args: {"query": "kiro news"}]')
+                yield KiroEvent(type="context_usage", context_usage_percentage=4.0)
+            else:
+                yield KiroEvent(type="content", content="here is what I found")
+                yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
+
+        first_then_followup.calls = 0
+
+        echo = [
+            {
+                "id": "call_bracket_ws",
+                "_bracket": True,
+                "function": {"name": "web_search", "arguments": '{"query": "kiro news"}'},
+            }
+        ]
+
+        async def make_search_request(tool_use_id, query, result_content):
+            followup = AsyncMock()
+            followup.status_code = 200
+            return followup
+
+        chunks: list[str] = []
+        with (
+            patch("kiro.streaming_anthropic.parse_kiro_stream", first_then_followup),
+            patch("kiro.streaming_anthropic.parse_bracket_tool_calls", return_value=echo),
+            patch(
+                "kiro.mcp_tools.call_kiro_mcp_api",
+                AsyncMock(return_value=("srvtoolu_1", {"results": [{"title": "t", "url": "u", "snippet": "s"}]})),
+            ),
+        ):
+            async for chunk in stream_kiro_to_anthropic(
+                mock_response,
+                "claude-opus-5",
+                mock_model_cache,
+                mock_auth_manager,
+                make_search_request=make_search_request,
+            ):
+                chunks.append(chunk)
+
+        events = parse_sse_events(chunks)
+        assert_valid_content_event_order(events)
+        starts = [event["content_block"] for event in events if event["type"] == "content_block_start"]
+        # server_tool_use is the gateway answering the search itself; a plain
+        # tool_use block would be the client running it a second time.
+        assert [block["type"] for block in starts].count("tool_use") == 0, [block["type"] for block in starts]
+        assert "server_tool_use" in [block["type"] for block in starts]
+
+    @pytest.mark.asyncio
     async def test_bracket_call_absent_from_the_native_channel_is_still_recovered(
         self, mock_response, mock_model_cache, mock_auth_manager
     ):

--- a/tests/unit/test_streaming_core.py
+++ b/tests/unit/test_streaming_core.py
@@ -23,6 +23,7 @@ from kiro.streaming_core import (
     KiroEvent,
     StreamResult,
     calculate_tokens_from_context_usage,
+    collect_stream_to_result,
     parse_kiro_stream,
     stream_with_first_token_retry,
 )
@@ -1083,3 +1084,57 @@ async def test_parse_stream_rejects_malformed_tool_input():
     ):
         async for _ in parse_kiro_stream(response):
             pass
+
+
+class TestCollectStreamToResultBracketRecovery:
+    """Bracket recovery in the non-streaming collector, driven by real frames."""
+
+    @staticmethod
+    def _response(chunks):
+        async def byte_stream():
+            for chunk in chunks:
+                yield chunk
+
+        response = MagicMock()
+        response.aiter_bytes.return_value = byte_stream()
+        return response
+
+    @pytest.mark.asyncio
+    async def test_bracket_echo_of_a_native_call_is_collected_once(self):
+        """The collector must not turn an echo into a second call or a second block.
+
+        Recovered calls were appended to the timeline whenever their id was absent
+        from it, and a recovered id is minted locally so it never matches. The
+        echo became a second tool_use block even after deduplication had removed
+        it from ``tool_calls``, leaving the two views of the same turn disagreeing.
+        """
+        chunks = [
+            b'{"name":"Edit","toolUseId":"toolu_native"}',
+            json.dumps({"input": '{"file_path":"a.py"}'}).encode(),
+            b'{"stop":true}',
+            json.dumps({"content": '[Called Edit with args: {"file_path": "a.py"}]'}).encode(),
+            b'{"contextUsagePercentage":5.0}',
+        ]
+
+        result = await collect_stream_to_result(self._response(chunks))
+
+        assert [call["id"] for call in result.tool_calls] == ["toolu_native"]
+        tool_blocks = [block for block in result.content_blocks if block["type"] == "tool_use"]
+        assert [block["tool"]["id"] for block in tool_blocks] == ["toolu_native"]
+
+    @pytest.mark.asyncio
+    async def test_bracket_call_the_native_channel_missed_is_still_collected(self):
+        """A recovered call with different arguments is a real call, not an echo."""
+        chunks = [
+            b'{"name":"Edit","toolUseId":"toolu_native"}',
+            json.dumps({"input": '{"file_path":"a.py"}'}).encode(),
+            b'{"stop":true}',
+            json.dumps({"content": '[Called Bash with args: {"command": "ls"}]'}).encode(),
+            b'{"contextUsagePercentage":5.0}',
+        ]
+
+        result = await collect_stream_to_result(self._response(chunks))
+
+        assert [(call.get("function") or {}).get("name") for call in result.tool_calls] == ["Edit", "Bash"]
+        tool_blocks = [block for block in result.content_blocks if block["type"] == "tool_use"]
+        assert len(tool_blocks) == 2

--- a/tests/unit/test_streaming_openai.py
+++ b/tests/unit/test_streaming_openai.py
@@ -1147,6 +1147,61 @@ class TestStreamingOpenaiBracketToolCalls:
 
         print("✓ Tool calls deduplicated")
 
+    @pytest.mark.asyncio
+    async def test_bracket_echo_of_a_native_call_reaches_the_client_once(
+        self, mock_http_client, mock_response, mock_model_cache, mock_auth_manager
+    ):
+        """Real deduplication, not a mocked one: the echo must not become a second call.
+
+        The sibling test above patches ``deduplicate_tool_calls`` and therefore
+        asserts only that it was called. This one lets it run, because the defect
+        lived inside it: a recovered call carries a locally minted id, so the id
+        pass never matched and the name+arguments pass only ever inspected
+        id-less entries.
+        """
+
+        async def mock_parse_kiro_stream(*args, **kwargs):
+            yield KiroEvent(
+                type="tool_use",
+                tool_use={
+                    "id": "toolu_native",
+                    "type": "function",
+                    "function": {"name": "Edit", "arguments": '{"file_path":"a.py"}'},
+                },
+            )
+            yield KiroEvent(type="content", content='[Called Edit with args: {"file_path": "a.py"}]')
+            yield KiroEvent(type="context_usage", context_usage_percentage=5.0)
+
+        echo = [
+            {
+                "id": "call_bracket",
+                "type": "function",
+                "_bracket": True,
+                "function": {"name": "Edit", "arguments": '{"file_path": "a.py"}'},
+            }
+        ]
+
+        chunks: list[str] = []
+        with patch("kiro.streaming_openai.parse_kiro_stream", mock_parse_kiro_stream):
+            with patch("kiro.streaming_openai.parse_bracket_tool_calls", return_value=echo):
+                async for chunk in stream_kiro_to_openai(
+                    mock_http_client, mock_response, "claude-sonnet-4", mock_model_cache, mock_auth_manager
+                ):
+                    chunks.append(chunk)
+
+        emitted = [
+            call
+            for chunk in chunks
+            if chunk.startswith("data: ") and chunk[len("data: ") :].strip() != "[DONE]"
+            for choice in json.loads(chunk[len("data: ") :].strip()).get("choices", [])
+            for call in (choice.get("delta") or {}).get("tool_calls") or []
+        ]
+
+        assert [call["id"] for call in emitted] == ["toolu_native"]
+        # Provenance is internal bookkeeping and must never reach a client.
+        assert all("_bracket" not in call for call in emitted)
+        assert all("_bracket" not in chunk for chunk in chunks)
+
 
 # ==================================================================================================
 # Tests for metering data


### PR DESCRIPTION
Three independent defects found while investigating a report that Claude Code was editing files without rendering a diff. That symptom turned out to be client-side — Claude Code's auto mode steers the model to `sed`/heredocs instead of `Edit`/`Write`, and the gateway was reproducing the request faithfully — but the investigation surfaced these.

## A recovered tool call could run twice

Bracket recovery exists to rescue a call the native channel missed, and it mints a local id. `deduplicate_tool_calls` could therefore never match it against the native call by id, and its name+arguments pass only ever inspected entries *without* an id, which left that pass dead. A model that emitted a tool call natively and also echoed it as text produced two calls, and the client executed the same edit twice.

Recovered calls now carry their provenance and are dropped only when a native call with the same name and canonical arguments already exists. Two native calls with identical payloads remain a legitimate parallel invocation and both survive; suppressing on the mere presence of a native call is the wider rule that already discarded a genuinely different call once.

All three conversion paths needed the fix, not just the shared helper. The Anthropic serializer ran no deduplication on this path at all, and the non-streaming collector appended a recovered call to the timeline whenever its id was absent from it — which it always was — so a call deduplication had already removed still reached `content_blocks`, leaving the two views of one turn disagreeing.

Deduplication also preferred the longer arguments. The parser compacts arguments that parse and leaves truncated ones raw, so the broken copy was routinely the longer one and won on size, handing the client arguments it could not decode. Parseability now outranks length.

## Prose buffered behind a thinking block came out after the tool call

Prose that arrives while a thinking block is open is held in a buffer, so only a flush can emit it — and the bracket-recovery branch ran before that flush. The narration introducing a tool call was emitted after the `tool_use` block, an order the real API never produces for a `stop_reason: tool_use` turn, and the raw `[Called ...]` text was replayed as prose. Without thinking the same stream came out correctly, which is why this appeared only on reasoning turns.

## Images on a merged message were dropped

`merge_adjacent_messages` combined content, tool calls, reasoning and tool results, but never images. The later message's images were discarded with no log, and nothing downstream can tell an absent image from one the client never sent. The OpenAI adapter produces exactly this shape, because flushing pending tool results emits a user turn that the following user turn merges into, so a screenshot followed by a question lost the screenshot.

## A failed tool was presented to the model as a successful one

`extract_tool_results_from_content` hardcoded `status: "success"` while `convert_tool_results_to_kiro_format`, thirty lines away, derived it from `is_error` — two functions filling the same Kiro field by different rules. The OpenAI adapter never populated `is_error` at all, so every failed tool reached the model labelled as working and it carried on from a stack trace. `is_error` is now declared on `ChatMessage` so pydantic validates it, rather than read off the extra-allow bag where `bool("false")` is `True`.

## An upstream refusal could not reach account failover

Three ways the pool lost the information it routes on:

- The 403 branch refreshed the token and continued without recording the response, so an account answering 403 to every attempt left every `last_*` slot empty and fell through to a generic "Unknown error" 502. `classify_error(403)`, which returns RECOVERABLE, never ran: no `report_failure`, no rotation, one unlucky account failing the whole request behind an opaque status.
- A streamed 429 or 5xx was stored as the fallback answer and then closed, and that closed response was returned once retries ran out. The route's `await response.aread()` raised, its except branch substituted "Unknown error", and the upstream reason was lost. The body is now captured before the stream is discarded, in the per-endpoint loop and in the rotation layer, under its own short timeout — inheriting the streaming read timeout would be paid once per attempt and once per endpoint, turning a fast refusal into a stall.
- `enhance_kiro_error` passed a hardcoded 403 to `is_suspension_error`, defeating the status guard that exists so payload wording cannot be mistaken for a verdict about the account: a validation error echoing prompt text that contained the suspension wording reported a healthy account as locked. The real status is now forwarded. Conversely, an explicit `TEMPORARILY_SUSPENDED` reason is set by the upstream and cannot be an echo, so it is conclusive on any status; gating it on 403 would let a suspension reported with another status keep burning attempts.

## Stop reasons the upstream can send and the maps did not cover

`GUARDRAIL_INTERVENED` and `MODEL_CONTEXT_WINDOW_EXCEEDED` are members of the upstream `StopReason` enum and were absent from both maps, so a filtered or context-exhausted turn was reported as a clean finish — the one failure this module exists to prevent. `MALFORMED_MODEL_OUTPUT` and `MALFORMED_TOOL_USE` are deliberately left unmapped: neither protocol has a value for "the model emitted garbage", and every candidate misleads in a different direction.

## Deliberately unchanged

An upstream `MAX_TOKENS` still outranks a delivered tool call. That asymmetry reads like a bug next to `content_was_truncated`, which defers to tool calls, but the two carry different weight: one is a local inference from missing completion signals, the other is the upstream stating why it stopped. Reporting `tool_use` there would claim the turn finished by calling a tool when generation was cut off mid-turn. The behaviour is unchanged and now pinned by a test, since nothing documented it.

For the same reason `MODEL_CONTEXT_WINDOW_EXCEEDED` is mapped but kept out of `TRUNCATING_REASONS`: membership there suppresses a tool call the model did deliver, and it is not established that the reason describes cut-off output rather than an oversized input.

## Testing

- 2204 tests pass. The 16 failures are the pre-existing Windows baseline (`debug_logger`, `debug_replay`, `debug_capture_replay` on POSIX atomic-rename semantics in temp, and `test_default_server_host` on a local `.env`); they are identical before and after this branch and pass on Linux CI.
- `ruff format --check`, `ruff check` and `mypy` clean. No frontend files touched, so the frontend jobs are unaffected.
- Each of the three commits is green on its own, so the history stays bisectable.
- Every new test was confirmed to fail with its bug reintroduced.
- Coverage `Missing` cross-checked against `git diff -U0`: no new line is uncovered.
- Verified live against a running gateway on both protocols, streaming and non-streaming: block order `thinking → text → tool_use`, one tool call, no raw bracket marker, `stop_reason: tool_use`, complete and parseable tool input, contiguous `tool_call` indices, a single `finish_reason`, and no internal bookkeeping key in the wire format. The image case was driven through two consecutive user turns — the shape the merge produces — and the model named the colour of a solid-red PNG on both protocols; the merge was confirmed to actually occur for that shape rather than being bypassed.

Not reachable from a client and therefore covered by unit tests only: bracket recovery itself, the 429/5xx error-body capture, and the guardrail stop reason.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stream integrity and failover issues: recovered tool calls could execute twice, merged messages lost or duplicated images, failed tools reached the model as successful, and upstream refusals could surface as opaque 502s.

**Bug Fixes**
- Recovered tool calls are deduplicated against native and gateway-answered calls by name and canonical arguments, so an echo no longer runs twice.
- Buffered prose is flushed before bracket recovery, keeping narration before the tool call on reasoning turns.
- Adjacent message merging now resolves images before concatenating content, so images survive and content-block-only images are not duplicated.
- Tool result status is derived from `is_error` in all paths, and only real booleans flip it, so failed tools reach the model as errors.
- Streamed error bodies are captured before the stream closes, so retries return the upstream reason instead of "Unknown error".
- 403 responses are returned for classification, and the newest failure wins over stale statuses, enabling account rotation instead of an opaque 502.
- Suspension detection uses the real status code and accepts explicit suspension reasons on any status.
- Added `GUARDRAIL_INTERVENED` and `MODEL_CONTEXT_WINDOW_EXCEEDED` to stop-reason maps.

<sup>Written for commit a3e38e8abd18fb655cba713b9b16254aadcf90a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/kiro-lb/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

